### PR TITLE
Fix Issue #72

### DIFF
--- a/include/okapi/chassis/controller/chassisController.hpp
+++ b/include/okapi/chassis/controller/chassisController.hpp
@@ -38,7 +38,7 @@ class ChassisController {
   /**
    * Drives the robot straight for a distance (using closed-loop control).
    *
-   * @param itarget distance to travel in meters
+   * @param itarget distance to travel in motor degrees
    */
   virtual void moveDistance(const double itarget) = 0;
 
@@ -52,7 +52,7 @@ class ChassisController {
   /**
    * Turns the robot clockwise in place (using closed-loop control).
    *
-   * @param idegTarget angle to turn for in degrees
+   * @param idegTarget angle to turn for in motor degrees
    */
   virtual void turnAngle(const double idegTarget) = 0;
 

--- a/include/okapi/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/chassis/controller/chassisControllerIntegrated.hpp
@@ -119,10 +119,10 @@ class ChassisControllerIntegrated : public virtual ChassisController {
   virtual void moveDistance(const QLength itarget) override;
 
   /**
-  * Drives the robot straight for a distance (using closed-loop control).
-  *
-  * @param itarget distance to travel in meters
-  */
+   * Drives the robot straight for a distance (using closed-loop control).
+   *
+   * @param itarget distance to travel in motor degrees
+   */
   virtual void moveDistance(const double itarget) override;
 
   /**
@@ -135,7 +135,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
   /**
    * Turns the robot clockwise in place (using closed-loop control).
    *
-   * @param idegTarget angle to turn for in degrees
+   * @param idegTarget angle to turn for in motor degrees
    */
   virtual void turnAngle(const double idegTarget) override;
 

--- a/include/okapi/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/chassis/controller/chassisControllerPid.hpp
@@ -128,10 +128,10 @@ class ChassisControllerPID : public virtual ChassisController {
   virtual void moveDistance(const QLength itarget) override;
 
   /**
-  * Drives the robot straight for a distance (using closed-loop control).
-  *
-  * @param itarget distance to travel in meters
-  */
+   * Drives the robot straight for a distance (using closed-loop control).
+   *
+   * @param itarget distance to travel in motor degrees
+   */
   virtual void moveDistance(const double itarget) override;
 
   /**
@@ -144,7 +144,7 @@ class ChassisControllerPID : public virtual ChassisController {
   /**
    * Turns the robot clockwise in place (using closed-loop control).
    *
-   * @param idegTarget angle to turn for in degrees
+   * @param idegTarget angle to turn for in motor degrees
    */
   virtual void turnAngle(const double idegTarget) override;
 

--- a/src/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/chassis/controller/chassisControllerIntegrated.cpp
@@ -101,7 +101,8 @@ void ChassisControllerIntegrated::moveDistance(const QLength itarget) {
 }
 
 void ChassisControllerIntegrated::moveDistance(const double itarget) {
-  moveDistance(itarget * meter);
+  // Divide by straightScale so the final result turns back into motor degrees
+  moveDistance((itarget / straightScale) * meter);
 }
 
 void ChassisControllerIntegrated::turnAngle(const QAngle idegTarget) {
@@ -126,6 +127,7 @@ void ChassisControllerIntegrated::turnAngle(const QAngle idegTarget) {
 }
 
 void ChassisControllerIntegrated::turnAngle(const double idegTarget) {
-  turnAngle(idegTarget * degree);
+  // Divide by turnScale so the final result turns back into motor degrees
+  turnAngle((idegTarget / turnScale) * degree);
 }
 } // namespace okapi

--- a/src/chassis/controller/chassisControllerPid.cpp
+++ b/src/chassis/controller/chassisControllerPid.cpp
@@ -114,7 +114,8 @@ void ChassisControllerPID::moveDistance(const QLength itarget) {
 }
 
 void ChassisControllerPID::moveDistance(const double itarget) {
-  moveDistance(itarget * meter);
+  // Divide by straightScale so the final result turns back into motor degrees
+  moveDistance((itarget / straightScale) * meter);
 }
 
 void ChassisControllerPID::turnAngle(const QAngle idegTarget) {
@@ -139,6 +140,7 @@ void ChassisControllerPID::turnAngle(const QAngle idegTarget) {
 }
 
 void ChassisControllerPID::turnAngle(const double idegTarget) {
-  turnAngle(idegTarget * degree);
+  // Divide by turnScale so the final result turns back into motor degrees
+  turnAngle((idegTarget / turnScale) * degree);
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

Divide the input to `moveDistance` and `turnAngle` by their respective scales so they get converted into motor degree units instead of meters.

### Benefits

Programming the robot using `moveDistance` and `turnAngle` without scales, then adding scales and re-running the program will not cause the robot to explode (typically thought of as unexpected behavior).

### Possible Drawbacks

None.

### Verification Process

Tested using:
```
  ChassisControllerIntegrated chassis(-11, 1);
  chassis.moveDistance(200);
  chassis.turnAngle(20);

  ChassisControllerIntegrated chassis2(-11, 1, pros::c::E_MOTOR_GEARSET_36, {2.5_in, 10.5_in});
  chassis2.moveDistance(200);
  chassis2.turnAngle(20);
```

The robot drove the same amount with `chassis` and `chassis2`.

### Applicable Issues

Closes #72.
