### PR TITLE
Issue #95: Add implementation of Supplier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,4 +118,4 @@ add_executable(OkapiLibV5
         test/crossPlatformTestRunner.cpp
         test/filterTests.cpp
         test/testMain.cpp
-        test/utilTests.cpp include/test/tests/api/implMocks.hpp test/implMocks.cpp)
+        test/utilTests.cpp include/test/tests/api/implMocks.hpp test/implMocks.cpp include/okapi/api/util/supplier.hpp)

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -79,6 +79,7 @@
 #include "okapi/api/units/QVolume.hpp"
 
 #include "okapi/api/util/mathUtil.hpp"
+#include "okapi/api/util/supplier.hpp"
 #include "okapi/impl/util/rate.hpp"
 #include "okapi/impl/util/timer.hpp"
 

--- a/include/okapi/api/filter/averageFilter.hpp
+++ b/include/okapi/api/filter/averageFilter.hpp
@@ -16,7 +16,9 @@ namespace okapi {
 class AverageFilterArgs : public FilterArgs {};
 
 /**
- * @param n number of taps in the filter
+ * A filter which returns the average of a list of values.
+ *
+ * @tparam n number of taps in the filter
  */
 template <std::size_t n> class AverageFilter : public Filter {
   public:

--- a/include/okapi/api/filter/filteredControllerInput.hpp
+++ b/include/okapi/api/filter/filteredControllerInput.hpp
@@ -13,6 +13,12 @@
 #include <memory>
 
 namespace okapi {
+/**
+ * A ControllerInput with a filter built in.
+ *
+ * @tparam InputType the type of the ControllerInput
+ * @tparam FilterType the type of the Filter
+ */
 template <typename InputType, typename FilterType>
 class FilteredControllerInput : public ControllerInput {
   public:

--- a/include/okapi/api/filter/medianFilter.hpp
+++ b/include/okapi/api/filter/medianFilter.hpp
@@ -19,7 +19,9 @@ namespace okapi {
 class MedianFilterArgs : public FilterArgs {};
 
 /**
- * @param n number of taps in the filter
+ * A filter which returns the median value of list of values.
+ *
+ * @tparam n number of taps in the filter
  */
 template <std::size_t n> class MedianFilter : public Filter {
   public:

--- a/include/okapi/api/util/supplier.hpp
+++ b/include/okapi/api/util/supplier.hpp
@@ -13,6 +13,7 @@
 namespace okapi {
 /**
  * A supplier of instances of T.
+ *
  * @tparam T the type to supply
  */
 template <typename T> class Supplier {

--- a/include/okapi/api/util/supplier.hpp
+++ b/include/okapi/api/util/supplier.hpp
@@ -1,0 +1,38 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_SUPPLIER_HPP_
+#define _OKAPI_SUPPLIER_HPP_
+
+#include <functional>
+
+namespace okapi {
+/**
+ * A supplier of instances of T.
+ * @tparam T the type to supply
+ */
+template <typename T> class Supplier {
+  public:
+  explicit Supplier(std::function<T(void)> ifunc) : func(ifunc) {
+  }
+
+  virtual ~Supplier() = default;
+
+  /**
+   * Get an instance of type T. This is usually a new instance, but it does not have to be.
+   * @return an instance of T
+   */
+  T get() const {
+    return func();
+  }
+
+  protected:
+  std::function<T(void)> func;
+};
+} // namespace okapi
+
+#endif


### PR DESCRIPTION
### Description of the Change

This PR adds a `Supplier` template class that accepts a `std::function` and serves to clarify the intent of the function. `Supplier` is meant to be used when multiple instances of one type are needed.

### Benefits

A simpler and more readable API.

### Possible Drawbacks

None.

### Verification Process

This simple change was not verified.

### Applicable Issues

Closes #95.