### PR TITLE
Issue #102: Add TimeUtil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ add_executable(OkapiLibV5
         test/filterTests.cpp
         test/utilTests.cpp
         include/test/tests/api/implMocks.hpp
-        test/implMocks.cpp include/okapi/api/util/timeUtil.cpp include/okapi/api/util/timeUtil.hpp)
+        test/implMocks.cpp include/okapi/api/util/timeUtil.cpp include/okapi/api/util/timeUtil.hpp include/okapi/impl/util/timeUtilFactory.cpp include/okapi/impl/util/timeUtilFactory.hpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,9 @@ add_executable(OkapiLibV5
         test/filterTests.cpp
         test/utilTests.cpp
         include/test/tests/api/implMocks.hpp
-        test/implMocks.cpp include/okapi/api/util/timeUtil.cpp include/okapi/api/util/timeUtil.hpp include/okapi/impl/util/timeUtilFactory.cpp include/okapi/impl/util/timeUtilFactory.hpp)
+        test/implMocks.cpp
+        src/api/util/timeUtil.cpp
+        include/okapi/api/util/timeUtil.hpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(OkapiLibV5
         include/okapi/api/util/abstractRate.hpp
         include/okapi/api/util/abstractTimer.hpp
         include/okapi/api/util/mathUtil.hpp
+        include/okapi/api/util/supplier.hpp
         include/okapi/api/coreProsAPI.hpp
         include/test/crossPlatformTestRunner.hpp
         include/test/tests/api/allApiTests.hpp
@@ -157,8 +158,7 @@ add_executable(OkapiLibV5
         test/filterTests.cpp
         test/utilTests.cpp
         include/test/tests/api/implMocks.hpp
-        test/implMocks.cpp
-        include/okapi/api/util/supplier.hpp)
+        test/implMocks.cpp include/okapi/api/util/timeUtil.cpp include/okapi/api/util/timeUtil.hpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -78,9 +78,13 @@
 #include "okapi/api/units/QTorque.hpp"
 #include "okapi/api/units/QVolume.hpp"
 
+#include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/abstractTimer.hpp"
 #include "okapi/api/util/mathUtil.hpp"
 #include "okapi/api/util/supplier.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include "okapi/impl/util/rate.hpp"
+#include "okapi/impl/util/timeUtilFactory.hpp"
 #include "okapi/impl/util/timer.hpp"
 
 #endif

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -11,7 +11,7 @@
 #include "okapi/api/chassis/controller/chassisController.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
-#include "okapi/api/util/supplier.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
 class ChassisControllerIntegrated : public virtual ChassisController {
@@ -27,9 +27,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    * @param iscales see ChassisScales docs
    */
   ChassisControllerIntegrated(
-    const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
-    const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-    std::unique_ptr<ChassisModel> imodel,
+    const TimeUtil &itimeUtil, std::unique_ptr<ChassisModel> imodel,
     const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
     const AsyncPosIntegratedControllerArgs &irightControllerArgs,
     AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -12,7 +12,7 @@
 #include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/util/abstractRate.hpp"
-#include "okapi/api/util/supplier.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
 namespace okapi {
@@ -28,9 +28,7 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
-  ChassisControllerPID(const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
-                       const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier,
-                       std::unique_ptr<AbstractRate> irate, std::unique_ptr<ChassisModel> imodel,
+  ChassisControllerPID(const TimeUtil &itimeUtil, std::unique_ptr<ChassisModel> imodel,
                        const IterativePosPIDControllerArgs &idistanceArgs,
                        const IterativePosPIDControllerArgs &iangleArgs,
                        AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -9,9 +9,8 @@
 #define _OKAPI_ASYNCPOSINTEGRATEDCONTROLLER_HPP_
 
 #include "okapi/api/control/async/asyncPositionController.hpp"
-#include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
-#include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
 class AsyncPosIntegratedControllerArgs : public AsyncPositionControllerArgs {
@@ -27,13 +26,10 @@ class AsyncPosIntegratedControllerArgs : public AsyncPositionControllerArgs {
  */
 class AsyncPosIntegratedController : public AsyncPositionController {
   public:
-  AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
-                               std::unique_ptr<SettledUtil> isettledUtil,
-                               std::unique_ptr<AbstractRate> irate);
+  AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 
   AsyncPosIntegratedController(const AsyncPosIntegratedControllerArgs &iparams,
-                               std::unique_ptr<SettledUtil> isettledUtil,
-                               std::unique_ptr<AbstractRate> irate);
+                               const TimeUtil &itimeUtil);
 
   /**
    * Sets the target for the controller.

--- a/include/okapi/api/control/async/asyncPosPidController.hpp
+++ b/include/okapi/api/control/async/asyncPosPidController.hpp
@@ -13,16 +13,14 @@
 #include "okapi/api/control/controllerInput.hpp"
 #include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
 namespace okapi {
 class AsyncPosPIDController : public AsyncWrapper, public AsyncPositionController {
   public:
   AsyncPosPIDController(std::shared_ptr<ControllerInput> iinput,
-                        std::shared_ptr<ControllerOutput> ioutput,
-                        const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-                        std::unique_ptr<AbstractTimer> itimer,
-                        const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
+                        std::shared_ptr<ControllerOutput> ioutput, const TimeUtil &itimeUtil,
                         double ikP, double ikI, double ikD, double ikBias = 0);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -9,9 +9,8 @@
 #define _OKAPI_ASYNCVELINTEGRATEDCONTROLLER_HPP_
 
 #include "okapi/api/control/async/asyncVelocityController.hpp"
-#include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
-#include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
 namespace okapi {
@@ -28,13 +27,10 @@ class AsyncVelIntegratedControllerArgs : public AsyncVelocityControllerArgs {
  */
 class AsyncVelIntegratedController : public AsyncVelocityController {
   public:
-  AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor,
-                               std::unique_ptr<SettledUtil> isettledUtil,
-                               std::unique_ptr<AbstractRate> irate);
+  AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 
   AsyncVelIntegratedController(const AsyncVelIntegratedControllerArgs &iparams,
-                               std::unique_ptr<SettledUtil> isettledUtil,
-                               std::unique_ptr<AbstractRate> irate);
+                               const TimeUtil &itimeUtil);
 
   /**
    * Sets the target for the controller.

--- a/include/okapi/api/control/async/asyncVelPidController.hpp
+++ b/include/okapi/api/control/async/asyncVelPidController.hpp
@@ -13,18 +13,15 @@
 #include "okapi/api/control/controllerInput.hpp"
 #include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/control/iterative/iterativeVelPidController.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
 namespace okapi {
 class AsyncVelPIDController : public AsyncWrapper, public AsyncVelocityController {
   public:
   AsyncVelPIDController(std::shared_ptr<ControllerInput> iinput,
-                        std::shared_ptr<ControllerOutput> ioutput,
-                        const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-                        std::unique_ptr<AbstractTimer> itimer,
-                        const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
-                        const double ikP, const double ikD, const double ikF,
-                        std::unique_ptr<VelMath> ivelMath);
+                        std::shared_ptr<ControllerOutput> ioutput, const TimeUtil &itimeUtil,
+                        double ikP, double ikD, double ikF, std::unique_ptr<VelMath> ivelMath);
 };
 } // namespace okapi
 

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -12,6 +12,7 @@
 
 #include "okapi/api/control/iterative/iterativePositionController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
 namespace okapi {
@@ -28,17 +29,14 @@ class IterativePosPIDController : public IterativePositionController {
    * Position PID controller.
    */
   IterativePosPIDController(double ikP, double ikI, double ikD, double ikBias,
-                            std::unique_ptr<AbstractTimer> iloopDtTimer,
-                            std::unique_ptr<SettledUtil> isettledUtil);
+                            const TimeUtil &itimeUtil);
 
   /**
    * Position PID controller.
    *
    * @param params PosPIDControllerArgs
    */
-  IterativePosPIDController(const IterativePosPIDControllerArgs &params,
-                            std::unique_ptr<AbstractTimer> iloopDtTimer,
-                            std::unique_ptr<SettledUtil> isettledUtil);
+  IterativePosPIDController(const IterativePosPIDControllerArgs &params, const TimeUtil &itimeUtil);
 
   /**
    * Do one iteration of the controller. Returns the reading in the range [-127, 127] unless the

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -11,6 +11,7 @@
 #include "okapi/api/control/iterative/iterativeVelocityController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/filter/velMath.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
 class IterativeVelPIDController : public IterativeVelocityController {
@@ -19,8 +20,7 @@ class IterativeVelPIDController : public IterativeVelocityController {
    * Velocity PD controller.
    */
   IterativeVelPIDController(double ikP, double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
-                            std::unique_ptr<AbstractTimer> iloopDtTimer,
-                            std::unique_ptr<SettledUtil> isettledUtil);
+                            const TimeUtil &itimeUtil);
 
   /**
    * Do one iteration of the controller.

--- a/include/okapi/api/util/timeUtil.hpp
+++ b/include/okapi/api/util/timeUtil.hpp
@@ -30,6 +30,12 @@ class TimeUtil {
 
   std::unique_ptr<SettledUtil> getSettledUtil() const;
 
+  const Supplier<std::unique_ptr<AbstractTimer>> getTimerSupplier() const;
+
+  const Supplier<std::unique_ptr<AbstractRate>> getRateSupplier() const;
+
+  const Supplier<std::unique_ptr<SettledUtil>> getSettledUtilSupplier() const;
+
   protected:
   Supplier<std::unique_ptr<AbstractTimer>> timerSupplier;
   Supplier<std::unique_ptr<AbstractRate>> rateSupplier;

--- a/include/okapi/api/util/timeUtil.hpp
+++ b/include/okapi/api/util/timeUtil.hpp
@@ -1,0 +1,40 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_TIMEUTIL_HPP_
+#define _OKAPI_TIMEUTIL_HPP_
+
+#include "okapi/api/control/util/settledUtil.hpp"
+#include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/abstractTimer.hpp"
+#include "okapi/api/util/supplier.hpp"
+
+namespace okapi {
+/**
+ * Utility class for holding an AbstractTimer, AbstractRate, and SettledUtil together in one
+ * class since they are commonly used together.
+ */
+class TimeUtil {
+  public:
+  TimeUtil(const Supplier<std::unique_ptr<AbstractTimer>> &timerSupplier,
+           const Supplier<std::unique_ptr<AbstractRate>> &rateSupplier,
+           const Supplier<std::unique_ptr<SettledUtil>> &settledUtilSupplier);
+
+  std::unique_ptr<AbstractTimer> getTimer() const;
+
+  std::unique_ptr<AbstractRate> getRate() const;
+
+  std::unique_ptr<SettledUtil> getSettledUtil() const;
+
+  protected:
+  Supplier<std::unique_ptr<AbstractTimer>> timerSupplier;
+  Supplier<std::unique_ptr<AbstractRate>> rateSupplier;
+  Supplier<std::unique_ptr<SettledUtil>> settledUtilSupplier;
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/impl/util/timeUtilFactory.hpp
+++ b/include/okapi/impl/util/timeUtilFactory.hpp
@@ -1,0 +1,20 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_TIMEUTILFACTORY_HPP_
+#define _OKAPI_TIMEUTILFACTORY_HPP_
+
+#include "okapi/api/util/timeUtil.hpp"
+
+namespace okapi {
+class TimeUtilFactory {
+  public:
+  static TimeUtil create();
+};
+} // namespace okapi
+
+#endif

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -12,6 +12,7 @@
 #include "okapi/api/device/motor/abstractMotor.hpp"
 #include "okapi/api/util/abstractRate.hpp"
 #include "okapi/api/util/abstractTimer.hpp"
+#include "okapi/api/util/timeUtil.hpp"
 #include <chrono>
 
 namespace okapi {
@@ -146,6 +147,10 @@ class MockRate : public AbstractRate {
 std::unique_ptr<SettledUtil> createSettledUtilPtr(double iatTargetError = 50,
                                                   double iatTargetDerivative = 5,
                                                   QTime iatTargetTime = 250_ms);
+
+TimeUtil createTimeUtil();
+
+TimeUtil createTimeUtil(const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier);
 } // namespace okapi
 
 #endif

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -9,15 +9,14 @@
 
 namespace okapi {
 ChassisControllerIntegrated::ChassisControllerIntegrated(
-  const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
-  const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-  std::unique_ptr<ChassisModel> imodel, const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
+  const TimeUtil &itimeUtil, std::unique_ptr<ChassisModel> imodel,
+  const AsyncPosIntegratedControllerArgs &ileftControllerArgs,
   const AsyncPosIntegratedControllerArgs &irightControllerArgs,
   AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales)
   : ChassisController(std::move(imodel)),
-    rate(std::move(irateSupplier.get())),
-    leftController(ileftControllerArgs, isettledUtilSupplier.get(), irateSupplier.get()),
-    rightController(irightControllerArgs, isettledUtilSupplier.get(), irateSupplier.get()),
+    rate(std::move(itimeUtil.getRate())),
+    leftController(ileftControllerArgs, itimeUtil),
+    rightController(irightControllerArgs, itimeUtil),
     lastTarget(0),
     gearRatio(igearset.ratio),
     straightScale(iscales.straight),

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -9,17 +9,16 @@
 #include <cmath>
 
 namespace okapi {
-ChassisControllerPID::ChassisControllerPID(
-  const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier,
-  const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier,
-  std::unique_ptr<AbstractRate> irate, std::unique_ptr<ChassisModel> imodel,
-  const IterativePosPIDControllerArgs &idistanceArgs,
-  const IterativePosPIDControllerArgs &iangleArgs, const AbstractMotor::GearsetRatioPair igearset,
-  const ChassisScales &iscales)
+ChassisControllerPID::ChassisControllerPID(const TimeUtil &itimeUtil,
+                                           std::unique_ptr<ChassisModel> imodel,
+                                           const IterativePosPIDControllerArgs &idistanceArgs,
+                                           const IterativePosPIDControllerArgs &iangleArgs,
+                                           const AbstractMotor::GearsetRatioPair igearset,
+                                           const ChassisScales &iscales)
   : ChassisController(std::move(imodel)),
-    rate(std::move(irate)),
-    distancePid(idistanceArgs, itimerSupplier.get(), isettledUtilSupplier.get()),
-    anglePid(iangleArgs, itimerSupplier.get(), isettledUtilSupplier.get()),
+    rate(std::move(itimeUtil.getRate())),
+    distancePid(idistanceArgs, itimeUtil),
+    anglePid(iangleArgs, itimeUtil),
     gearRatio(igearset.ratio),
     straightScale(iscales.straight),
     turnScale(iscales.turn) {

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -14,16 +14,18 @@ AsyncPosIntegratedControllerArgs::AsyncPosIntegratedControllerArgs(
   : motor(imotor) {
 }
 
-AsyncPosIntegratedController::AsyncPosIntegratedController(
-  std::shared_ptr<AbstractMotor> imotor, std::unique_ptr<SettledUtil> isettledUtil,
-  std::unique_ptr<AbstractRate> irate)
-  : motor(imotor), settledUtil(std::move(isettledUtil)), rate(std::move(irate)) {
+AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+                                                           const TimeUtil &itimeUtil)
+  : motor(imotor),
+    settledUtil(std::move(itimeUtil.getSettledUtil())),
+    rate(std::move(itimeUtil.getRate())) {
 }
 
 AsyncPosIntegratedController::AsyncPosIntegratedController(
-  const AsyncPosIntegratedControllerArgs &iparams, std::unique_ptr<SettledUtil> isettledUtil,
-  std::unique_ptr<AbstractRate> irate)
-  : motor(iparams.motor), settledUtil(std::move(isettledUtil)), rate(std::move(irate)) {
+  const AsyncPosIntegratedControllerArgs &iparams, const TimeUtil &itimeUtil)
+  : motor(iparams.motor),
+    settledUtil(std::move(itimeUtil.getSettledUtil())),
+    rate(std::move(itimeUtil.getRate())) {
 }
 
 void AsyncPosIntegratedController::setTarget(const double itarget) {

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -8,15 +8,13 @@
 #include "okapi/api/control/async/asyncPosPidController.hpp"
 
 namespace okapi {
-AsyncPosPIDController::AsyncPosPIDController(
-  std::shared_ptr<ControllerInput> iinput, std::shared_ptr<ControllerOutput> ioutput,
-  const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-  std::unique_ptr<AbstractTimer> itimer,
-  const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier, const double ikP,
-  const double ikI, const double ikD, const double ikBias)
+AsyncPosPIDController::AsyncPosPIDController(std::shared_ptr<ControllerInput> iinput,
+                                             std::shared_ptr<ControllerOutput> ioutput,
+                                             const TimeUtil &itimeUtil, const double ikP,
+                                             const double ikI, const double ikD,
+                                             const double ikBias)
   : AsyncWrapper(iinput, ioutput,
-                 std::make_unique<IterativePosPIDController>(
-                   ikP, ikI, ikD, ikBias, std::move(itimer), isettledUtilSupplier.get()),
-                 irateSupplier, isettledUtilSupplier.get()) {
+                 std::make_unique<IterativePosPIDController>(ikP, ikI, ikD, ikBias, itimeUtil),
+                 itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
 }
 } // namespace okapi

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -14,16 +14,18 @@ AsyncVelIntegratedControllerArgs::AsyncVelIntegratedControllerArgs(
   : motor(imotor) {
 }
 
-AsyncVelIntegratedController::AsyncVelIntegratedController(
-  std::shared_ptr<AbstractMotor> imotor, std::unique_ptr<SettledUtil> isettledUtil,
-  std::unique_ptr<AbstractRate> irate)
-  : motor(imotor), settledUtil(std::move(isettledUtil)), rate(std::move(irate)) {
+AsyncVelIntegratedController::AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+                                                           const TimeUtil &itimeUtil)
+  : motor(imotor),
+    settledUtil(std::move(itimeUtil.getSettledUtil())),
+    rate(std::move(itimeUtil.getRate())) {
 }
 
 AsyncVelIntegratedController::AsyncVelIntegratedController(
-  const AsyncVelIntegratedControllerArgs &iparams, std::unique_ptr<SettledUtil> isettledUtil,
-  std::unique_ptr<AbstractRate> irate)
-  : motor(iparams.motor), settledUtil(std::move(isettledUtil)), rate(std::move(irate)) {
+  const AsyncVelIntegratedControllerArgs &iparams, const TimeUtil &itimeUtil)
+  : motor(iparams.motor),
+    settledUtil(std::move(itimeUtil.getSettledUtil())),
+    rate(std::move(itimeUtil.getRate())) {
 }
 
 void AsyncVelIntegratedController::setTarget(const double itarget) {

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -9,16 +9,14 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncVelPIDController::AsyncVelPIDController(
-  std::shared_ptr<ControllerInput> iinput, std::shared_ptr<ControllerOutput> ioutput,
-  const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-  std::unique_ptr<AbstractTimer> itimer,
-  const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier, const double ikP,
-  const double ikD, const double ikF, std::unique_ptr<VelMath> ivelMath)
-  : AsyncWrapper(iinput, ioutput,
-                 std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, std::move(ivelMath),
-                                                             std::move(itimer),
-                                                             isettledUtilSupplier.get()),
-                 irateSupplier, isettledUtilSupplier.get()) {
+AsyncVelPIDController::AsyncVelPIDController(std::shared_ptr<ControllerInput> iinput,
+                                             std::shared_ptr<ControllerOutput> ioutput,
+                                             const TimeUtil &itimeUtil, const double ikP,
+                                             const double ikD, const double ikF,
+                                             std::unique_ptr<VelMath> ivelMath)
+  : AsyncWrapper(
+      iinput, ioutput,
+      std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, std::move(ivelMath), itimeUtil),
+      itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -18,17 +18,15 @@ IterativePosPIDControllerArgs::IterativePosPIDControllerArgs(const double ikP, c
 }
 
 IterativePosPIDController::IterativePosPIDController(const IterativePosPIDControllerArgs &params,
-                                                     std::unique_ptr<AbstractTimer> iloopDtTimer,
-                                                     std::unique_ptr<SettledUtil> isettledUtil)
-  : IterativePosPIDController(params.kP, params.kI, params.kD, params.kBias,
-                              std::move(iloopDtTimer), std::move(isettledUtil)) {
+                                                     const TimeUtil &itimeUtil)
+  : IterativePosPIDController(params.kP, params.kI, params.kD, params.kBias, itimeUtil) {
 }
 
 IterativePosPIDController::IterativePosPIDController(const double ikP, const double ikI,
                                                      const double ikD, const double ikBias,
-                                                     std::unique_ptr<AbstractTimer> iloopDtTimer,
-                                                     std::unique_ptr<SettledUtil> isettledUtil)
-  : loopDtTimer(std::move(iloopDtTimer)), settledUtil(std::move(isettledUtil)) {
+                                                     const TimeUtil &itimeUtil)
+  : loopDtTimer(std::move(itimeUtil.getTimer())),
+    settledUtil(std::move(itimeUtil.getSettledUtil())) {
   if (ikI != 0) {
     setIntegralLimits(-1 / ikI, 1 / ikI);
   }

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -14,11 +14,10 @@ namespace okapi {
 IterativeVelPIDController::IterativeVelPIDController(const double ikP, const double ikD,
                                                      const double ikF,
                                                      std::unique_ptr<VelMath> ivelMath,
-                                                     std::unique_ptr<AbstractTimer> iloopDtTimer,
-                                                     std::unique_ptr<SettledUtil> isettledUtil)
+                                                     const TimeUtil &itimeUtil)
   : velMath(std::move(ivelMath)),
-    loopDtTimer(std::move(iloopDtTimer)),
-    settledUtil(std::move(isettledUtil)) {
+    loopDtTimer(std::move(itimeUtil.getTimer())),
+    settledUtil(std::move(itimeUtil.getSettledUtil())) {
   setGains(ikP, ikD, ikF);
 }
 

--- a/src/api/util/timeUtil.cpp
+++ b/src/api/util/timeUtil.cpp
@@ -27,4 +27,16 @@ std::unique_ptr<AbstractRate> TimeUtil::getRate() const {
 std::unique_ptr<SettledUtil> TimeUtil::getSettledUtil() const {
   return settledUtilSupplier.get();
 }
+
+const Supplier<std::unique_ptr<AbstractTimer>> TimeUtil::getTimerSupplier() const {
+  return timerSupplier;
+}
+
+const Supplier<std::unique_ptr<AbstractRate>> TimeUtil::getRateSupplier() const {
+  return rateSupplier;
+}
+
+const Supplier<std::unique_ptr<SettledUtil>> TimeUtil::getSettledUtilSupplier() const {
+  return settledUtilSupplier;
+}
 } // namespace okapi

--- a/src/api/util/timeUtil.cpp
+++ b/src/api/util/timeUtil.cpp
@@ -1,0 +1,30 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/util/timeUtil.hpp"
+
+namespace okapi {
+TimeUtil::TimeUtil(const okapi::Supplier<std::unique_ptr<okapi::AbstractTimer>> &timerSupplier,
+                   const okapi::Supplier<std::unique_ptr<okapi::AbstractRate>> &rateSupplier,
+                   const okapi::Supplier<std::unique_ptr<okapi::SettledUtil>> &settledUtilSupplier)
+  : timerSupplier(timerSupplier),
+    rateSupplier(rateSupplier),
+    settledUtilSupplier(settledUtilSupplier) {
+}
+
+std::unique_ptr<AbstractTimer> TimeUtil::getTimer() const {
+  return timerSupplier.get();
+}
+
+std::unique_ptr<AbstractRate> TimeUtil::getRate() const {
+  return rateSupplier.get();
+}
+
+std::unique_ptr<SettledUtil> TimeUtil::getSettledUtil() const {
+  return settledUtilSupplier.get();
+}
+} // namespace okapi

--- a/src/impl/chassis/controller/chassisControllerFactory.cpp
+++ b/src/impl/chassis/controller/chassisControllerFactory.cpp
@@ -8,23 +8,9 @@
 #include "okapi/impl/chassis/controller/chassisControllerFactory.hpp"
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"
-#include "okapi/impl/control/util/settledUtilFactory.hpp"
-#include "okapi/impl/util/rate.hpp"
-#include "okapi/impl/util/timer.hpp"
+#include "okapi/impl/util/timeUtilFactory.hpp"
 
 namespace okapi {
-
-auto createSettledUtilSupplier() {
-  return Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); });
-}
-
-auto createRateSupplier() {
-  return Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); });
-}
-
-auto createTimerSupplier() {
-  return Supplier<std::unique_ptr<AbstractTimer>>([]() { return std::make_unique<Timer>(); });
-}
 
 ChassisControllerIntegrated
 ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
@@ -32,7 +18,7 @@ ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
   auto rightMtr = std::make_shared<Motor>(irightSideMotor);
-  return ChassisControllerIntegrated(createSettledUtilSupplier(), createRateSupplier(),
+  return ChassisControllerIntegrated(TimeUtilFactory::create(),
                                      std::make_unique<SkidSteerModel>(leftMtr, rightMtr),
                                      AsyncPosIntegratedControllerArgs(leftMtr),
                                      AsyncPosIntegratedControllerArgs(rightMtr), igearset, iscales);
@@ -44,7 +30,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
-  return ChassisControllerIntegrated(createSettledUtilSupplier(), createRateSupplier(),
+  return ChassisControllerIntegrated(TimeUtilFactory::create(),
                                      std::make_unique<SkidSteerModel>(leftMtr, rightMtr),
                                      AsyncPosIntegratedControllerArgs(leftMtr),
                                      AsyncPosIntegratedControllerArgs(rightMtr), igearset, iscales);
@@ -58,7 +44,7 @@ ChassisControllerIntegrated ChassisControllerFactory::create(
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
   auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
   return ChassisControllerIntegrated(
-    createSettledUtilSupplier(), createRateSupplier(),
+    TimeUtilFactory::create(),
     std::make_unique<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
     AsyncPosIntegratedControllerArgs(topLeftMtr), AsyncPosIntegratedControllerArgs(topRightMtr),
     igearset, iscales);
@@ -70,8 +56,7 @@ ChassisControllerPID ChassisControllerFactory::create(
   const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
   auto rightMtr = std::make_shared<Motor>(irightSideMotor);
-  return ChassisControllerPID(createSettledUtilSupplier(), createTimerSupplier(),
-                              std::make_unique<Rate>(),
+  return ChassisControllerPID(TimeUtilFactory::create(),
                               std::make_unique<SkidSteerModel>(leftMtr, rightMtr), idistanceArgs,
                               iangleArgs, igearset, iscales);
 }
@@ -84,8 +69,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
-  return ChassisControllerPID(createSettledUtilSupplier(), createTimerSupplier(),
-                              std::make_unique<Rate>(),
+  return ChassisControllerPID(TimeUtilFactory::create(),
                               std::make_unique<SkidSteerModel>(leftMtr, rightMtr), idistanceArgs,
                               iangleArgs, igearset, iscales);
 }
@@ -100,7 +84,7 @@ ChassisControllerPID ChassisControllerFactory::create(
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
   auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
   return ChassisControllerPID(
-    createSettledUtilSupplier(), createTimerSupplier(), std::make_unique<Rate>(),
+    TimeUtilFactory::create(),
     std::make_unique<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
     idistanceArgs, iangleArgs, igearset, iscales);
 }

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -6,97 +6,70 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/control/async/asyncControllerFactory.hpp"
-#include "okapi/impl/control/util/settledUtilFactory.hpp"
 #include "okapi/impl/filter/velMathFactory.hpp"
-#include "okapi/impl/util/rate.hpp"
-#include "okapi/impl/util/timer.hpp"
+#include "okapi/impl/util/timeUtilFactory.hpp"
 
 namespace okapi {
 AsyncPosIntegratedController AsyncControllerFactory::posIntegrated(Motor imotor) {
-  return AsyncPosIntegratedController(std::make_shared<Motor>(imotor),
-                                      SettledUtilFactory::createPtr(), std::make_unique<Rate>());
+  return AsyncPosIntegratedController(std::make_shared<Motor>(imotor), TimeUtilFactory::create());
 }
 
 AsyncPosIntegratedController AsyncControllerFactory::posIntegrated(MotorGroup imotor) {
   return AsyncPosIntegratedController(std::make_shared<MotorGroup>(imotor),
-                                      SettledUtilFactory::createPtr(), std::make_unique<Rate>());
+                                      TimeUtilFactory::create());
 }
 
 AsyncVelIntegratedController AsyncControllerFactory::velIntegrated(Motor imotor) {
-  return AsyncVelIntegratedController(std::make_shared<Motor>(imotor),
-                                      SettledUtilFactory::createPtr(), std::make_unique<Rate>());
+  return AsyncVelIntegratedController(std::make_shared<Motor>(imotor), TimeUtilFactory::create());
 }
 
 AsyncVelIntegratedController AsyncControllerFactory::velIntegrated(MotorGroup imotor) {
   return AsyncVelIntegratedController(std::make_shared<MotorGroup>(imotor),
-                                      SettledUtilFactory::createPtr(), std::make_unique<Rate>());
+                                      TimeUtilFactory::create());
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor, const double ikP,
                                                      const double ikI, const double ikD,
                                                      const double ikBias) {
-  return AsyncPosPIDController(
-    imotor.getEncoder(), std::make_shared<Motor>(imotor),
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikI, ikD, ikBias);
+  return AsyncPosPIDController(imotor.getEncoder(), std::make_shared<Motor>(imotor),
+                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor, const double ikP,
                                                      const double ikI, const double ikD,
                                                      const double ikBias) {
-  return AsyncPosPIDController(
-    imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikI, ikD, ikBias);
+  return AsyncPosPIDController(imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
+                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(std::shared_ptr<ControllerInput> iinput,
                                                      std::shared_ptr<ControllerOutput> ioutput,
                                                      const double ikP, const double ikI,
                                                      const double ikD, const double ikBias) {
-  return AsyncPosPIDController(
-    iinput, ioutput,
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikI, ikD, ikBias);
+  return AsyncPosPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, const double ikP,
                                                      const double ikD, const double ikF,
                                                      const double iTPR) {
-  return AsyncVelPIDController(
-    imotor.getEncoder(), std::make_shared<Motor>(imotor),
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikD, ikF, VelMathFactory::createPtr(iTPR));
+  return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<Motor>(imotor),
+                               TimeUtilFactory::create(), ikP, ikD, ikF,
+                               VelMathFactory::createPtr(iTPR));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, const double ikP,
                                                      const double ikD, const double ikF,
                                                      const double iTPR) {
-  return AsyncVelPIDController(
-    imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikD, ikF, VelMathFactory::createPtr(iTPR));
+  return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
+                               TimeUtilFactory::create(), ikP, ikD, ikF,
+                               VelMathFactory::createPtr(iTPR));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(std::shared_ptr<ControllerInput> iinput,
                                                      std::shared_ptr<ControllerOutput> ioutput,
                                                      const double ikP, const double ikD,
                                                      const double ikF, const double iTPR) {
-  return AsyncVelPIDController(
-    iinput, ioutput,
-    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
-    std::make_unique<Timer>(),
-    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }), ikP,
-    ikD, ikF, VelMathFactory::createPtr(iTPR));
+  return AsyncVelPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikD, ikF,
+                               VelMathFactory::createPtr(iTPR));
 }
 } // namespace okapi

--- a/src/impl/control/iterative/iterativeControllerFactory.cpp
+++ b/src/impl/control/iterative/iterativeControllerFactory.cpp
@@ -6,23 +6,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/control/iterative/iterativeControllerFactory.hpp"
-#include "okapi/impl/control/util/settledUtilFactory.hpp"
 #include "okapi/impl/filter/velMathFactory.hpp"
-#include "okapi/impl/util/timer.hpp"
+#include "okapi/impl/util/timeUtilFactory.hpp"
 
 namespace okapi {
 IterativePosPIDController IterativeControllerFactory::posPID(const double ikP, const double ikI,
                                                              const double ikD,
                                                              const double ikBias) {
-  return IterativePosPIDController(ikP, ikI, ikD, ikBias, std::make_unique<Timer>(),
-                                   SettledUtilFactory::createPtr());
+  return IterativePosPIDController(ikP, ikI, ikD, ikBias, TimeUtilFactory::create());
 }
 
 IterativeVelPIDController IterativeControllerFactory::velPID(const double ikP, const double ikD,
                                                              const double ikF,
                                                              const VelMathArgs &iparams) {
   return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
-                                   std::make_unique<Timer>(), SettledUtilFactory::createPtr());
+                                   TimeUtilFactory::create());
 }
 
 IterativeMotorVelocityController

--- a/src/impl/util/timeUtilFactory.cpp
+++ b/src/impl/util/timeUtilFactory.cpp
@@ -1,0 +1,20 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/impl/util/timeUtilFactory.hpp"
+#include "okapi/impl/control/util/settledUtilFactory.hpp"
+#include "okapi/impl/util/rate.hpp"
+#include "okapi/impl/util/timer.hpp"
+
+namespace okapi {
+TimeUtil TimeUtilFactory::create() {
+  return TimeUtil(
+    Supplier<std::unique_ptr<AbstractTimer>>([]() { return std::make_unique<Timer>(); }),
+    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<Rate>(); }),
+    Supplier<std::unique_ptr<SettledUtil>>([]() { return SettledUtilFactory::createPtr(); }));
+}
+} // namespace okapi

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -35,8 +35,10 @@ class IterativeControllerTest : public ::testing::Test {
 };
 
 TEST_F(IterativeControllerTest, IterativePosPIDControllerTest) {
-  IterativePosPIDController controller(0.004, 0, 0, 0, std::make_unique<ConstantMockTimer>(10_ms),
-                                       createSettledUtilPtr());
+  IterativePosPIDController controller(
+    0.004, 0, 0, 0, createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>([]() {
+      return std::make_unique<ConstantMockTimer>(10_ms);
+    })));
 
   runSimulation(controller, 45);
 
@@ -49,7 +51,8 @@ TEST_F(IterativeControllerTest, IterativeVelPIDController) {
     0.000015, 0, 0,
     std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
                               std::make_unique<ConstantMockTimer>(10_ms)),
-    std::make_unique<ConstantMockTimer>(10_ms), createSettledUtilPtr());
+    createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
+      []() { return std::make_unique<ConstantMockTimer>(10_ms); })));
 
   runSimulation(controller, 10);
 
@@ -62,7 +65,8 @@ TEST_F(IterativeControllerTest, IterativeVelPIDControllerFeedForwardOnly) {
     0, 0, 0.1,
     std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
                               std::make_unique<ConstantMockTimer>(10_ms)),
-    std::make_unique<ConstantMockTimer>(10_ms), createSettledUtilPtr());
+    createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
+      []() { return std::make_unique<ConstantMockTimer>(10_ms); })));
 
   controller.setTarget(5);
 
@@ -79,7 +83,8 @@ TEST_F(IterativeControllerTest, IterativeMotorVelocityController) {
           0, 0, 0,
           std::make_unique<VelMath>(imev5TPR, std::make_shared<AverageFilter<2>>(),
                                     std::make_unique<ConstantMockTimer>(10_ms)),
-          std::make_unique<ConstantMockTimer>(10_ms), createSettledUtilPtr()) {
+          createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
+            []() { return std::make_unique<ConstantMockTimer>(10_ms); }))) {
     }
 
     double step(const double inewReading) override {
@@ -134,15 +139,13 @@ class AsyncControllerTest : public ::testing::Test {
 
 TEST_F(AsyncControllerTest, AsyncPosIntegratedController) {
   auto motor = std::make_shared<MockMotor>();
-  AsyncPosIntegratedController controller(motor, createSettledUtilPtr(),
-                                          std::make_unique<MockRate>());
+  AsyncPosIntegratedController controller(motor, createTimeUtil());
   assertControllerFollowsDisableLifecycle(controller, motor->lastPosition, motor->lastVoltage);
 }
 
 TEST_F(AsyncControllerTest, AsyncVelIntegratedController) {
   auto motor = std::make_shared<MockMotor>();
-  AsyncVelIntegratedController controller(motor, createSettledUtilPtr(),
-                                          std::make_unique<MockRate>());
+  AsyncVelIntegratedController controller(motor, createTimeUtil());
   assertControllerFollowsDisableLifecycle(controller, motor->lastVelocity, motor->lastVoltage);
 }
 

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -196,13 +196,6 @@ bool ConstantMockTimer::repeat(QFrequency frequency) {
   return false;
 }
 
-std::unique_ptr<SettledUtil> createSettledUtilPtr(const double iatTargetError,
-                                                  const double iatTargetDerivative,
-                                                  const QTime iatTargetTime) {
-  return std::make_unique<SettledUtil>(std::make_unique<MockTimer>(), iatTargetError,
-                                       iatTargetDerivative, iatTargetTime);
-}
-
 MockRate::MockRate() = default;
 
 void MockRate::delay(QFrequency ihz) {
@@ -219,5 +212,26 @@ void MockRate::delayUntil(QTime itime) {
 
 void MockRate::delayUntil(uint32_t ims) {
   std::this_thread::sleep_for(std::chrono::milliseconds(ims));
+}
+
+std::unique_ptr<SettledUtil> createSettledUtilPtr(const double iatTargetError,
+                                                  const double iatTargetDerivative,
+                                                  const QTime iatTargetTime) {
+  return std::make_unique<SettledUtil>(std::make_unique<MockTimer>(), iatTargetError,
+                                       iatTargetDerivative, iatTargetTime);
+}
+
+TimeUtil createTimeUtil() {
+  return TimeUtil(
+    Supplier<std::unique_ptr<AbstractTimer>>([]() { return std::make_unique<MockTimer>(); }),
+    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<MockRate>(); }),
+    Supplier<std::unique_ptr<SettledUtil>>([]() { return createSettledUtilPtr(); }));
+}
+
+TimeUtil createTimeUtil(const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier) {
+  return TimeUtil(itimerSupplier, Supplier<std::unique_ptr<AbstractRate>>([]() {
+                    return std::make_unique<MockRate>();
+                  }),
+                  Supplier<std::unique_ptr<SettledUtil>>([]() { return createSettledUtilPtr(); }));
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

A utility class was added to simplify the constructors for classes which need time-related classes such as `AbstractTimer`, `AbstractRate`, and `SettledUtil`.

### Benefits

Greatly simplified constructor calls.

### Possible Drawbacks

None.

### Verification Process

The tests still pass.

### Applicable Issues

Closes #102.
