### PR TITLE
Issue #75: Add AbstractTimer and expose millis

### DIFF
--- a/include/okapi/api/util/abstractTimer.hpp
+++ b/include/okapi/api/util/abstractTimer.hpp
@@ -5,75 +5,77 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-#ifndef _OKAPI_TIMER_HPP_
-#define _OKAPI_TIMER_HPP_
+#ifndef _OKAPI_ABSTRACTTIMER_HPP_
+#define _OKAPI_ABSTRACTTIMER_HPP_
 
-#include "okapi/api/util/abstractTimer.hpp"
+#include "api.h"
+#include "okapi/api/units/QFrequency.hpp"
+#include "okapi/api/units/QTime.hpp"
 
 namespace okapi {
-class Timer : public AbstractTimer {
+class AbstractTimer {
   public:
-  Timer();
+  virtual ~AbstractTimer();
 
   /**
    * Returns the current time in units of QTime.
    *
    * @return the current time
    */
-  virtual QTime millis() const override;
+  virtual QTime millis() const = 0;
 
   /**
    * Returns the time passed in ms since the previous call of this function.
    *
    * @return The time passed in ms since the previous call of this function
    */
-  virtual QTime getDt() override;
+  virtual QTime getDt() = 0;
 
   /**
    * Returns the time the timer was first constructed.
    *
    * @return The time the timer was first constructed
    */
-  virtual QTime getStartingTime() const override;
+  virtual QTime getStartingTime() const = 0;
 
   /**
    * Returns the time since the timer was first constructed.
    *
    * @return The time since the timer was first constructed
    */
-  virtual QTime getDtFromStart() const override;
+  virtual QTime getDtFromStart() const = 0;
 
   /**
    * Place a time marker. Placing another marker will overwrite the previous one.
    */
-  virtual void placeMark() override;
+  virtual void placeMark() = 0;
 
   /**
    * Place a hard time marker. Placing another hard marker will not overwrite the previous one;
    * instead, call clearHardMark() and then place another.
    */
-  virtual void placeHardMark() override;
+  virtual void placeHardMark() = 0;
 
   /**
    * Clears the hard marker.
    *
    * @return The old hard marker
    */
-  virtual QTime clearHardMark() override;
+  virtual QTime clearHardMark() = 0;
 
   /**
    * Returns the time since the time marker.
    *
    * @return The time since the time marker
    */
-  virtual QTime getDtFromMark() const override;
+  virtual QTime getDtFromMark() const = 0;
 
   /**
    * Returns the time since the hard time marker.
    *
    * @return The time since the hard time marker
    */
-  virtual QTime getDtFromHardMark() const override;
+  virtual QTime getDtFromHardMark() const = 0;
 
   /**
    * Returns true when the input time period has passed, then resets. Meant to be used in loops
@@ -83,7 +85,7 @@ class Timer : public AbstractTimer {
    * @return true when the input time period has passed, false after reading true until the
    *   period has passed again
    */
-  virtual bool repeat(const QTime time) override;
+  virtual bool repeat(const QTime time) = 0;
 
   /**
    * Returns true when the input time period has passed, then resets. Meant to be used in loops
@@ -93,14 +95,7 @@ class Timer : public AbstractTimer {
    * @return true when the input time period has passed, false after reading true until the
    *   period has passed again
    */
-  virtual bool repeat(const QFrequency frequency) override;
-
-  protected:
-  QTime firstCalled;
-  QTime lastCalled;
-  QTime mark;
-  QTime hardMark;
-  QTime repeatMark;
+  virtual bool repeat(const QFrequency frequency) = 0;
 };
 } // namespace okapi
 

--- a/src/util/abstractTimer.cpp
+++ b/src/util/abstractTimer.cpp
@@ -1,0 +1,12 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/util/abstractTimer.hpp"
+
+namespace okapi {
+AbstractTimer::~AbstractTimer() = default;
+} // namespace okapi

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -11,9 +11,7 @@ namespace okapi {
 Timer::Timer() : firstCalled(millis()), lastCalled(firstCalled), mark(firstCalled) {
 }
 
-Timer::~Timer() = default;
-
-QTime Timer::millis() {
+QTime Timer::millis() const {
   return pros::millis() * millisecond;
 }
 


### PR DESCRIPTION
### Description of the Change

Add an interface capturing the methods of `Timer` called `AbstractTimer`. Expose `Timer::millis()` as another method of `AbstractTimer`.

### Benefits

It will be easier to mock `Timer`, and `AbstractTimer` can be used in place of calls to the kernel, so more tests can be moved off the V5 Brain.

### Possible Drawbacks

Another level of indirection to the kernel. Another constructor parameter, though users won't have to deal with it and I plan on more explicitly following the facade pattern in the future.

### Verification Process

The tests still pass.

### Applicable Issues

Closes #75.
