### PR TITLE
Issue #121: Add more ChassisController::waitUntilSettled tests

### DIFF
--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -29,6 +29,8 @@ class MockContinuousRotarySensor : public ContinuousRotarySensor {
   int32_t reset() const override;
 
   int32_t get() const override;
+
+  mutable std::int32_t value{0};
 };
 
 /**
@@ -72,6 +74,7 @@ class MockMotor : public AbstractMotor {
 
   std::int32_t moveVoltage(std::int16_t ivoltage) const override;
 
+  std::shared_ptr<MockContinuousRotarySensor> encoder;
   mutable std::int16_t lastVelocity{};
   mutable std::int16_t lastVoltage{};
   mutable std::int16_t lastPosition{};

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -238,6 +238,52 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleThenMoveDistanceAsyncTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
+TEST_F(ChassisControllerIntegratedTest, MoveDistanceAndWaitTest) {
+  controller->moveDistance(100);
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerIntegratedTest, MoveDistanceGetPushedAndWaitTest) {
+  controller->moveDistance(100);
+
+  // First bump
+  leftMotor->encoder->value = 500;
+  rightMotor->encoder->value = 500;
+  controller->waitUntilSettled();
+
+  // Second bump
+  leftMotor->encoder->value = 1000;
+  rightMotor->encoder->value = 1000;
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerIntegratedTest, TurnAngleAndWaitTest) {
+  controller->turnAngle(100);
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerIntegratedTest, TurnAngleGetPushedAndWaitTest) {
+  controller->turnAngle(100);
+
+  // First bump
+  leftMotor->encoder->value = 500;
+  rightMotor->encoder->value = 500;
+  controller->waitUntilSettled();
+
+  // Second bump
+  leftMotor->encoder->value = 1000;
+  rightMotor->encoder->value = 1000;
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
 class ChassisControllerPIDTest : public ::testing::Test {
   protected:
   void SetUp() override {
@@ -422,6 +468,52 @@ TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
 
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerPIDTest, MoveDistanceAndWaitTest) {
+  controller->moveDistance(100);
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerPIDTest, MoveDistanceGetBumpedAndWaitTest) {
+  controller->moveDistance(100);
+
+  // First bump
+  leftMotor->encoder->value = 500;
+  rightMotor->encoder->value = 500;
+  controller->waitUntilSettled();
+
+  // Second bump
+  leftMotor->encoder->value = 1000;
+  rightMotor->encoder->value = 1000;
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerPIDTest, TurnAngleAndWaitTest) {
+  controller->turnAngle(100);
+  controller->waitUntilSettled();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerPIDTest, TurnAngleGetBumpedAndWaitTest) {
+  controller->turnAngle(100);
+
+  // First bump
+  leftMotor->encoder->value = 500;
+  rightMotor->encoder->value = 500;
+  controller->waitUntilSettled();
+
+  // Second bump
+  leftMotor->encoder->value = 1000;
+  rightMotor->encoder->value = 1000;
+  controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -14,18 +14,20 @@
 
 namespace okapi {
 double MockContinuousRotarySensor::controllerGet() {
-  return 0;
+  return value;
 }
 
 int32_t MockContinuousRotarySensor::reset() const {
+  value = 0;
   return 0;
 }
 
 int32_t MockContinuousRotarySensor::get() const {
-  return 0;
+  return value;
 }
 
-MockMotor::MockMotor() = default;
+MockMotor::MockMotor() : encoder(std::make_shared<MockContinuousRotarySensor>()) {
+}
 
 void MockMotor::controllerSet(const double ivalue) {
   moveVelocity((int16_t)ivalue);
@@ -46,7 +48,7 @@ double MockMotor::getTargetPosition() const {
 }
 
 double MockMotor::getPosition() const {
-  return 0;
+  return encoder->get();
 }
 
 int32_t MockMotor::getTargetVelocity() const {
@@ -86,7 +88,7 @@ int32_t MockMotor::setVoltageLimit(const std::int32_t ilimit) const {
 }
 
 std::shared_ptr<ContinuousRotarySensor> MockMotor::getEncoder() const {
-  return std::make_shared<MockContinuousRotarySensor>();
+  return encoder;
 }
 
 std::int32_t MockMotor::moveVelocity(const std::int16_t ivelocity) const {


### PR DESCRIPTION
### Description of the Change

Four kinds of tests were added:
1. Calling `waitUntilSettled()` after `moveDistance()`
2. Calling `waitUntilSettled()` after `turnAngle()`
3. Calling `waitUntilSettled()` after the robot has moved after `moveDistance()`
4. Calling `waitUntilSettled()` after the robot has moved after `turnAngle()`

### Benefits

More assurity in the behavior of the `ChassisController` implementations under weird uses.

### Possible Drawbacks

None.

### Verification Process

The tests pass :)

### Applicable Issues

Closes #121.
