### PR TITLE
Issue #101: Add ReadOnlyChassisModel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ add_executable(OkapiLibV5
         test/unitTests.cpp
         test/implMocks.cpp
         src/api/util/timeUtil.cpp
-        include/okapi/api/util/timeUtil.hpp)
+        include/okapi/api/util/timeUtil.hpp include/okapi/api/chassis/model/readOnlyChassisModel.hpp src/api/chassis/model/readOnlyChassisModel.cpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -14,6 +14,7 @@
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"
+#include "okapi/api/chassis/model/readOnlyChassisModel.hpp"
 #include "okapi/impl/chassis/controller/chassisControllerFactory.hpp"
 #include "okapi/impl/chassis/model/chassisModelFactory.hpp"
 

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -8,11 +8,11 @@
 #ifndef _OKAPI_CHASSISMODEL_HPP_
 #define _OKAPI_CHASSISMODEL_HPP_
 
+#include "okapi/api/chassis/model/readOnlyChassisModel.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
 #include <array>
 #include <initializer_list>
 #include <memory>
-#include <valarray>
 #include <vector>
 
 namespace okapi {
@@ -21,9 +21,16 @@ class ChassisModelArgs {
   virtual ~ChassisModelArgs();
 };
 
-class ChassisModel {
+/**
+ * A version of the ReadOnlyChassisModel that also supports write methods, such as setting motor
+ * speed. Because this class can write to motors, there can only be one owner and as such copying
+ * is disabled.
+ */
+class ChassisModel : public ReadOnlyChassisModel {
   public:
-  virtual ~ChassisModel();
+  ChassisModel() = default;
+  ChassisModel(const ChassisModel &) = delete;
+  ChassisModel &operator=(const ChassisModel &) = delete;
 
   /**
    * Drive the robot forwards (using open-loop control).
@@ -86,13 +93,6 @@ class ChassisModel {
    * @param ipower motor power
    */
   virtual void right(double ispeed) const = 0;
-
-  /**
-   * Read the sensors.
-   *
-   * @return sensor readings (format is implementation dependent)
-   */
-  virtual std::valarray<std::int32_t> getSensorVals() const = 0;
 
   /**
    * Reset the sensors to their zero point.

--- a/include/okapi/api/chassis/model/readOnlyChassisModel.hpp
+++ b/include/okapi/api/chassis/model/readOnlyChassisModel.hpp
@@ -1,0 +1,33 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_READONLYCHASSISMODEL_HPP_
+#define _OKAPI_READONLYCHASSISMODEL_HPP_
+
+#include "okapi/api/coreProsAPI.hpp"
+#include <valarray>
+
+namespace okapi {
+/**
+ * A version of the ChassisModel that only supports read methods, such as querying sensor values.
+ * This class does not let you write to motors, so it supports having multiple owners and as a
+ * result copying is enabled.
+ */
+class ReadOnlyChassisModel {
+  public:
+  virtual ~ReadOnlyChassisModel();
+
+  /**
+   * Read the sensors.
+   *
+   * @return sensor readings (format is implementation dependent)
+   */
+  virtual std::valarray<std::int32_t> getSensorVals() const = 0;
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -62,8 +62,6 @@ class SkidSteerModel : public ChassisModel {
 
   explicit SkidSteerModel(const SkidSteerModelArgs &iparams);
 
-  SkidSteerModel(const SkidSteerModel &other);
-
   /**
    * Drive the robot forwards (using open-loop control). Uses velocity mode.
    *

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -75,8 +75,6 @@ class XDriveModel : public ChassisModel {
 
   explicit XDriveModel(const XDriveModelArgs &iparams);
 
-  XDriveModel(const XDriveModel &other);
-
   /**
    * Drive the robot forwards (using open-loop control). Uses velocity mode.
    *

--- a/src/api/chassis/model/readOnlyChassisModel.cpp
+++ b/src/api/chassis/model/readOnlyChassisModel.cpp
@@ -5,8 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-#include "okapi/api/chassis/model/chassisModel.hpp"
+#include "okapi/api/chassis/model/readOnlyChassisModel.hpp"
 
 namespace okapi {
-ChassisModelArgs::~ChassisModelArgs() = default;
-} // namespace okapi
+ReadOnlyChassisModel::~ReadOnlyChassisModel() = default;
+}

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -62,14 +62,6 @@ SkidSteerModel::SkidSteerModel(const SkidSteerModelArgs &iparams)
     maxOutput(iparams.maxOutput) {
 }
 
-SkidSteerModel::SkidSteerModel(const SkidSteerModel &other)
-  : leftSideMotor(other.leftSideMotor),
-    rightSideMotor(other.rightSideMotor),
-    leftSensor(other.leftSensor),
-    rightSensor(other.rightSensor),
-    maxOutput(other.maxOutput) {
-}
-
 void SkidSteerModel::forward(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   leftSideMotor->moveVelocity(speed * maxOutput);

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -77,16 +77,6 @@ XDriveModel::XDriveModel(const XDriveModelArgs &iparams)
     maxOutput(iparams.maxOutput) {
 }
 
-XDriveModel::XDriveModel(const XDriveModel &other)
-  : topLeftMotor(other.topLeftMotor),
-    topRightMotor(other.topRightMotor),
-    bottomRightMotor(other.bottomRightMotor),
-    bottomLeftMotor(other.bottomLeftMotor),
-    leftSensor(other.leftSensor),
-    rightSensor(other.rightSensor),
-    maxOutput(other.maxOutput) {
-}
-
 void XDriveModel::forward(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   topLeftMotor->moveVelocity(speed * maxOutput);


### PR DESCRIPTION
### Description of the Change

There should be a "read-only" `ChassisModel` to help enforce a one-writer policy. This PR introduces that interface.

### Benefits

Classes can now accept a `ChassisModel` without owning it.

### Possible Drawbacks

None.

### Verification Process

This pure API change was not verified.

### Applicable Issues

Closes #101.
