### PR TITLE
Chassis Model/Controller Factories

### DIFF
--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -12,6 +12,7 @@
 #include "okapi/api/chassis/controller/chassisControllerIntegrated.hpp"
 #include "okapi/api/chassis/controller/chassisControllerPid.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"
+#include "okapi/api/chassis/model/chassisModelFactory.hpp"
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -8,6 +8,7 @@
 #ifndef _OKAPI_API_HPP_
 #define _OKAPI_API_HPP_
 
+#include "okapi/api/chassis/controller/chassisControllerFactory.hpp"
 #include "okapi/api/chassis/controller/chassisControllerIntegrated.hpp"
 #include "okapi/api/chassis/controller/chassisControllerPid.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -10,6 +10,7 @@
 
 #include "api.h"
 #include "okapi/api/chassis/model/chassisModel.hpp"
+#include "okapi/api/device/motor/abstractMotor.hpp"
 #include "okapi/api/units/QAngle.hpp"
 #include "okapi/api/units/QLength.hpp"
 #include <memory>
@@ -138,21 +139,21 @@ class ChassisController {
    *
    * @param mode new brake mode
    */
-  virtual void setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const;
+  virtual void setBrakeMode(const AbstractMotor::motorBrakeMode mode) const;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  virtual void setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const;
+  virtual void setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  virtual void setGearing(const pros::c::motor_gearset_e_t gearset) const;
+  virtual void setGearing(const AbstractMotor::motorGearset gearset) const;
 
   protected:
   std::shared_ptr<ChassisModel> model;

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -8,7 +8,6 @@
 #ifndef _OKAPI_CHASSISCONTROLLER_HPP_
 #define _OKAPI_CHASSISCONTROLLER_HPP_
 
-#include "api.h"
 #include "okapi/api/chassis/model/chassisModel.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
 #include "okapi/api/units/QAngle.hpp"

--- a/include/okapi/api/chassis/controller/chassisControllerFactory.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerFactory.hpp
@@ -23,10 +23,10 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerIntegrated
-  create(Motor ileftSideMotor, Motor irightSideMotor,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerIntegrated create(
+    Motor ileftSideMotor, Motor irightSideMotor,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
@@ -37,10 +37,10 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerIntegrated
-  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerIntegrated create(
+    MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
@@ -53,10 +53,10 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerIntegrated
-  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerIntegrated create(
+    Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -68,12 +68,11 @@ class ChassisControllerFactory {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerPID
-  create(Motor ileftSideMotor, Motor irightSideMotor,
-         const IterativePosPIDControllerArgs &idistanceArgs,
-         const IterativePosPIDControllerArgs &iangleArgs,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerPID create(
+    Motor ileftSideMotor, Motor irightSideMotor, const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -85,12 +84,12 @@ class ChassisControllerFactory {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerPID
-  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-         const IterativePosPIDControllerArgs &idistanceArgs,
-         const IterativePosPIDControllerArgs &iangleArgs,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerPID create(
+    MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+    const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -102,12 +101,12 @@ class ChassisControllerFactory {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  static ChassisControllerPID
-  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
-         const IterativePosPIDControllerArgs &idistanceArgs,
-         const IterativePosPIDControllerArgs &iangleArgs,
-         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-         const ChassisScales &iscales = ChassisScales({1, 1}));
+  static ChassisControllerPID create(
+    Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+    const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/controller/chassisControllerFactory.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerFactory.hpp
@@ -1,0 +1,114 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_CHASSISCONTROLLERFACTORY_HPP_
+#define _OKAPI_CHASSISCONTROLLERFACTORY_HPP_
+
+#include "okapi/api/chassis/controller/chassisControllerIntegrated.hpp"
+#include "okapi/api/chassis/controller/chassisControllerPid.hpp"
+
+namespace okapi {
+class ChassisControllerFactory {
+  public:
+  /**
+   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
+   * steer layout. Puts the motors into degree units.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param igearset motor internal gearset
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerIntegrated
+  create(Motor ileftSideMotor, Motor irightSideMotor,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
+   * steer layout. Puts the motors into degree units.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param igearset motor internal gearset
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerIntegrated
+  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
+   * layout. Puts the motors into degree units.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param igearset motor internal gearset
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerIntegrated
+  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(Motor ileftSideMotor, Motor irightSideMotor,
+         const IterativePosPIDControllerArgs &idistanceArgs,
+         const IterativePosPIDControllerArgs &iangleArgs,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+         const IterativePosPIDControllerArgs &idistanceArgs,
+         const IterativePosPIDControllerArgs &iangleArgs,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+         const IterativePosPIDControllerArgs &idistanceArgs,
+         const IterativePosPIDControllerArgs &iangleArgs,
+         const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -29,50 +29,6 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    * @param iscales see ChassisScales docs
    */
   ChassisControllerIntegrated(
-    Motor ileftSideMotor, Motor irightSideMotor,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
-   * steer layout. Puts the motors into degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param igearset motor internal gearset
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerIntegrated(
-    MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
-   * layout. Puts the motors into degree units.
-   *
-   * @param itopLeftMotor top left motor
-   * @param itopRightMotor top right motor
-   * @param ibottomRightMotor bottom right motor
-   * @param ibottomLeftMotor bottom left motor
-   * @param igearset motor internal gearset
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerIntegrated(
-    Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
-   * steer layout. Puts the motors into degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param igearset motor internal gearset
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerIntegrated(
     std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
     const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
     const ChassisScales &iscales = ChassisScales({1, 1}));

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -10,45 +10,11 @@
 
 #include "okapi/api/chassis/controller/chassisController.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"
-#include "okapi/api/chassis/model/skidSteerModel.hpp"
-#include "okapi/api/chassis/model/xDriveModel.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 
 namespace okapi {
 class ChassisControllerIntegrated : public virtual ChassisController {
   public:
-  /**
-   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
-   * steer layout. Puts the motors into degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param igearset motor internal gearset
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerIntegrated(
-    std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
-    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
-   * layout. Puts the motors into degree units.
-   *
-   * @param itopLeftMotor top left motor
-   * @param itopRightMotor top right motor
-   * @param ibottomRightMotor bottom right motor
-   * @param ibottomLeftMotor bottom left motor
-   * @param igearset motor internal gearset
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerIntegrated(
-    std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
-    std::shared_ptr<AbstractMotor> ibottomRightMotor,
-    std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
   /**
    * ChassisController using the V5 motor's integrated control. Puts the motors into degree units.
    *

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -13,8 +13,6 @@
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
-#include "okapi/api/device/motor/motor.hpp"
-#include "okapi/api/device/motor/motorGroup.hpp"
 
 namespace okapi {
 class ChassisControllerIntegrated : public virtual ChassisController {
@@ -30,7 +28,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    */
   ChassisControllerIntegrated(
     std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
     const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
@@ -48,7 +46,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
     std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
     std::shared_ptr<AbstractMotor> ibottomRightMotor,
     std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
     const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
@@ -64,7 +62,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
     std::shared_ptr<ChassisModel> imodel,
     const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
     const AsyncPosIntegratedControllerArgs &irightControllerArgs,
-    const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
     const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -13,8 +13,6 @@
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
-#include "okapi/api/device/motor/motor.hpp"
-#include "okapi/api/device/motor/motorGroup.hpp"
 #include <memory>
 
 namespace okapi {
@@ -30,12 +28,12 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                       std::shared_ptr<AbstractMotor> irightSideMotor,
-                       const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
+  ChassisControllerPID(
+    std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
+    const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes an x-drive
@@ -49,14 +47,14 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  ChassisControllerPID(std::shared_ptr<AbstractMotor> itopLeftMotor,
-                       std::shared_ptr<AbstractMotor> itopRightMotor,
-                       std::shared_ptr<AbstractMotor> ibottomRightMotor,
-                       std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-                       const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
+  ChassisControllerPID(
+    std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
+    std::shared_ptr<AbstractMotor> ibottomRightMotor,
+    std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+    const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. Puts the motors into encoder degree units.
@@ -66,11 +64,11 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  ChassisControllerPID(std::shared_ptr<ChassisModel> imodel,
-                       const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
+  ChassisControllerPID(
+    std::shared_ptr<ChassisModel> imodel, const IterativePosPIDControllerArgs &idistanceArgs,
+    const IterativePosPIDControllerArgs &iangleArgs,
+    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
+    const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * Drives the robot straight for a distance (using closed-loop control).

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -30,54 +30,6 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param iscales see ChassisScales docs
    */
-  ChassisControllerPID(Motor ileftSideMotor, Motor irightSideMotor,
-                       const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using PID control. This constructor assumes a skid
-   * steer layout. Puts the motors into encoder degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param idistanceArgs distance PID controller params
-   * @param iangleArgs angle PID controller params (keeps the robot straight)
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerPID(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                       const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using PID control. This constructor assumes a skid
-   * steer layout. Puts the motors into encoder degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param idistanceArgs distance PID controller params
-   * @param iangleArgs angle PID controller params (keeps the robot straight)
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerPID(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-                       Motor ibottomLeftMotor, const IterativePosPIDControllerArgs &idistanceArgs,
-                       const IterativePosPIDControllerArgs &iangleArgs,
-                       const pros::c::motor_gearset_e_t igearset = pros::c::E_MOTOR_GEARSET_36,
-                       const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using PID control. This constructor assumes a skid
-   * steer layout. Puts the motors into encoder degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param idistanceArgs distance PID controller params
-   * @param iangleArgs angle PID controller params (keeps the robot straight)
-   * @param iscales see ChassisScales docs
-   */
   ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftSideMotor,
                        std::shared_ptr<AbstractMotor> irightSideMotor,
                        const IterativePosPIDControllerArgs &idistanceArgs,

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -10,52 +10,12 @@
 
 #include "okapi/api/chassis/controller/chassisController.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"
-#include "okapi/api/chassis/model/skidSteerModel.hpp"
-#include "okapi/api/chassis/model/xDriveModel.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include <memory>
 
 namespace okapi {
 class ChassisControllerPID : public virtual ChassisController {
   public:
-  /**
-   * ChassisController using PID control. This constructor assumes a skid
-   * steer layout. Puts the motors into encoder degree units.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param idistanceArgs distance PID controller params
-   * @param iangleArgs angle PID controller params (keeps the robot straight)
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerPID(
-    std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
-    const IterativePosPIDControllerArgs &idistanceArgs,
-    const IterativePosPIDControllerArgs &iangleArgs,
-    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
-  /**
-   * ChassisController using PID control. This constructor assumes an x-drive
-   * layout. Puts the motors into encoder degree units.
-   *
-   * @param itopLeftMotor top left motor
-   * @param itopRightMotor top right motor
-   * @param ibottomRightMotor bottom right motor
-   * @param ibottomLeftMotor bottom left motor
-   * @param idistanceArgs distance PID controller params
-   * @param iangleArgs angle PID controller params (keeps the robot straight)
-   * @param iscales see ChassisScales docs
-   */
-  ChassisControllerPID(
-    std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
-    std::shared_ptr<AbstractMotor> ibottomRightMotor,
-    std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-    const IterativePosPIDControllerArgs &idistanceArgs,
-    const IterativePosPIDControllerArgs &iangleArgs,
-    const AbstractMotor::motorGearset igearset = AbstractMotor::motorGearset::E_MOTOR_GEARSET_36,
-    const ChassisScales &iscales = ChassisScales({1, 1}));
-
   /**
    * ChassisController using PID control. Puts the motors into encoder degree units.
    *

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -107,21 +107,21 @@ class ChassisModel {
    *
    * @param mode new brake mode
    */
-  virtual void setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const = 0;
+  virtual void setBrakeMode(const AbstractMotor::motorBrakeMode mode) const = 0;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  virtual void setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const = 0;
+  virtual void setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const = 0;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  virtual void setGearing(const pros::c::motor_gearset_e_t gearset) const = 0;
+  virtual void setGearing(const AbstractMotor::motorGearset gearset) const = 0;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -8,7 +8,6 @@
 #ifndef _OKAPI_CHASSISMODEL_HPP_
 #define _OKAPI_CHASSISMODEL_HPP_
 
-#include "api.h"
 #include "okapi/api/device/motor/abstractMotor.hpp"
 #include <array>
 #include <initializer_list>

--- a/include/okapi/api/chassis/model/chassisModelFactory.hpp
+++ b/include/okapi/api/chassis/model/chassisModelFactory.hpp
@@ -1,0 +1,122 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_CHASSISMODELFACTORY_HPP_
+#define _OKAPI_CHASSISMODELFACTORY_HPP_
+
+#include "okapi/api/chassis/model/skidSteerModel.hpp"
+#include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
+#include "okapi/api/chassis/model/xDriveModel.hpp"
+#include "okapi/api/device/motor/motor.hpp"
+#include "okapi/api/device/motor/motorGroup.hpp"
+#include "okapi/api/device/rotarysensor/adiEncoder.hpp"
+
+namespace okapi {
+class ChassisModelFactory {
+  public:
+  /**
+   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
+   * motors are powered +127, the robot should move forward in a straight line.
+   *
+   * This constructor infers the two sensors from the left and right motors (using the integrated
+   * encoders).
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   */
+  static SkidSteerModel create(Motor ileftSideMotor, Motor irightSideMotor,
+                               const double imaxOutput = 127);
+
+  /**
+   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
+   * motors are powered +127, the robot should move forward in a straight line.
+   *
+   * This constructor infers the two sensors from the left and right motors (using the integrated
+   * encoders).
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   */
+  static SkidSteerModel create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                               const double imaxOutput = 127);
+
+  /**
+   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
+   * motors are powered +127, the robot should move forward in a straight line.
+   *
+   * This constructor infers the two sensors from the left and right motors (using the integrated
+   * encoders).
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   */
+  static SkidSteerModel create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                               ADIEncoder ileftEnc, ADIEncoder irightEnc,
+                               const double imaxOutput = 127);
+
+  /**
+   * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
+   * +127, the robot should move forward in a straight line.
+   *
+   * This constructor infers the two sensors from the top left and top right motors (using the
+   * integrated encoders).
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   */
+  static XDriveModel create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
+                            Motor ibottomLeftMotor, const double imaxOutput = 127);
+
+  /**
+   * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
+   * +127, the robot should move forward in a straight line.
+   *
+   * This constructor infers the two sensors from the top left and top right motors (using the
+   * integrated encoders).
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   */
+  static XDriveModel create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
+                            Motor ibottomLeftMotor, ADIEncoder ileftEnc, ADIEncoder irightEnc,
+                            const double imaxOutput = 127);
+
+  /**
+   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
+   * motors are powered +127, the robot should move forward in a straight line.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param ileftEnc left side encoder
+   * @param imiddleEnc middle encoder (mounted perpendicular to the left and right side encoders)
+   * @param irightEnc right side encoder
+   */
+  static ThreeEncoderSkidSteerModel create(Motor ileftSideMotor, Motor irightSideMotor,
+                                           ADIEncoder ileftEnc, ADIEncoder imiddleEnc,
+                                           ADIEncoder irightEnc, const double imaxOutput = 127);
+
+  /**
+   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
+   * motors are powered +127, the robot should move forward in a straight line.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param ileftEnc left side encoder
+   * @param imiddleEnc middle encoder (mounted perpendicular to the left and right side encoders)
+   * @param irightEnc right side encoder
+   */
+  static ThreeEncoderSkidSteerModel create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                           ADIEncoder ileftEnc, ADIEncoder imiddleEnc,
+                                           ADIEncoder irightEnc, const double imaxOutput = 127);
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -10,9 +10,6 @@
 
 #include "okapi/api/chassis/model/chassisModel.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
-#include "okapi/api/device/motor/motor.hpp"
-#include "okapi/api/device/motor/motorGroup.hpp"
-#include "okapi/api/device/rotarysensor/adiEncoder.hpp"
 #include "okapi/api/device/rotarysensor/continuousRotarySensor.hpp"
 
 namespace okapi {
@@ -37,44 +34,6 @@ class SkidSteerModelArgs : public ChassisModelArgs {
 
 class SkidSteerModel : public ChassisModel {
   public:
-  /**
-   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
-   * motors are powered +127, the robot should move forward in a straight line.
-   *
-   * This constructor infers the two sensors from the left and right motors (using the integrated
-   * encoders).
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   */
-  SkidSteerModel(Motor ileftSideMotor, Motor irightSideMotor, const double imaxOutput = 127);
-
-  /**
-   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
-   * motors are powered +127, the robot should move forward in a straight line.
-   *
-   * This constructor infers the two sensors from the left and right motors (using the integrated
-   * encoders).
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   */
-  SkidSteerModel(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                 const double imaxOutput = 127);
-
-  /**
-   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
-   * motors are powered +127, the robot should move forward in a straight line.
-   *
-   * This constructor infers the two sensors from the left and right motors (using the integrated
-   * encoders).
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   */
-  SkidSteerModel(MotorGroup ileftSideMotor, MotorGroup irightSideMotor, ADIEncoder ileftEnc,
-                 ADIEncoder irightEnc, const double imaxOutput = 127);
-
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
    * motors are powered +127, the robot should move forward in a straight line.

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -187,21 +187,21 @@ class SkidSteerModel : public ChassisModel {
    *
    * @param mode new brake mode
    */
-  virtual void setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const override;
+  virtual void setBrakeMode(const AbstractMotor::motorBrakeMode mode) const override;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  virtual void setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const override;
+  virtual void setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const override;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  virtual void setGearing(const pros::c::motor_gearset_e_t gearset) const override;
+  virtual void setGearing(const AbstractMotor::motorGearset gearset) const override;
 
   /**
    * Returns the left side motor.

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -35,20 +35,6 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
    * @param imiddleEnc middle encoder (mounted perpendicular to the left and right side encoders)
    * @param irightEnc right side encoder
    */
-  ThreeEncoderSkidSteerModel(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                             ADIEncoder ileftEnc, ADIEncoder imiddleEnc, ADIEncoder irightEnc,
-                             const double imaxOutput = 127);
-
-  /**
-   * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
-   * motors are powered +127, the robot should move forward in a straight line.
-   *
-   * @param ileftSideMotor left side motor
-   * @param irightSideMotor right side motor
-   * @param ileftEnc left side encoder
-   * @param imiddleEnc middle encoder (mounted perpendicular to the left and right side encoders)
-   * @param irightEnc right side encoder
-   */
   ThreeEncoderSkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                              std::shared_ptr<AbstractMotor> irightSideMotor,
                              std::shared_ptr<ContinuousRotarySensor> ileftEnc,

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -203,21 +203,21 @@ class XDriveModel : public ChassisModel {
    *
    * @param mode new brake mode
    */
-  virtual void setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const override;
+  virtual void setBrakeMode(const AbstractMotor::motorBrakeMode mode) const override;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  virtual void setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const override;
+  virtual void setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const override;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  virtual void setGearing(const pros::c::motor_gearset_e_t gearset) const override;
+  virtual void setGearing(const AbstractMotor::motorGearset gearset) const override;
 
   /**
    * Returns the top left motor.

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -10,9 +10,6 @@
 
 #include "okapi/api/chassis/model/chassisModel.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
-#include "okapi/api/device/motor/motor.hpp"
-#include "okapi/api/device/motor/motorGroup.hpp"
-#include "okapi/api/device/rotarysensor/adiEncoder.hpp"
 #include "okapi/api/device/rotarysensor/continuousRotarySensor.hpp"
 
 namespace okapi {
@@ -41,37 +38,6 @@ class XDriveModelArgs : public ChassisModelArgs {
 
 class XDriveModel : public ChassisModel {
   public:
-  /**
-   * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
-   * +127, the robot should move forward in a straight line.
-   *
-   * This constructor infers the two sensors from the top left and top right motors (using the
-   * integrated encoders).
-   *
-   * @param itopLeftMotor top left motor
-   * @param itopRightMotor top right motor
-   * @param ibottomRightMotor bottom right motor
-   * @param ibottomLeftMotor bottom left motor
-   */
-  XDriveModel(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-              Motor ibottomLeftMotor, const double imaxOutput = 127);
-
-  /**
-   * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
-   * +127, the robot should move forward in a straight line.
-   *
-   * This constructor infers the two sensors from the top left and top right motors (using the
-   * integrated encoders).
-   *
-   * @param itopLeftMotor top left motor
-   * @param itopRightMotor top right motor
-   * @param ibottomRightMotor bottom right motor
-   * @param ibottomLeftMotor bottom left motor
-   */
-  XDriveModel(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-              Motor ibottomLeftMotor, ADIEncoder ileftEnc, ADIEncoder irightEnc,
-              const double imaxOutput = 127);
-
   /**
    * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
    * +127, the robot should move forward in a straight line.

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -166,7 +166,7 @@ class AbstractMotor : public ControllerOutput {
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param imode The new brake motor brake mode to set for the motor
+   * @param imode The new motor brake mode to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setBrakeMode(const motorBrakeMode imode) const = 0;

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -8,7 +8,6 @@
 #ifndef _OKAPI_ABSTRACTMOTOR_HPP_
 #define _OKAPI_ABSTRACTMOTOR_HPP_
 
-#include "api.h"
 #include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/device/rotarysensor/integratedEncoder.hpp"
 

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -15,6 +15,36 @@
 namespace okapi {
 class AbstractMotor : public ControllerOutput {
   public:
+  /**
+   * Indicates the 'brake mode' of a motor.
+   */
+  typedef enum {
+    E_MOTOR_BRAKE_COAST = 0, // Motor coasts when stopped, traditional behavior
+    E_MOTOR_BRAKE_BRAKE = 1, // Motor brakes when stopped
+    E_MOTOR_BRAKE_HOLD = 2,  // Motor actively holds position when stopped
+    E_MOTOR_BRAKE_INVALID = INT32_MAX
+  } motorBrakeMode;
+
+  /**
+   * Indicates the units used by the motor encoders.
+   */
+  typedef enum {
+    E_MOTOR_ENCODER_DEGREES = 0,
+    E_MOTOR_ENCODER_ROTATIONS = 1,
+    E_MOTOR_ENCODER_COUNTS = 2,
+    E_MOTOR_ENCODER_INVALID = INT32_MAX
+  } motorEncoderUnits;
+
+  /**
+   * Indicates the internal gear ratio of a motor.
+   */
+  typedef enum {
+    E_MOTOR_GEARSET_36 = 0, // 36:1, 100 RPM, Red gear set
+    E_MOTOR_GEARSET_18 = 1, // 18:1, 200 RPM, Green gear set
+    E_MOTOR_GEARSET_06 = 2, // 6:1, 600 RPM, Blue gear set
+    E_MOTOR_GEARSET_INVALID = INT32_MAX
+  } motorGearset;
+
   virtual ~AbstractMotor();
 
   /**
@@ -132,15 +162,15 @@ class AbstractMotor : public ControllerOutput {
   virtual std::int32_t tarePosition() const = 0;
 
   /**
-   * Sets one of motor_brake_mode_e_t to the motor.
+   * Sets one of motorBrakeMode to the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param imode The motor_brake_mode_e_t to set for the motor
+   * @param imode The new brake motor brake mode to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setBrakeMode(const pros::c::motor_brake_mode_e_t imode) const = 0;
+  virtual std::int32_t setBrakeMode(const motorBrakeMode imode) const = 0;
 
   /**
    * Sets the current limit for the motor in mA.
@@ -154,7 +184,7 @@ class AbstractMotor : public ControllerOutput {
   virtual std::int32_t setCurrentLimit(const std::int32_t ilimit) const = 0;
 
   /**
-   * Sets one of motor_encoder_units_e_t for the motor encoder.
+   * Sets one of motorEncoderUnits for the motor encoder.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
@@ -162,10 +192,10 @@ class AbstractMotor : public ControllerOutput {
    * @param iunits The new motor encoder units
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setEncoderUnits(const pros::c::motor_encoder_units_e_t iunits) const = 0;
+  virtual std::int32_t setEncoderUnits(const motorEncoderUnits iunits) const = 0;
 
   /**
-   * Sets one of motor_gearset_e_t for the motor.
+   * Sets one of motorGearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
@@ -173,7 +203,7 @@ class AbstractMotor : public ControllerOutput {
    * @param igearset The new motor gearset
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setGearing(const pros::c::motor_gearset_e_t igearset) const = 0;
+  virtual std::int32_t setGearing(const motorGearset igearset) const = 0;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/okapi/api/device/motor/motor.hpp
+++ b/include/okapi/api/device/motor/motor.hpp
@@ -143,12 +143,12 @@ class Motor : public AbstractMotor, public pros::Motor {
   virtual std::int32_t tarePosition() const override;
 
   /**
-   * Sets one of motor_brake_mode_e_t to the motor.
+   * Sets one of AbstractMotor::motorBrakeMode to the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param imode The motor_brake_mode_e_t to set for the motor
+   * @param imode The new motor brake mode to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setBrakeMode(const AbstractMotor::motorBrakeMode imode) const override;
@@ -165,7 +165,7 @@ class Motor : public AbstractMotor, public pros::Motor {
   virtual std::int32_t setCurrentLimit(const std::int32_t ilimit) const override;
 
   /**
-   * Sets one of motor_encoder_units_e_t for the motor encoder.
+   * Sets one of AbstractMotor::motorEncoderUnits for the motor encoder.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
@@ -177,7 +177,7 @@ class Motor : public AbstractMotor, public pros::Motor {
   setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const override;
 
   /**
-   * Sets one of motor_gearset_e_t for the motor.
+   * Sets one of AbstractMotor::motorGearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.

--- a/include/okapi/api/device/motor/motor.hpp
+++ b/include/okapi/api/device/motor/motor.hpp
@@ -151,7 +151,7 @@ class Motor : public AbstractMotor, public pros::Motor {
    * @param imode The motor_brake_mode_e_t to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setBrakeMode(const pros::c::motor_brake_mode_e_t imode) const override;
+  virtual std::int32_t setBrakeMode(const AbstractMotor::motorBrakeMode imode) const override;
 
   /**
    * Sets the current limit for the motor in mA.
@@ -174,7 +174,7 @@ class Motor : public AbstractMotor, public pros::Motor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t
-  setEncoderUnits(const pros::c::motor_encoder_units_e_t iunits) const override;
+  setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const override;
 
   /**
    * Sets one of motor_gearset_e_t for the motor.
@@ -185,7 +185,7 @@ class Motor : public AbstractMotor, public pros::Motor {
    * @param igearset The new motor gearset
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setGearing(const pros::c::motor_gearset_e_t igearset) const override;
+  virtual std::int32_t setGearing(const AbstractMotor::motorGearset igearset) const override;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/okapi/api/device/motor/motorGroup.hpp
+++ b/include/okapi/api/device/motor/motorGroup.hpp
@@ -156,7 +156,7 @@ class MotorGroup : public AbstractMotor {
    * @param imode The motor_brake_mode_e_t to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setBrakeMode(const pros::c::motor_brake_mode_e_t imode) const override;
+  virtual std::int32_t setBrakeMode(const AbstractMotor::motorBrakeMode imode) const override;
 
   /**
    * Sets the current limit for the motor in mA.
@@ -179,7 +179,7 @@ class MotorGroup : public AbstractMotor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t
-  setEncoderUnits(const pros::c::motor_encoder_units_e_t iunits) const override;
+  setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const override;
 
   /**
    * Sets one of motor_gearset_e_t for the motor.
@@ -190,7 +190,7 @@ class MotorGroup : public AbstractMotor {
    * @param igearset The new motor gearset
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  virtual std::int32_t setGearing(const pros::c::motor_gearset_e_t igearset) const override;
+  virtual std::int32_t setGearing(const AbstractMotor::motorGearset igearset) const override;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/okapi/api/device/motor/motorGroup.hpp
+++ b/include/okapi/api/device/motor/motorGroup.hpp
@@ -148,12 +148,12 @@ class MotorGroup : public AbstractMotor {
   virtual std::int32_t tarePosition() const override;
 
   /**
-   * Sets one of motor_brake_mode_e_t to the motor.
+   * Sets one of AbstractMotor::motorBrakeMode to the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param imode The motor_brake_mode_e_t to set for the motor
+   * @param imode The new motor brake mode to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setBrakeMode(const AbstractMotor::motorBrakeMode imode) const override;
@@ -170,7 +170,7 @@ class MotorGroup : public AbstractMotor {
   virtual std::int32_t setCurrentLimit(const std::int32_t ilimit) const override;
 
   /**
-   * Sets one of motor_encoder_units_e_t for the motor encoder.
+   * Sets one of AbstractMotor::motorEncoderUnits for the motor encoder.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
@@ -182,7 +182,7 @@ class MotorGroup : public AbstractMotor {
   setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const override;
 
   /**
-   * Sets one of motor_gearset_e_t for the motor.
+   * Sets one of AbstractMotor::motorGearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -57,15 +57,15 @@ void ChassisController::resetSensors() const {
   model->resetSensors();
 }
 
-void ChassisController::setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const {
+void ChassisController::setBrakeMode(const AbstractMotor::motorBrakeMode mode) const {
   model->setBrakeMode(mode);
 }
 
-void ChassisController::setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const {
+void ChassisController::setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const {
   model->setEncoderUnits(units);
 }
 
-void ChassisController::setGearing(const pros::c::motor_gearset_e_t gearset) const {
+void ChassisController::setGearing(const AbstractMotor::motorGearset gearset) const {
   model->setGearing(gearset);
 }
 } // namespace okapi

--- a/src/api/chassis/controller/chassisControllerFactory.cpp
+++ b/src/api/chassis/controller/chassisControllerFactory.cpp
@@ -10,7 +10,7 @@
 namespace okapi {
 ChassisControllerIntegrated
 ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
-                                 const pros::c::motor_gearset_e_t igearset,
+                                 const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
   return ChassisControllerIntegrated(std::make_shared<Motor>(ileftSideMotor),
                                      std::make_shared<Motor>(irightSideMotor), igearset, iscales);
@@ -18,7 +18,7 @@ ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
 
 ChassisControllerIntegrated
 ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                                 const pros::c::motor_gearset_e_t igearset,
+                                 const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
   return ChassisControllerIntegrated(std::make_shared<MotorGroup>(ileftSideMotor),
                                      std::make_shared<MotorGroup>(irightSideMotor), igearset,
@@ -27,7 +27,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
 
 ChassisControllerIntegrated
 ChassisControllerFactory::create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-                                 Motor ibottomLeftMotor, const pros::c::motor_gearset_e_t igearset,
+                                 Motor ibottomLeftMotor, const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
   return ChassisControllerIntegrated(std::make_shared<Motor>(itopLeftMotor),
                                      std::make_shared<Motor>(itopRightMotor),
@@ -37,7 +37,7 @@ ChassisControllerFactory::create(Motor itopLeftMotor, Motor itopRightMotor, Moto
 
 ChassisControllerPID ChassisControllerFactory::create(
   Motor ileftSideMotor, Motor irightSideMotor, const IterativePosPIDControllerArgs &idistanceArgs,
-  const IterativePosPIDControllerArgs &iangleArgs, const pros::c::motor_gearset_e_t igearset,
+  const IterativePosPIDControllerArgs &iangleArgs, const AbstractMotor::motorGearset igearset,
   const ChassisScales &iscales) {
   return ChassisControllerPID(std::make_shared<Motor>(ileftSideMotor),
                               std::make_shared<Motor>(irightSideMotor), idistanceArgs, iangleArgs,
@@ -48,7 +48,7 @@ ChassisControllerPID
 ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
                                  const IterativePosPIDControllerArgs &idistanceArgs,
                                  const IterativePosPIDControllerArgs &iangleArgs,
-                                 const pros::c::motor_gearset_e_t igearset,
+                                 const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
   return ChassisControllerPID(std::make_shared<MotorGroup>(ileftSideMotor),
                               std::make_shared<MotorGroup>(irightSideMotor), idistanceArgs,
@@ -58,7 +58,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
 ChassisControllerPID ChassisControllerFactory::create(
   Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
   const IterativePosPIDControllerArgs &idistanceArgs,
-  const IterativePosPIDControllerArgs &iangleArgs, const pros::c::motor_gearset_e_t igearset,
+  const IterativePosPIDControllerArgs &iangleArgs, const AbstractMotor::motorGearset igearset,
   const ChassisScales &iscales) {
   return ChassisControllerPID(
     std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),

--- a/src/api/chassis/controller/chassisControllerFactory.cpp
+++ b/src/api/chassis/controller/chassisControllerFactory.cpp
@@ -6,42 +6,54 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/chassis/controller/chassisControllerFactory.hpp"
+#include "okapi/api/chassis/model/skidSteerModel.hpp"
+#include "okapi/api/chassis/model/xDriveModel.hpp"
 
 namespace okapi {
 ChassisControllerIntegrated
 ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
                                  const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerIntegrated(std::make_shared<Motor>(ileftSideMotor),
-                                     std::make_shared<Motor>(irightSideMotor), igearset, iscales);
+  auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
+  auto rightMtr = std::make_shared<Motor>(irightSideMotor);
+  return ChassisControllerIntegrated(std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+                                     AsyncPosIntegratedControllerArgs(leftMtr),
+                                     AsyncPosIntegratedControllerArgs(rightMtr), igearset, iscales);
 }
 
 ChassisControllerIntegrated
 ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
                                  const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerIntegrated(std::make_shared<MotorGroup>(ileftSideMotor),
-                                     std::make_shared<MotorGroup>(irightSideMotor), igearset,
-                                     iscales);
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  return ChassisControllerIntegrated(std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+                                     AsyncPosIntegratedControllerArgs(leftMtr),
+                                     AsyncPosIntegratedControllerArgs(rightMtr), igearset, iscales);
 }
 
 ChassisControllerIntegrated
 ChassisControllerFactory::create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
                                  Motor ibottomLeftMotor, const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerIntegrated(std::make_shared<Motor>(itopLeftMotor),
-                                     std::make_shared<Motor>(itopRightMotor),
-                                     std::make_shared<Motor>(ibottomRightMotor),
-                                     std::make_shared<Motor>(ibottomLeftMotor), igearset, iscales);
+  auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
+  auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
+  auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
+  auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
+  return ChassisControllerIntegrated(
+    std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
+    AsyncPosIntegratedControllerArgs(topLeftMtr), AsyncPosIntegratedControllerArgs(topRightMtr),
+    igearset, iscales);
 }
 
 ChassisControllerPID ChassisControllerFactory::create(
   Motor ileftSideMotor, Motor irightSideMotor, const IterativePosPIDControllerArgs &idistanceArgs,
   const IterativePosPIDControllerArgs &iangleArgs, const AbstractMotor::motorGearset igearset,
   const ChassisScales &iscales) {
-  return ChassisControllerPID(std::make_shared<Motor>(ileftSideMotor),
-                              std::make_shared<Motor>(irightSideMotor), idistanceArgs, iangleArgs,
-                              igearset, iscales);
+  auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
+  auto rightMtr = std::make_shared<Motor>(irightSideMotor);
+  return ChassisControllerPID(std::make_shared<SkidSteerModel>(leftMtr, rightMtr), idistanceArgs,
+                              iangleArgs, igearset, iscales);
 }
 
 ChassisControllerPID
@@ -50,8 +62,9 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
                                  const IterativePosPIDControllerArgs &iangleArgs,
                                  const AbstractMotor::motorGearset igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerPID(std::make_shared<MotorGroup>(ileftSideMotor),
-                              std::make_shared<MotorGroup>(irightSideMotor), idistanceArgs,
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  return ChassisControllerPID(std::make_shared<SkidSteerModel>(leftMtr, rightMtr), idistanceArgs,
                               iangleArgs, igearset, iscales);
 }
 
@@ -60,9 +73,12 @@ ChassisControllerPID ChassisControllerFactory::create(
   const IterativePosPIDControllerArgs &idistanceArgs,
   const IterativePosPIDControllerArgs &iangleArgs, const AbstractMotor::motorGearset igearset,
   const ChassisScales &iscales) {
+  auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
+  auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
+  auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
+  auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
   return ChassisControllerPID(
-    std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
-    std::make_shared<Motor>(ibottomRightMotor), std::make_shared<Motor>(ibottomLeftMotor),
+    std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
     idistanceArgs, iangleArgs, igearset, iscales);
 }
 } // namespace okapi

--- a/src/api/chassis/controller/chassisControllerFactory.cpp
+++ b/src/api/chassis/controller/chassisControllerFactory.cpp
@@ -1,0 +1,68 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/chassis/controller/chassisControllerFactory.hpp"
+
+namespace okapi {
+ChassisControllerIntegrated
+ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
+                                 const pros::c::motor_gearset_e_t igearset,
+                                 const ChassisScales &iscales) {
+  return ChassisControllerIntegrated(std::make_shared<Motor>(ileftSideMotor),
+                                     std::make_shared<Motor>(irightSideMotor), igearset, iscales);
+}
+
+ChassisControllerIntegrated
+ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                 const pros::c::motor_gearset_e_t igearset,
+                                 const ChassisScales &iscales) {
+  return ChassisControllerIntegrated(std::make_shared<MotorGroup>(ileftSideMotor),
+                                     std::make_shared<MotorGroup>(irightSideMotor), igearset,
+                                     iscales);
+}
+
+ChassisControllerIntegrated
+ChassisControllerFactory::create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
+                                 Motor ibottomLeftMotor, const pros::c::motor_gearset_e_t igearset,
+                                 const ChassisScales &iscales) {
+  return ChassisControllerIntegrated(std::make_shared<Motor>(itopLeftMotor),
+                                     std::make_shared<Motor>(itopRightMotor),
+                                     std::make_shared<Motor>(ibottomRightMotor),
+                                     std::make_shared<Motor>(ibottomLeftMotor), igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  Motor ileftSideMotor, Motor irightSideMotor, const IterativePosPIDControllerArgs &idistanceArgs,
+  const IterativePosPIDControllerArgs &iangleArgs, const pros::c::motor_gearset_e_t igearset,
+  const ChassisScales &iscales) {
+  return ChassisControllerPID(std::make_shared<Motor>(ileftSideMotor),
+                              std::make_shared<Motor>(irightSideMotor), idistanceArgs, iangleArgs,
+                              igearset, iscales);
+}
+
+ChassisControllerPID
+ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                 const IterativePosPIDControllerArgs &idistanceArgs,
+                                 const IterativePosPIDControllerArgs &iangleArgs,
+                                 const pros::c::motor_gearset_e_t igearset,
+                                 const ChassisScales &iscales) {
+  return ChassisControllerPID(std::make_shared<MotorGroup>(ileftSideMotor),
+                              std::make_shared<MotorGroup>(irightSideMotor), idistanceArgs,
+                              iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+  const IterativePosPIDControllerArgs &idistanceArgs,
+  const IterativePosPIDControllerArgs &iangleArgs, const pros::c::motor_gearset_e_t igearset,
+  const ChassisScales &iscales) {
+  return ChassisControllerPID(
+    std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
+    std::make_shared<Motor>(ibottomRightMotor), std::make_shared<Motor>(ibottomLeftMotor),
+    idistanceArgs, iangleArgs, igearset, iscales);
+}
+} // namespace okapi

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -11,34 +11,6 @@
 
 namespace okapi {
 ChassisControllerIntegrated::ChassisControllerIntegrated(
-  std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
-  const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)
-  : ChassisController(std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor)),
-    leftController(ileftSideMotor),
-    rightController(irightSideMotor),
-    lastTarget(0),
-    straightScale(iscales.straight),
-    turnScale(iscales.turn) {
-  setGearing(igearset);
-  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
-}
-
-ChassisControllerIntegrated::ChassisControllerIntegrated(
-  std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
-  std::shared_ptr<AbstractMotor> ibottomRightMotor, std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-  const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)
-  : ChassisController(std::make_shared<XDriveModel>(itopLeftMotor, itopRightMotor,
-                                                    ibottomRightMotor, ibottomLeftMotor)),
-    leftController(itopLeftMotor),
-    rightController(itopRightMotor),
-    lastTarget(0),
-    straightScale(iscales.straight),
-    turnScale(iscales.turn) {
-  setGearing(igearset);
-  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
-}
-
-ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::shared_ptr<ChassisModel> imodel, const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
   const AsyncPosIntegratedControllerArgs &irightControllerArgs,
   const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -10,33 +10,6 @@
 #include "okapi/api/util/timer.hpp"
 
 namespace okapi {
-ChassisControllerIntegrated::ChassisControllerIntegrated(Motor ileftSideMotor,
-                                                         Motor irightSideMotor,
-                                                         const pros::c::motor_gearset_e_t igearset,
-                                                         const ChassisScales &iscales)
-  : ChassisControllerIntegrated(std::make_shared<Motor>(ileftSideMotor),
-                                std::make_shared<Motor>(irightSideMotor), igearset, iscales) {
-}
-
-ChassisControllerIntegrated::ChassisControllerIntegrated(MotorGroup ileftSideMotor,
-                                                         MotorGroup irightSideMotor,
-                                                         const pros::c::motor_gearset_e_t igearset,
-                                                         const ChassisScales &iscales)
-  : ChassisControllerIntegrated(std::make_shared<MotorGroup>(ileftSideMotor),
-                                std::make_shared<MotorGroup>(irightSideMotor), igearset, iscales) {
-}
-
-ChassisControllerIntegrated::ChassisControllerIntegrated(Motor itopLeftMotor, Motor itopRightMotor,
-                                                         Motor ibottomRightMotor,
-                                                         Motor ibottomLeftMotor,
-                                                         const pros::c::motor_gearset_e_t igearset,
-                                                         const ChassisScales &iscales)
-  : ChassisControllerIntegrated(std::make_shared<Motor>(itopLeftMotor),
-                                std::make_shared<Motor>(itopRightMotor),
-                                std::make_shared<Motor>(ibottomRightMotor),
-                                std::make_shared<Motor>(ibottomLeftMotor), igearset, iscales) {
-}
-
 ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
   const pros::c::motor_gearset_e_t igearset, const ChassisScales &iscales)

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -12,7 +12,7 @@
 namespace okapi {
 ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
-  const pros::c::motor_gearset_e_t igearset, const ChassisScales &iscales)
+  const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)
   : ChassisController(std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor)),
     leftController(ileftSideMotor),
     rightController(irightSideMotor),
@@ -20,13 +20,13 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
   std::shared_ptr<AbstractMotor> ibottomRightMotor, std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-  const pros::c::motor_gearset_e_t igearset, const ChassisScales &iscales)
+  const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)
   : ChassisController(std::make_shared<XDriveModel>(itopLeftMotor, itopRightMotor,
                                                     ibottomRightMotor, ibottomLeftMotor)),
     leftController(itopLeftMotor),
@@ -35,13 +35,13 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::shared_ptr<ChassisModel> imodel, const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
   const AsyncPosIntegratedControllerArgs &irightControllerArgs,
-  const pros::c::motor_gearset_e_t igearset, const ChassisScales &iscales)
+  const AbstractMotor::motorGearset igearset, const ChassisScales &iscales)
   : ChassisController(imodel),
     leftController(ileftControllerArgs),
     rightController(irightControllerArgs),
@@ -49,7 +49,7 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 void ChassisControllerIntegrated::moveDistance(const QLength itarget) {

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -14,7 +14,7 @@ ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftS
                                            std::shared_ptr<AbstractMotor> irightSideMotor,
                                            const IterativePosPIDControllerArgs &idistanceArgs,
                                            const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
+                                           const AbstractMotor::motorGearset igearset,
                                            const ChassisScales &iscales)
   : ChassisController(std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor)),
     distancePid(idistanceArgs),
@@ -22,7 +22,7 @@ ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftS
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> itopLeftMotor,
@@ -31,7 +31,7 @@ ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> itopLe
                                            std::shared_ptr<AbstractMotor> ibottomLeftMotor,
                                            const IterativePosPIDControllerArgs &idistanceArgs,
                                            const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
+                                           const AbstractMotor::motorGearset igearset,
                                            const ChassisScales &iscales)
   : ChassisController(std::make_shared<XDriveModel>(itopLeftMotor, itopRightMotor,
                                                     ibottomRightMotor, ibottomLeftMotor)),
@@ -40,13 +40,13 @@ ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> itopLe
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 ChassisControllerPID::ChassisControllerPID(std::shared_ptr<ChassisModel> imodel,
                                            const IterativePosPIDControllerArgs &idistanceArgs,
                                            const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
+                                           const AbstractMotor::motorGearset igearset,
                                            const ChassisScales &iscales)
   : ChassisController(imodel),
     distancePid(idistanceArgs),
@@ -54,7 +54,7 @@ ChassisControllerPID::ChassisControllerPID(std::shared_ptr<ChassisModel> imodel,
     straightScale(iscales.straight),
     turnScale(iscales.turn) {
   setGearing(igearset);
-  setEncoderUnits(pros::c::E_MOTOR_ENCODER_DEGREES);
+  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
 }
 
 void ChassisControllerPID::moveDistance(const QLength itarget) {

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -10,38 +10,6 @@
 #include <cmath>
 
 namespace okapi {
-ChassisControllerPID::ChassisControllerPID(Motor ileftSideMotor, Motor irightSideMotor,
-                                           const IterativePosPIDControllerArgs &idistanceArgs,
-                                           const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
-                                           const ChassisScales &iscales)
-  : ChassisControllerPID(std::make_shared<Motor>(ileftSideMotor),
-                         std::make_shared<Motor>(irightSideMotor), idistanceArgs, iangleArgs,
-                         igearset, iscales) {
-}
-
-ChassisControllerPID::ChassisControllerPID(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                                           const IterativePosPIDControllerArgs &idistanceArgs,
-                                           const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
-                                           const ChassisScales &iscales)
-  : ChassisControllerPID(std::make_shared<MotorGroup>(ileftSideMotor),
-                         std::make_shared<MotorGroup>(irightSideMotor), idistanceArgs, iangleArgs,
-                         igearset, iscales) {
-}
-
-ChassisControllerPID::ChassisControllerPID(Motor itopLeftMotor, Motor itopRightMotor,
-                                           Motor ibottomRightMotor, Motor ibottomLeftMotor,
-                                           const IterativePosPIDControllerArgs &idistanceArgs,
-                                           const IterativePosPIDControllerArgs &iangleArgs,
-                                           const pros::c::motor_gearset_e_t igearset,
-                                           const ChassisScales &iscales)
-  : ChassisControllerPID(
-      std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
-      std::make_shared<Motor>(ibottomRightMotor), std::make_shared<Motor>(ibottomLeftMotor),
-      idistanceArgs, iangleArgs, igearset, iscales) {
-}
-
 ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                            std::shared_ptr<AbstractMotor> irightSideMotor,
                                            const IterativePosPIDControllerArgs &idistanceArgs,

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -10,39 +10,6 @@
 #include <cmath>
 
 namespace okapi {
-ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                                           std::shared_ptr<AbstractMotor> irightSideMotor,
-                                           const IterativePosPIDControllerArgs &idistanceArgs,
-                                           const IterativePosPIDControllerArgs &iangleArgs,
-                                           const AbstractMotor::motorGearset igearset,
-                                           const ChassisScales &iscales)
-  : ChassisController(std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor)),
-    distancePid(idistanceArgs),
-    anglePid(iangleArgs),
-    straightScale(iscales.straight),
-    turnScale(iscales.turn) {
-  setGearing(igearset);
-  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
-}
-
-ChassisControllerPID::ChassisControllerPID(std::shared_ptr<AbstractMotor> itopLeftMotor,
-                                           std::shared_ptr<AbstractMotor> itopRightMotor,
-                                           std::shared_ptr<AbstractMotor> ibottomRightMotor,
-                                           std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-                                           const IterativePosPIDControllerArgs &idistanceArgs,
-                                           const IterativePosPIDControllerArgs &iangleArgs,
-                                           const AbstractMotor::motorGearset igearset,
-                                           const ChassisScales &iscales)
-  : ChassisController(std::make_shared<XDriveModel>(itopLeftMotor, itopRightMotor,
-                                                    ibottomRightMotor, ibottomLeftMotor)),
-    distancePid(idistanceArgs),
-    anglePid(iangleArgs),
-    straightScale(iscales.straight),
-    turnScale(iscales.turn) {
-  setGearing(igearset);
-  setEncoderUnits(AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES);
-}
-
 ChassisControllerPID::ChassisControllerPID(std::shared_ptr<ChassisModel> imodel,
                                            const IterativePosPIDControllerArgs &idistanceArgs,
                                            const IterativePosPIDControllerArgs &iangleArgs,

--- a/src/api/chassis/model/chassisModelFactory.cpp
+++ b/src/api/chassis/model/chassisModelFactory.cpp
@@ -1,0 +1,70 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/chassis/model/chassisModelFactory.hpp"
+
+namespace okapi {
+SkidSteerModel ChassisModelFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
+                                           const double imaxOutput) {
+  return SkidSteerModel(std::make_shared<Motor>(ileftSideMotor),
+                        std::make_shared<Motor>(irightSideMotor), imaxOutput);
+}
+
+SkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                           const double imaxOutput) {
+  return SkidSteerModel(std::make_shared<MotorGroup>(ileftSideMotor),
+                        std::make_shared<MotorGroup>(irightSideMotor), imaxOutput);
+}
+
+SkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                           ADIEncoder ileftEnc, ADIEncoder irightEnc,
+                                           const double imaxOutput) {
+  return SkidSteerModel(
+    std::make_shared<MotorGroup>(ileftSideMotor), std::make_shared<MotorGroup>(irightSideMotor),
+    std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(irightEnc), imaxOutput);
+}
+
+XDriveModel ChassisModelFactory::create(Motor itopLeftMotor, Motor itopRightMotor,
+                                        Motor ibottomRightMotor, Motor ibottomLeftMotor,
+                                        const double imaxOutput) {
+  return XDriveModel(std::make_shared<Motor>(itopLeftMotor),
+                     std::make_shared<Motor>(itopRightMotor),
+                     std::make_shared<Motor>(ibottomRightMotor),
+                     std::make_shared<Motor>(ibottomLeftMotor), imaxOutput);
+}
+
+XDriveModel ChassisModelFactory::create(Motor itopLeftMotor, Motor itopRightMotor,
+                                        Motor ibottomRightMotor, Motor ibottomLeftMotor,
+                                        ADIEncoder ileftEnc, ADIEncoder irightEnc,
+                                        const double imaxOutput) {
+  return XDriveModel(
+    std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
+    std::make_shared<Motor>(ibottomRightMotor), std::make_shared<Motor>(ibottomLeftMotor),
+    std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(irightEnc), imaxOutput);
+}
+
+ThreeEncoderSkidSteerModel ChassisModelFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
+                                                       ADIEncoder ileftEnc, ADIEncoder imiddleEnc,
+                                                       ADIEncoder irightEnc,
+                                                       const double imaxOutput) {
+  return ThreeEncoderSkidSteerModel(
+    std::make_shared<Motor>(ileftSideMotor), std::make_shared<Motor>(irightSideMotor),
+    std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(imiddleEnc),
+    std::make_shared<ADIEncoder>(irightEnc), imaxOutput);
+}
+
+ThreeEncoderSkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor,
+                                                       MotorGroup irightSideMotor,
+                                                       ADIEncoder ileftEnc, ADIEncoder imiddleEnc,
+                                                       ADIEncoder irightEnc,
+                                                       const double imaxOutput) {
+  return ThreeEncoderSkidSteerModel(
+    std::make_shared<MotorGroup>(ileftSideMotor), std::make_shared<MotorGroup>(irightSideMotor),
+    std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(imiddleEnc),
+    std::make_shared<ADIEncoder>(irightEnc), imaxOutput);
+}
+} // namespace okapi

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -202,17 +202,17 @@ void SkidSteerModel::resetSensors() const {
   rightSensor->reset();
 }
 
-void SkidSteerModel::setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const {
+void SkidSteerModel::setBrakeMode(const AbstractMotor::motorBrakeMode mode) const {
   leftSideMotor->setBrakeMode(mode);
   rightSideMotor->setBrakeMode(mode);
 }
 
-void SkidSteerModel::setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const {
+void SkidSteerModel::setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const {
   leftSideMotor->setEncoderUnits(units);
   rightSideMotor->setEncoderUnits(units);
 }
 
-void SkidSteerModel::setGearing(const pros::c::motor_gearset_e_t gearset) const {
+void SkidSteerModel::setGearing(const AbstractMotor::motorGearset gearset) const {
   leftSideMotor->setGearing(gearset);
   rightSideMotor->setGearing(gearset);
 }

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -34,24 +34,6 @@ SkidSteerModelArgs::SkidSteerModelArgs(std::shared_ptr<AbstractMotor> ileftSideM
     maxOutput(imaxOutput) {
 }
 
-SkidSteerModel::SkidSteerModel(Motor ileftSideMotor, Motor irightSideMotor, const double imaxOutput)
-  : SkidSteerModel(std::make_shared<Motor>(ileftSideMotor),
-                   std::make_shared<Motor>(irightSideMotor), imaxOutput) {
-}
-
-SkidSteerModel::SkidSteerModel(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                               const double imaxOutput)
-  : SkidSteerModel(std::make_shared<MotorGroup>(ileftSideMotor),
-                   std::make_shared<MotorGroup>(irightSideMotor), imaxOutput) {
-}
-
-SkidSteerModel::SkidSteerModel(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
-                               ADIEncoder ileftEnc, ADIEncoder irightEnc, const double imaxOutput)
-  : SkidSteerModel(
-      std::make_shared<MotorGroup>(ileftSideMotor), std::make_shared<MotorGroup>(irightSideMotor),
-      std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(irightEnc), imaxOutput) {
-}
-
 SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                std::shared_ptr<AbstractMotor> irightSideMotor,
                                std::shared_ptr<ContinuousRotarySensor> ileftEnc,

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -17,17 +17,6 @@ ThreeEncoderSkidSteerModelArgs::ThreeEncoderSkidSteerModelArgs(
     middleSensor(imiddleEnc) {
 }
 
-ThreeEncoderSkidSteerModel::ThreeEncoderSkidSteerModel(MotorGroup ileftSideMotor,
-                                                       MotorGroup irightSideMotor,
-                                                       ADIEncoder ileftEnc, ADIEncoder imiddleEnc,
-                                                       ADIEncoder irightEnc,
-                                                       const double imaxOutput)
-  : ThreeEncoderSkidSteerModel(
-      std::make_shared<MotorGroup>(ileftSideMotor), std::make_shared<MotorGroup>(irightSideMotor),
-      std::make_shared<ADIEncoder>(ileftEnc), std::make_shared<ADIEncoder>(imiddleEnc),
-      std::make_shared<ADIEncoder>(irightEnc), imaxOutput) {
-}
-
 ThreeEncoderSkidSteerModel::ThreeEncoderSkidSteerModel(
   std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
   std::shared_ptr<ContinuousRotarySensor> ileftEnc,

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -257,21 +257,21 @@ void XDriveModel::resetSensors() const {
   rightSensor->reset();
 }
 
-void XDriveModel::setBrakeMode(const pros::c::motor_brake_mode_e_t mode) const {
+void XDriveModel::setBrakeMode(const AbstractMotor::motorBrakeMode mode) const {
   topLeftMotor->setBrakeMode(mode);
   topRightMotor->setBrakeMode(mode);
   bottomRightMotor->setBrakeMode(mode);
   bottomLeftMotor->setBrakeMode(mode);
 }
 
-void XDriveModel::setEncoderUnits(const pros::c::motor_encoder_units_e_t units) const {
+void XDriveModel::setEncoderUnits(const AbstractMotor::motorEncoderUnits units) const {
   topLeftMotor->setEncoderUnits(units);
   topRightMotor->setEncoderUnits(units);
   bottomRightMotor->setEncoderUnits(units);
   bottomLeftMotor->setEncoderUnits(units);
 }
 
-void XDriveModel::setGearing(const pros::c::motor_gearset_e_t gearset) const {
+void XDriveModel::setGearing(const AbstractMotor::motorGearset gearset) const {
   topLeftMotor->setGearing(gearset);
   topRightMotor->setGearing(gearset);
   bottomRightMotor->setGearing(gearset);

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -41,22 +41,6 @@ XDriveModelArgs::XDriveModelArgs(std::shared_ptr<AbstractMotor> itopLeftMotor,
     maxOutput(imaxOutput) {
 }
 
-XDriveModel::XDriveModel(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-                         Motor ibottomLeftMotor, const double imaxOutput)
-  : XDriveModel(std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
-                std::make_shared<Motor>(ibottomRightMotor),
-                std::make_shared<Motor>(ibottomLeftMotor), imaxOutput) {
-}
-
-XDriveModel::XDriveModel(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor,
-                         Motor ibottomLeftMotor, ADIEncoder ileftEnc, ADIEncoder irightEnc,
-                         const double imaxOutput)
-  : XDriveModel(std::make_shared<Motor>(itopLeftMotor), std::make_shared<Motor>(itopRightMotor),
-                std::make_shared<Motor>(ibottomRightMotor),
-                std::make_shared<Motor>(ibottomLeftMotor), std::make_shared<ADIEncoder>(ileftEnc),
-                std::make_shared<ADIEncoder>(irightEnc), imaxOutput) {
-}
-
 XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
                          std::shared_ptr<AbstractMotor> itopRightMotor,
                          std::shared_ptr<AbstractMotor> ibottomRightMotor,

--- a/src/api/device/motor/motor.cpp
+++ b/src/api/device/motor/motor.cpp
@@ -54,20 +54,47 @@ std::int32_t Motor::tarePosition() const {
   return tare_position();
 }
 
-std::int32_t Motor::setBrakeMode(const pros::c::motor_brake_mode_e_t imode) const {
-  return set_brake_mode(imode);
+std::int32_t Motor::setBrakeMode(const AbstractMotor::motorBrakeMode imode) const {
+  switch (imode) {
+  case AbstractMotor::motorBrakeMode::E_MOTOR_BRAKE_BRAKE:
+    return set_brake_mode(pros::c::E_MOTOR_BRAKE_BRAKE);
+  case AbstractMotor::motorBrakeMode::E_MOTOR_BRAKE_COAST:
+    return set_brake_mode(pros::c::E_MOTOR_BRAKE_COAST);
+  case AbstractMotor::motorBrakeMode::E_MOTOR_BRAKE_HOLD:
+    return set_brake_mode(pros::c::E_MOTOR_BRAKE_HOLD);
+  case AbstractMotor::motorBrakeMode::E_MOTOR_BRAKE_INVALID:
+    return set_brake_mode(pros::c::E_MOTOR_BRAKE_INVALID);
+  }
 }
 
 std::int32_t Motor::setCurrentLimit(const std::int32_t ilimit) const {
   return set_current_limit(ilimit);
 }
 
-std::int32_t Motor::setEncoderUnits(const pros::c::motor_encoder_units_e_t iunits) const {
-  return set_encoder_units(iunits);
+std::int32_t Motor::setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const {
+  switch (iunits) {
+  case AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_COUNTS:
+    return set_encoder_units(pros::c::E_MOTOR_ENCODER_COUNTS);
+  case AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_DEGREES:
+    return set_encoder_units(pros::c::E_MOTOR_ENCODER_DEGREES);
+  case AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_ROTATIONS:
+    return set_encoder_units(pros::c::E_MOTOR_ENCODER_ROTATIONS);
+  case AbstractMotor::motorEncoderUnits::E_MOTOR_ENCODER_INVALID:
+    return set_encoder_units(pros::c::E_MOTOR_ENCODER_INVALID);
+  }
 }
 
-std::int32_t Motor::setGearing(const pros::c::motor_gearset_e_t igearset) const {
-  return set_gearing(igearset);
+std::int32_t Motor::setGearing(const AbstractMotor::motorGearset igearset) const {
+  switch (igearset) {
+  case AbstractMotor::motorGearset::E_MOTOR_GEARSET_06:
+    return set_gearing(pros::c::E_MOTOR_GEARSET_06);
+  case AbstractMotor::motorGearset::E_MOTOR_GEARSET_18:
+    return set_gearing(pros::c::E_MOTOR_GEARSET_18);
+  case AbstractMotor::motorGearset::E_MOTOR_GEARSET_36:
+    return set_gearing(pros::c::E_MOTOR_GEARSET_36);
+  case AbstractMotor::motorGearset::E_MOTOR_GEARSET_INVALID:
+    return set_gearing(pros::c::E_MOTOR_GEARSET_INVALID);
+  }
 }
 
 std::int32_t Motor::setReversed(const bool ireverse) const {

--- a/src/api/device/motor/motorGroup.cpp
+++ b/src/api/device/motor/motorGroup.cpp
@@ -93,7 +93,7 @@ std::int32_t MotorGroup::tarePosition() const {
   return out;
 }
 
-std::int32_t MotorGroup::setBrakeMode(const pros::c::motor_brake_mode_e_t imode) const {
+std::int32_t MotorGroup::setBrakeMode(const AbstractMotor::motorBrakeMode imode) const {
   auto out = 1;
   for (auto &&elem : motors) {
     const auto errorCode = elem.setBrakeMode(imode);
@@ -115,7 +115,7 @@ std::int32_t MotorGroup::setCurrentLimit(const std::int32_t ilimit) const {
   return out;
 }
 
-std::int32_t MotorGroup::setEncoderUnits(const pros::c::motor_encoder_units_e_t iunits) const {
+std::int32_t MotorGroup::setEncoderUnits(const AbstractMotor::motorEncoderUnits iunits) const {
   auto out = 1;
   for (auto &&elem : motors) {
     const auto errorCode = elem.setEncoderUnits(iunits);
@@ -126,7 +126,7 @@ std::int32_t MotorGroup::setEncoderUnits(const pros::c::motor_encoder_units_e_t 
   return out;
 }
 
-std::int32_t MotorGroup::setGearing(const pros::c::motor_gearset_e_t igearset) const {
+std::int32_t MotorGroup::setGearing(const AbstractMotor::motorGearset igearset) const {
   auto out = 1;
   for (auto &&elem : motors) {
     const auto errorCode = elem.setGearing(igearset);

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -221,8 +221,8 @@ void opcontrol() {
   Motor armMotor = 15_mtr;
   armMotor.move(10);
 
-  ChassisControllerIntegrated robotChassisController =
-    ChassisControllerFactory::create({19, 20}, {-14}, pros::c::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
+  ChassisControllerIntegrated robotChassisController = ChassisControllerFactory::create(
+    {19, 20}, {-14}, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
 
   Controller controller;
   ControllerButton btn1(E_CONTROLLER_DIGITAL_A);

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -11,6 +11,58 @@
 #include "test/testRunner.hpp"
 #include "test/tests/allHeadlessTests.hpp"
 
+void opcontrol() {
+  using namespace okapi;
+  pros::Task::delay(100);
+
+  runHeadlessTests();
+  return;
+
+  MotorGroup leftMotors({19_mtr, 20_mtr});
+  MotorGroup rightMotors({13_rmtr, 14_rmtr});
+  Motor armMotor = 15_mtr;
+  armMotor.move(10);
+
+  auto chassis = ChassisControllerFactory::create(
+    {19, 20}, {-14}, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
+
+  Controller controller;
+  ControllerButton btn1(E_CONTROLLER_DIGITAL_A);
+  ControllerButton btn2(E_CONTROLLER_DIGITAL_B);
+  ControllerButton btn3(E_CONTROLLER_DIGITAL_Y);
+  ControllerButton btn4(E_CONTROLLER_DIGITAL_X);
+
+  while (true) {
+    chassis.arcade(controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_Y),
+                   controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_X));
+
+    if (btn1.changedToPressed()) {
+      printf("move distance\n");
+      chassis.moveDistance(12_in);
+    }
+
+    if (btn2.changedToPressed()) {
+      printf("turn angle\n");
+      chassis.turnAngle(90_deg);
+    }
+
+    if (btn3.changedToPressed()) {
+      printf("move arm\n");
+      armMotor.moveRelative(-10, 127);
+    }
+
+    if (btn4.changedToPressed()) {
+      printf("autonomous routine\n");
+      for (int i = 0; i < 4; i++) {
+        chassis.moveDistance(12_in);
+        chassis.turnAngle(90_deg);
+      }
+    }
+
+    pros::Task::delay(10);
+  }
+}
+
 void runHeadlessTests() {
   using namespace okapi;
 
@@ -186,69 +238,5 @@ void constructorTests() {
     auto mtr = 1_mtr;
     AsyncWrapper wrapper(std::make_shared<IntegratedEncoder>(mtr), std::make_shared<Motor>(mtr),
                          std::make_unique<IterativePosPIDController>(0, 0, 0));
-  }
-}
-
-void opcontrol() {
-  using namespace okapi;
-  pros::Task::delay(100);
-
-  // auto myMotor = 11_mtr;
-  // AsyncVelPIDController apid(std::make_shared<IntegratedEncoder>(myMotor),
-  //                            std::make_shared<Motor>(myMotor), 0.001, 0, 0);
-  //
-  // apid.setTarget(20);
-  //
-  // for (;;) {
-  //   printf("Error: %1.2f, Output: %1.2f\n", apid.getError(), apid.getOutput());
-  //   pros::Task::delay(15);
-  // }
-
-  runHeadlessTests();
-  return;
-
-  MotorGroup leftMotors({19_mtr, 20_mtr});
-  MotorGroup rightMotors({13_rmtr, 14_rmtr});
-  Motor armMotor = 15_mtr;
-  armMotor.move(10);
-
-  ChassisControllerIntegrated robotChassisController = ChassisControllerFactory::create(
-    {19, 20}, {-14}, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
-
-  Controller controller;
-  ControllerButton btn1(E_CONTROLLER_DIGITAL_A);
-  ControllerButton btn2(E_CONTROLLER_DIGITAL_B);
-  ControllerButton btn3(E_CONTROLLER_DIGITAL_Y);
-  ControllerButton btn4(E_CONTROLLER_DIGITAL_X);
-
-  while (true) {
-    // printf("loop\n");
-    robotChassisController.arcade(controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_Y),
-                                  controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_X));
-
-    if (btn1.changedToPressed()) {
-      printf("move distance\n");
-      robotChassisController.moveDistance(12_in);
-    }
-
-    if (btn2.changedToPressed()) {
-      printf("turn angle\n");
-      robotChassisController.turnAngle(90_deg);
-    }
-
-    if (btn3.changedToPressed()) {
-      printf("move arm\n");
-      armMotor.moveRelative(-10, 127);
-    }
-
-    if (btn4.changedToPressed()) {
-      printf("autonomous routine\n");
-      for (int i = 0; i < 4; i++) {
-        robotChassisController.moveDistance(12_in);
-        robotChassisController.turnAngle(90_deg);
-      }
-    }
-
-    pros::Task::delay(10);
   }
 }

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -83,15 +83,6 @@ void constructorTests() {
     int1.stop();                      // Stop motors
     auto vals = int1.getSensorVals(); // Read left and right sensors
     int1.resetSensors();              // Set sensors to 0
-
-    ChassisControllerPID controller1(
-      std::make_shared<SkidSteerModel>(MotorGroup({1_mtr, 2_mtr}), MotorGroup({3_mtr, 4_mtr}),
-                                       leftEncoder, rightEncoder),
-      IterativePosPIDControllerArgs(0, 0, 0), IterativePosPIDControllerArgs(0, 0, 0));
-
-    ChassisControllerPID controller2(
-      std::make_shared<XDriveModel>(1_mtr, 2_mtr, 3_mtr, 4_mtr, leftEncoder, rightEncoder),
-      IterativePosPIDControllerArgs(0, 0, 0), IterativePosPIDControllerArgs(0, 0, 0));
   }
 
   {

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -11,6 +11,10 @@
 #include "test/testRunner.hpp"
 #include "test/tests/allHeadlessTests.hpp"
 
+void runHeadlessTests();
+
+void constructorTests();
+
 void opcontrol() {
   using namespace okapi;
   pros::Task::delay(100);

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -64,10 +64,11 @@ void constructorTests() {
   {
     ADIEncoder leftEncoder(1, 2, true);
     ADIEncoder rightEncoder(3, 4);
-    ChassisControllerIntegrated int1(1_mtr, 2_mtr);
-    ChassisControllerIntegrated int2(MotorGroup({1_mtr, 2_mtr, 3_mtr}), MotorGroup({4_mtr, 5_mtr}));
-    ChassisControllerIntegrated int3(1, 2);
-    ChassisControllerIntegrated int4({1, 2, 3}, {-4, -5});
+    ChassisControllerIntegrated int1 = ChassisControllerFactory::create(1_mtr, 2_mtr);
+    ChassisControllerIntegrated int2 = ChassisControllerFactory::create(
+      MotorGroup({1_mtr, 2_mtr, 3_mtr}), MotorGroup({4_mtr, 5_mtr}));
+    ChassisControllerIntegrated int3 = ChassisControllerFactory::create(1, 2);
+    ChassisControllerIntegrated int4 = ChassisControllerFactory::create({1, 2, 3}, {-4, -5});
 
     int1.moveDistance(0_in); // Closed-loop control
     int1.turnAngle(0_deg);   // Closed-loop control
@@ -220,8 +221,8 @@ void opcontrol() {
   Motor armMotor = 15_mtr;
   armMotor.move(10);
 
-  ChassisControllerIntegrated robotChassisController({19, 20}, {-14}, pros::c::E_MOTOR_GEARSET_36,
-                                                     {4_in, 11.5_in});
+  ChassisControllerIntegrated robotChassisController =
+    ChassisControllerFactory::create({19, 20}, {-14}, pros::c::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
 
   Controller controller;
   ControllerButton btn1(E_CONTROLLER_DIGITAL_A);


### PR DESCRIPTION
### Description of the Change

Add a `ChassisModel` and a `ChassisController` factory to decouple the dependency on the PROS kernel from the `ChassisModel` and `ChassisController` interfaces/implementations. Remove simpler constructors from these interfaces and move them into the factories.

### Benefits

No dependencies on the PROS kernel in these interfaces means that they can be tested off of the V5. This moves us closer to moving all the current unit tests off of the V5.

### Possible Drawbacks

Slightly increased API complexity. Users will now have to do
```
  auto chassis = ChassisControllerFactory::create(
    {19, 20}, {-14}, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
```
instead of 
```
  ChassisControllerIntegrated chassis(
    {19, 20}, {-14}, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {4_in, 11.5_in});
```

### Verification Process

A simple test program like the following confirmed functionality:
```
  auto robot = ChassisControllerFactory::create(
    -11, 1, AbstractMotor::motorGearset::E_MOTOR_GEARSET_36, {2.75_in, 10.5_in});
  robot.moveDistance(100);
  robot.moveDistance(3_in);
```
