### PR TITLE
Issue #123: Make isSettled return true if the controller is disabled

### DIFF
--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -45,6 +45,8 @@ class AsyncPosIntegratedController : public AsyncPositionController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   bool isSettled() override;

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -46,6 +46,8 @@ class AsyncVelIntegratedController : public AsyncVelocityController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   bool isSettled() override;

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -57,6 +57,8 @@ class AsyncWrapper : virtual public AsyncController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   bool isSettled() override;

--- a/include/okapi/api/control/closedLoopController.hpp
+++ b/include/okapi/api/control/closedLoopController.hpp
@@ -36,6 +36,8 @@ template <typename I, typename E> class ClosedLoopController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   virtual bool isSettled() = 0;

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -74,6 +74,8 @@ class IterativePosPIDController : public IterativePositionController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   bool isSettled() override;

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -56,6 +56,8 @@ class IterativeVelPIDController : public IterativeVelocityController {
    * Returns whether the controller has settled at the target. Determining what settling means is
    * implementation-dependent.
    *
+   * If the controller is disabled, this method must return true.
+   *
    * @return whether the controller is settled
    */
   bool isSettled() override;

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -43,7 +43,7 @@ double AsyncPosIntegratedController::getError() const {
 }
 
 bool AsyncPosIntegratedController::isSettled() {
-  return settledUtil->isSettled(getError());
+  return isDisabled() ? true : settledUtil->isSettled(getError());
 }
 
 void AsyncPosIntegratedController::reset() {

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -43,7 +43,7 @@ double AsyncVelIntegratedController::getError() const {
 }
 
 bool AsyncVelIntegratedController::isSettled() {
-  return settledUtil->isSettled(getError());
+  return isDisabled() ? true : settledUtil->isSettled(getError());
 }
 
 void AsyncVelIntegratedController::reset() {

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -51,7 +51,7 @@ double IterativePosPIDController::getDerivative() const {
 }
 
 bool IterativePosPIDController::isSettled() {
-  return settledUtil->isSettled(error);
+  return isDisabled() ? true : settledUtil->isSettled(error);
 }
 
 void IterativePosPIDController::setSampleTime(const QTime isampleTime) {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -94,7 +94,7 @@ double IterativeVelPIDController::getDerivative() const {
 }
 
 bool IterativeVelPIDController::isSettled() {
-  return settledUtil->isSettled(error);
+  return isDisabled() ? true : settledUtil->isSettled(error);
 }
 
 void IterativeVelPIDController::reset() {

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -176,6 +176,46 @@ TEST_F(AsyncControllerTest, AsyncVelIntegratedController) {
   assertControllerFollowsTargetLifecycle(AsyncVelIntegratedController(motor, createTimeUtil()));
 }
 
+void assertControllerIsSettledWhenDisabled(ClosedLoopController<double, double> &controller) {
+  controller.setTarget(100);
+  EXPECT_FALSE(controller.isSettled());
+
+  controller.flipDisable();
+  EXPECT_TRUE(controller.isSettled());
+}
+
+TEST(IterativePosPIDControllerTest, SettledWhenDisabled) {
+  IterativePosPIDController controller(
+    0.004, 0, 0, 0, createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>([]() {
+      return std::make_unique<ConstantMockTimer>(10_ms);
+    })));
+
+  assertControllerIsSettledWhenDisabled(controller);
+}
+
+TEST(IterativeVelPIDControllerTest, SettledWhenDisabled) {
+  IterativeVelPIDController controller(
+    0, 0, 0.1,
+    std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
+                              std::make_unique<ConstantMockTimer>(10_ms)),
+    createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
+      []() { return std::make_unique<ConstantMockTimer>(10_ms); })));
+
+  assertControllerIsSettledWhenDisabled(controller);
+}
+
+TEST(AsyncPosIntegratedControllerTest, SettledWhenDisabled) {
+  AsyncPosIntegratedController controller(std::make_shared<MockMotor>(), createTimeUtil());
+
+  assertControllerIsSettledWhenDisabled(controller);
+}
+
+TEST(AsyncVelIntegratedControllerTest, SettledWhenDisabled) {
+  AsyncVelIntegratedController controller(std::make_shared<MockMotor>(), createTimeUtil());
+
+  assertControllerIsSettledWhenDisabled(controller);
+}
+
 TEST(FilteredControllerInputTest, InputShouldBePassedThrough) {
   class MockControllerInput : public ControllerInput {
     public:


### PR DESCRIPTION
### Description of the Change

In order to prevent program hangs when waiting for a disabled controller to settle, `ClosedLoopController::isSettled` should return `true` if the controller is disabled.

### Benefits

Described above.

### Possible Drawbacks

If the controller is moved by external forces while disabled, then `isSettled()` will not reflect that. `getError()` would still show that movement, though. This could have a small impact on some users.

### Verification Process

The tests still pass :)

### Applicable Issues

Closes #123.
