### PR TITLE
Issue #104: Make controllerSet range -1,1

### DIFF
--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -36,7 +36,7 @@ class AsyncWrapper : virtual public AsyncController {
   AsyncWrapper(std::shared_ptr<ControllerInput> iinput, std::shared_ptr<ControllerOutput> ioutput,
                std::unique_ptr<IterativeController> icontroller,
                const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-               std::unique_ptr<SettledUtil> isettledUtil, double iscale = 127);
+               std::unique_ptr<SettledUtil> isettledUtil);
 
   /**
    * Sets the target for the controller.
@@ -117,7 +117,6 @@ class AsyncWrapper : virtual public AsyncController {
   std::unique_ptr<AbstractRate> settledRate;
   std::unique_ptr<SettledUtil> settledUtil;
   CROSSPLATFORM_THREAD task;
-  const double scale = 127;
 
   static void trampoline(void *context);
   void loop();

--- a/include/okapi/api/control/controllerOutput.hpp
+++ b/include/okapi/api/control/controllerOutput.hpp
@@ -13,9 +13,9 @@ class ControllerOutput {
   public:
   /**
    * Writes the value of the controller output. This method might be automatically called in another
-   * thread by the controller.
+   * thread by the controller. The range of input values is expected to be [-1, 1].
    *
-   * @param ivalue the controller's output
+   * @param ivalue the controller's output in the range [-1, 1]
    */
   virtual void controllerSet(double ivalue) = 0;
 };

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -34,9 +34,9 @@ class AbstractMotor : public ControllerOutput {
    * Indicates the internal gear ratio of a motor.
    */
   enum class gearset {
-    red = 0,   // 36:1, 100 RPM, Red gear set
-    green = 1, // 18:1, 200 RPM, Green gear set
-    blue = 2,  // 6:1, 600 RPM, Blue gear set
+    red = 100,   // 36:1, 100 RPM, Red gear set
+    green = 200, // 18:1, 200 RPM, Green gear set
+    blue = 600,  // 6:1,  600 RPM, Blue gear set
     invalid = INT32_MAX
   };
 

--- a/include/okapi/impl/device/motor/adiMotor.hpp
+++ b/include/okapi/impl/device/motor/adiMotor.hpp
@@ -25,9 +25,9 @@ class ADIMotor : public ControllerOutput {
 
   /**
    * Writes the value of the controller output. This method might be automatically called in another
-   * thread by the controller.
+   * thread by the controller. The range of input values is expected to be [-1, 1].
    *
-   * @param ivalue the controller's output
+   * @param ivalue the controller's output in the range [-1, 1]
    */
   virtual void controllerSet(const double ivalue) override;
 

--- a/include/okapi/impl/device/motor/motor.hpp
+++ b/include/okapi/impl/device/motor/motor.hpp
@@ -22,7 +22,7 @@ class Motor : public AbstractMotor, public pros::Motor {
   Motor(const std::int8_t port);
 
   explicit Motor(
-    const std::uint8_t port, const bool reverse, const AbstractMotor::gearset gearset,
+    const std::uint8_t port, const bool reverse, const AbstractMotor::gearset igearset,
     const AbstractMotor::encoderUnits encoderUnits = AbstractMotor::encoderUnits::degrees);
 
   /**
@@ -219,11 +219,14 @@ class Motor : public AbstractMotor, public pros::Motor {
 
   /**
    * Writes the value of the controller output. This method might be automatically called in another
-   * thread by the controller.
+   * thread by the controller. The range of input values is expected to be [-1, 1].
    *
-   * @param ivalue the controller's output
+   * @param ivalue the controller's output in the range [-1, 1]
    */
   virtual void controllerSet(const double ivalue) override;
+
+protected:
+  AbstractMotor::gearset gearset;
 };
 
 inline namespace literals {

--- a/include/okapi/impl/device/motor/motorGroup.hpp
+++ b/include/okapi/impl/device/motor/motorGroup.hpp
@@ -217,9 +217,9 @@ class MotorGroup : public AbstractMotor {
 
   /**
    * Writes the value of the controller output. This method might be automatically called in another
-   * thread by the controller.
+   * thread by the controller. The range of input values is expected to be [-1, 1].
    *
-   * @param ivalue the controller's output
+   * @param ivalue the controller's output in the range [-1, 1]
    */
   virtual void controllerSet(const double ivalue) override;
 

--- a/src/api/control/async/asyncWrapper.cpp
+++ b/src/api/control/async/asyncWrapper.cpp
@@ -14,15 +14,14 @@ AsyncWrapper::AsyncWrapper(std::shared_ptr<ControllerInput> iinput,
                            std::shared_ptr<ControllerOutput> ioutput,
                            std::unique_ptr<IterativeController> icontroller,
                            const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
-                           std::unique_ptr<SettledUtil> isettledUtil, const double iscale)
+                           std::unique_ptr<SettledUtil> isettledUtil)
   : input(iinput),
     output(ioutput),
     controller(std::move(icontroller)),
     loopRate(std::move(irateSupplier.get())),
     settledRate(std::move(irateSupplier.get())),
     settledUtil(std::move(isettledUtil)),
-    task(trampoline, this),
-    scale(iscale) {
+    task(trampoline, this) {
 }
 
 void AsyncWrapper::loop() {
@@ -30,7 +29,7 @@ void AsyncWrapper::loop() {
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
   while (true) {
     if (!controller->isDisabled()) {
-      output->controllerSet(scale * controller->step(input->controllerGet()));
+      output->controllerSet(controller->step(input->controllerGet()));
     }
 
     loopRate->delayUntil(controller->getSampleTime());

--- a/src/impl/device/motor/adiMotor.cpp
+++ b/src/impl/device/motor/adiMotor.cpp
@@ -17,6 +17,6 @@ void ADIMotor::moveVoltage(const std::int32_t ivoltage) const {
 }
 
 void ADIMotor::controllerSet(const double ivalue) {
-  motor.set_value(ivalue * reversed);
+  motor.set_value(ivalue * reversed * 127);
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

`ControllerOutput::controllerSet()` does not have a defined input range.
This range should be `[-1, 1]` and should be documented as such.

### Benefits

A standard input range should produce a more predictable API.

### Possible Drawbacks

The exact input range could be unintuitive for some users, but sufficient documentation should help.

### Verification Process

This change was not verified.

### Applicable Issues

Closes #104.
