### PR TITLE
Issue #129: Override stop in the ChassisControllers

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -118,7 +118,7 @@ class ChassisController {
   /**
    * Stop the robot (set all the motors to 0).
    */
-  virtual void stop() const;
+  virtual void stop();
 
   /**
    * Drive the robot with a tank drive layout. Uses voltage mode.

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -111,6 +111,11 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    */
   void waitUntilSettled() override;
 
+  /**
+   * Stop the robot (set all the motors to 0).
+   */
+  void stop() override;
+
   protected:
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<AsyncPosIntegratedController> leftController;

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -113,6 +113,11 @@ class ChassisControllerPID : public virtual ChassisController {
    */
   void waitUntilSettled() override;
 
+  /**
+   * Stop the robot (set all the motors to 0).
+   */
+  void stop() override;
+
   protected:
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<IterativePosPIDController> distancePid;
@@ -129,6 +134,7 @@ class ChassisControllerPID : public virtual ChassisController {
 
   bool waitForDistanceSettled();
   bool waitForAngleSettled();
+  void stopAfterSettled();
 
   typedef enum { distance, angle } modeType;
   modeType mode;

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -60,7 +60,7 @@ class ChassisModel : public ReadOnlyChassisModel {
   /**
    * Stop the robot (set all the motors to 0).
    */
-  virtual void stop() const = 0;
+  virtual void stop() = 0;
 
   /**
    * Drive the robot with a tank drive layout. Uses voltage mode.

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -90,7 +90,7 @@ class SkidSteerModel : public ChassisModel {
   /**
    * Stop the robot (set all the motors to 0). Uses velocity mode.
    */
-  void stop() const override;
+  void stop() override;
 
   /**
    * Drive the robot with a tank drive layout. Uses voltage mode.

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -103,7 +103,7 @@ class XDriveModel : public ChassisModel {
   /**
    * Stop the robot (set all the motors to 0). Uses velocity mode.
    */
-  void stop() const override;
+  void stop() override;
 
   /**
    * Drive the robot with a tank drive layout. Uses voltage mode.

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -27,7 +27,7 @@ void ChassisController::rotate(const int ispeed) const {
   model->rotate(ispeed);
 }
 
-void ChassisController::stop() const {
+void ChassisController::stop() {
   model->stop();
 }
 

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -105,4 +105,11 @@ void ChassisControllerIntegrated::waitUntilSettled() {
   rightController->flipDisable(true);
   model->stop();
 }
+
+void ChassisControllerIntegrated::stop() {
+  leftController->flipDisable(true);
+  rightController->flipDisable(true);
+
+  ChassisController::stop();
+}
 } // namespace okapi

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -162,10 +162,7 @@ void ChassisControllerPID::waitUntilSettled() {
 
       // Only disable the controllers and stop if we are totally settled and won't try again
       if (completelySettled) {
-        doneLooping = true;
-        distancePid->flipDisable(true);
-        anglePid->flipDisable(true);
-        model->stop();
+        stopAfterSettled();
       }
 
       break;
@@ -175,9 +172,7 @@ void ChassisControllerPID::waitUntilSettled() {
 
       // Only disable the controllers and stop if we are totally settled and won't try again
       if (completelySettled) {
-        doneLooping = true;
-        anglePid->flipDisable(true);
-        model->stop();
+        stopAfterSettled();
       }
 
       break;
@@ -224,5 +219,30 @@ bool ChassisControllerPID::waitForAngleSettled() {
 
   // True will cause the loop to exit
   return true;
+}
+
+void ChassisControllerPID::stopAfterSettled() {
+  switch (mode) {
+  case distance:
+    doneLooping = true;
+    distancePid->flipDisable(true);
+    anglePid->flipDisable(true);
+    model->stop();
+    break;
+
+  case angle:
+    doneLooping = true;
+    anglePid->flipDisable(true);
+    model->stop();
+    break;
+
+  default:
+    break;
+  }
+}
+
+void ChassisControllerPID::stop() {
+  stopAfterSettled();
+  ChassisController::stop();
 }
 } // namespace okapi

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -92,7 +92,7 @@ void SkidSteerModel::rotate(const double ispeed) const {
   rightSideMotor->moveVelocity(-1 * speed * maxOutput);
 }
 
-void SkidSteerModel::stop() const {
+void SkidSteerModel::stop() {
   leftSideMotor->moveVelocity(0);
   rightSideMotor->moveVelocity(0);
 }

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -113,7 +113,7 @@ void XDriveModel::rotate(const double ispeed) const {
   bottomLeftMotor->moveVelocity(speed * maxOutput);
 }
 
-void XDriveModel::stop() const {
+void XDriveModel::stop() {
   topLeftMotor->moveVelocity(0);
   topRightMotor->moveVelocity(0);
   bottomRightMotor->moveVelocity(0);

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -284,6 +284,24 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleGetPushedAndWaitTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
+TEST_F(ChassisControllerIntegratedTest, MoveDistanceAndStopTest) {
+  controller->moveDistanceAsync(100);
+  controller->stop();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
+}
+
+TEST_F(ChassisControllerIntegratedTest, TurnAngleAndStopTest) {
+  controller->turnAngleAsync(100);
+  controller->stop();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
+}
+
 class ChassisControllerPIDTest : public ::testing::Test {
   protected:
   void SetUp() override {
@@ -516,4 +534,21 @@ TEST_F(ChassisControllerPIDTest, TurnAngleGetBumpedAndWaitTest) {
   controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+}
+
+TEST_F(ChassisControllerPIDTest, MoveDistanceAndStopTest) {
+  controller->moveDistanceAsync(100);
+  controller->stop();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+}
+
+TEST_F(ChassisControllerPIDTest, TurnAngleAndStopTest) {
+  controller->turnAngleAsync(100);
+  controller->stop();
+
+  assertMotorsHaveBeenStopped(leftMotor, rightMotor);
+  EXPECT_TRUE(angleController->isDisabled());
 }


### PR DESCRIPTION
### Description of the Change

The `ChassisController` implementations need to override `stop()` so they can disable their internal controllers, stop PID loops, etc. `stop()` was also made non-const.

### Verification Process

This change was tested with CCPID on a real robot, and some tests were written to assert that motors get stopped and controllers get disabled.

### Applicable Issues

Closes #129.
