### PR TITLE
Issue #130: Change angle error direction

### DIFF
--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -71,13 +71,13 @@ void ChassisControllerPID::loop() {
       case distance:
         encVals = model->getSensorVals() - encStartVals;
         distanceElapsed = static_cast<double>((encVals[0] + encVals[1])) / 2.0;
-        angleChange = static_cast<double>(encVals[1] - encVals[0]);
+        angleChange = static_cast<double>(encVals[0] - encVals[1]);
         model->driveVector(distancePid->step(distanceElapsed), anglePid->step(angleChange));
 
         break;
       case angle:
         encVals = model->getSensorVals() - encStartVals;
-        angleChange = static_cast<double>(encVals[1] - encVals[0]);
+        angleChange = static_cast<double>(encVals[0] - encVals[1]);
         model->rotate(anglePid->step(angleChange));
 
         break;


### PR DESCRIPTION
### Description of the Change

CCPID's angle error was in the wrong direction, causing clockwise movement to decrease error (i.e. gain error in the negative direction). Turning clockwise should be the positive direction, not the negative direction.

### Verification Process

This was tested on a real robot.

### Applicable Issues

Closes #130.
