### PR TITLE
Issue #122: Make reset non-const

### DIFF
--- a/include/okapi/api/device/rotarysensor/continuousRotarySensor.hpp
+++ b/include/okapi/api/device/rotarysensor/continuousRotarySensor.hpp
@@ -18,7 +18,7 @@ class ContinuousRotarySensor : public RotarySensor {
    *
    * @return 1 on success, PROS_ERR on fail
    */
-  virtual std::int32_t reset() const = 0;
+  virtual std::int32_t reset() = 0;
 };
 } // namespace okapi
 

--- a/include/okapi/impl/device/rotarysensor/adiEncoder.hpp
+++ b/include/okapi/impl/device/rotarysensor/adiEncoder.hpp
@@ -27,9 +27,9 @@ class ADIEncoder : public ContinuousRotarySensor {
   /**
    * Reset the sensor to zero.
    *
-   * @return 1 on suceess, PROS_ERR on fail
+   * @return 1 on success, PROS_ERR on fail
    */
-  virtual std::int32_t reset() const override;
+  virtual std::int32_t reset() override;
 
   /**
    * Get the sensor value for use in a control loop. This method might be automatically called in

--- a/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
+++ b/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
@@ -31,9 +31,9 @@ class IntegratedEncoder : public ContinuousRotarySensor {
   /**
    * Reset the sensor to zero.
    *
-   * @return 1 on suceess, PROS_ERR on fail
+   * @return 1 on success, PROS_ERR on fail
    */
-  virtual std::int32_t reset() const override;
+  virtual std::int32_t reset() override;
 
   /**
    * Get the sensor value for use in a control loop. This method might be automatically called in

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -26,7 +26,7 @@ class MockContinuousRotarySensor : public ContinuousRotarySensor {
   public:
   double controllerGet() override;
 
-  int32_t reset() const override;
+  int32_t reset() override;
 
   int32_t get() const override;
 

--- a/src/impl/device/rotarysensor/adiEncoder.cpp
+++ b/src/impl/device/rotarysensor/adiEncoder.cpp
@@ -17,7 +17,7 @@ std::int32_t ADIEncoder::get() const {
   return enc.get_value();
 }
 
-std::int32_t ADIEncoder::reset() const {
+std::int32_t ADIEncoder::reset() {
   return enc.reset();
 }
 

--- a/src/impl/device/rotarysensor/integratedEncoder.cpp
+++ b/src/impl/device/rotarysensor/integratedEncoder.cpp
@@ -15,7 +15,7 @@ std::int32_t IntegratedEncoder::get() const {
   return motor.get_position();
 }
 
-std::int32_t IntegratedEncoder::reset() const {
+std::int32_t IntegratedEncoder::reset() {
   return motor.tare_position();
 }
 

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -17,7 +17,7 @@ double MockContinuousRotarySensor::controllerGet() {
   return value;
 }
 
-int32_t MockContinuousRotarySensor::reset() const {
+int32_t MockContinuousRotarySensor::reset() {
   value = 0;
   return 0;
 }


### PR DESCRIPTION
### Description of the Change

`ContinuousRotarySensor::reset()` can sometimes involve calls to software instead of just resetting hardware, so this method should not be `const`.

### Applicable Issues

Closes #122.
