### PR TITLE
Issue #133: Put units into the okapi namespace

### DIFF
--- a/include/okapi/api/units/QAcceleration.hpp
+++ b/include/okapi/api/units/QAcceleration.hpp
@@ -19,25 +19,25 @@
 #include "okapi/api/units/RQuantity.hpp"
 
 namespace okapi {
-  QUANTITY_TYPE(0, 1, -2, 0, QAcceleration)
+QUANTITY_TYPE(0, 1, -2, 0, QAcceleration)
 
-  constexpr QAcceleration mps2 = meter / (second * second);
-  constexpr QAcceleration G = 9.80665 * mps2;
+constexpr QAcceleration mps2 = meter / (second * second);
+constexpr QAcceleration G = 9.80665 * mps2;
 
-  inline namespace literals {
-    constexpr QAcceleration operator"" _mps2(long double x) {
-      return QAcceleration(x);
-    }
-    constexpr QAcceleration operator"" _mps2(unsigned long long int x) {
-      return QAcceleration(static_cast<double>(x));
-    }
-    constexpr QAcceleration operator"" _G(long double x) {
-      return static_cast<double>(x) * G;
-    }
-    constexpr QAcceleration operator"" _G(unsigned long long int x) {
-      return static_cast<double>(x) * G;
-    }
-  }
+inline namespace literals {
+constexpr QAcceleration operator"" _mps2(long double x) {
+  return QAcceleration(x);
 }
+constexpr QAcceleration operator"" _mps2(unsigned long long int x) {
+  return QAcceleration(static_cast<double>(x));
+}
+constexpr QAcceleration operator"" _G(long double x) {
+  return static_cast<double>(x) * G;
+}
+constexpr QAcceleration operator"" _G(unsigned long long int x) {
+  return static_cast<double>(x) * G;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QAcceleration.hpp
+++ b/include/okapi/api/units/QAcceleration.hpp
@@ -18,22 +18,26 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 1, -2, 0, QAcceleration)
+namespace okapi {
+  QUANTITY_TYPE(0, 1, -2, 0, QAcceleration)
 
-constexpr QAcceleration mps2 = meter / (second * second);
-constexpr QAcceleration G = 9.80665 * mps2;
+  constexpr QAcceleration mps2 = meter / (second * second);
+  constexpr QAcceleration G = 9.80665 * mps2;
 
-constexpr QAcceleration operator"" _mps2(long double x) {
-  return QAcceleration(x);
-}
-constexpr QAcceleration operator"" _mps2(unsigned long long int x) {
-  return QAcceleration(static_cast<double>(x));
-}
-constexpr QAcceleration operator"" _G(long double x) {
-  return static_cast<double>(x) * G;
-}
-constexpr QAcceleration operator"" _G(unsigned long long int x) {
-  return static_cast<double>(x) * G;
+  inline namespace literals {
+    constexpr QAcceleration operator"" _mps2(long double x) {
+      return QAcceleration(x);
+    }
+    constexpr QAcceleration operator"" _mps2(unsigned long long int x) {
+      return QAcceleration(static_cast<double>(x));
+    }
+    constexpr QAcceleration operator"" _G(long double x) {
+      return static_cast<double>(x) * G;
+    }
+    constexpr QAcceleration operator"" _G(unsigned long long int x) {
+      return static_cast<double>(x) * G;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QAngle.hpp
+++ b/include/okapi/api/units/QAngle.hpp
@@ -17,27 +17,26 @@
 #include "okapi/api/units/RQuantity.hpp"
 #include <cmath>
 
-namespace okapi
-{
-  QUANTITY_TYPE(0, 0, 0, 1, QAngle)
+namespace okapi {
+QUANTITY_TYPE(0, 0, 0, 1, QAngle)
 
-  constexpr QAngle radian(1.0);
-  constexpr QAngle degree = static_cast<double>(2_pi / 360.0) * radian;
+constexpr QAngle radian(1.0);
+constexpr QAngle degree = static_cast<double>(2_pi / 360.0) * radian;
 
-  inline namespace literals {
-    constexpr QAngle operator"" _rad(long double x) {
-      return QAngle(x);
-    }
-    constexpr QAngle operator"" _rad(unsigned long long int x) {
-      return QAngle(static_cast<double>(x));
-    }
-    constexpr QAngle operator"" _deg(long double x) {
-      return static_cast<double>(x) * degree;
-    }
-    constexpr QAngle operator"" _deg(unsigned long long int x) {
-      return static_cast<double>(x) * degree;
-    }
-  }
+inline namespace literals {
+constexpr QAngle operator"" _rad(long double x) {
+  return QAngle(x);
 }
+constexpr QAngle operator"" _rad(unsigned long long int x) {
+  return QAngle(static_cast<double>(x));
+}
+constexpr QAngle operator"" _deg(long double x) {
+  return static_cast<double>(x) * degree;
+}
+constexpr QAngle operator"" _deg(unsigned long long int x) {
+  return static_cast<double>(x) * degree;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QAngle.hpp
+++ b/include/okapi/api/units/QAngle.hpp
@@ -17,22 +17,27 @@
 #include "okapi/api/units/RQuantity.hpp"
 #include <cmath>
 
-QUANTITY_TYPE(0, 0, 0, 1, QAngle)
+namespace okapi
+{
+  QUANTITY_TYPE(0, 0, 0, 1, QAngle)
 
-constexpr QAngle radian(1.0);
-constexpr QAngle degree = static_cast<double>(2_pi / 360.0) * radian;
+  constexpr QAngle radian(1.0);
+  constexpr QAngle degree = static_cast<double>(2_pi / 360.0) * radian;
 
-constexpr QAngle operator"" _rad(long double x) {
-  return QAngle(x);
-}
-constexpr QAngle operator"" _rad(unsigned long long int x) {
-  return QAngle(static_cast<double>(x));
-}
-constexpr QAngle operator"" _deg(long double x) {
-  return static_cast<double>(x) * degree;
-}
-constexpr QAngle operator"" _deg(unsigned long long int x) {
-  return static_cast<double>(x) * degree;
+  inline namespace literals {
+    constexpr QAngle operator"" _rad(long double x) {
+      return QAngle(x);
+    }
+    constexpr QAngle operator"" _rad(unsigned long long int x) {
+      return QAngle(static_cast<double>(x));
+    }
+    constexpr QAngle operator"" _deg(long double x) {
+      return static_cast<double>(x) * degree;
+    }
+    constexpr QAngle operator"" _deg(unsigned long long int x) {
+      return static_cast<double>(x) * degree;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QAngularAcceleration.hpp
+++ b/include/okapi/api/units/QAngularAcceleration.hpp
@@ -16,8 +16,8 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 0, -2, 1, QAngularAcceleration)
+namespace okapi {
+QUANTITY_TYPE(0, 0, -2, 1, QAngularAcceleration)
 }
 
 #endif

--- a/include/okapi/api/units/QAngularAcceleration.hpp
+++ b/include/okapi/api/units/QAngularAcceleration.hpp
@@ -16,6 +16,8 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 0, -2, 1, QAngularAcceleration)
+namespace okapi{
+  QUANTITY_TYPE(0, 0, -2, 1, QAngularAcceleration)
+}
 
 #endif

--- a/include/okapi/api/units/QAngularJerk.hpp
+++ b/include/okapi/api/units/QAngularJerk.hpp
@@ -16,6 +16,8 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 0, -3, 1, QAngularJerk)
+namespace okapi {
+  QUANTITY_TYPE(0, 0, -3, 1, QAngularJerk)
+}
 
 #endif

--- a/include/okapi/api/units/QAngularJerk.hpp
+++ b/include/okapi/api/units/QAngularJerk.hpp
@@ -17,7 +17,7 @@
 #include "okapi/api/units/RQuantity.hpp"
 
 namespace okapi {
-  QUANTITY_TYPE(0, 0, -3, 1, QAngularJerk)
+QUANTITY_TYPE(0, 0, -3, 1, QAngularJerk)
 }
 
 #endif

--- a/include/okapi/api/units/QAngularSpeed.hpp
+++ b/include/okapi/api/units/QAngularSpeed.hpp
@@ -18,16 +18,20 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 0, -1, 1, QAngularSpeed)
+namespace okapi{
+  QUANTITY_TYPE(0, 0, -1, 1, QAngularSpeed)
 
-constexpr QAngularSpeed radps = radian / second;
-constexpr QAngularSpeed rpm = (360 * degree) / minute;
+  constexpr QAngularSpeed radps = radian / second;
+  constexpr QAngularSpeed rpm = (360 * degree) / minute;
 
-constexpr QAngularSpeed operator"" _rpm(long double x) {
-  return x * rpm;
-}
-constexpr QAngularSpeed operator"" _rpm(unsigned long long int x) {
-  return static_cast<double>(x) * rpm;
+  inline namespace literals{
+    constexpr QAngularSpeed operator"" _rpm(long double x) {
+      return x * rpm;
+    }
+    constexpr QAngularSpeed operator"" _rpm(unsigned long long int x) {
+      return static_cast<double>(x) * rpm;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QAngularSpeed.hpp
+++ b/include/okapi/api/units/QAngularSpeed.hpp
@@ -18,20 +18,20 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 0, -1, 1, QAngularSpeed)
+namespace okapi {
+QUANTITY_TYPE(0, 0, -1, 1, QAngularSpeed)
 
-  constexpr QAngularSpeed radps = radian / second;
-  constexpr QAngularSpeed rpm = (360 * degree) / minute;
+constexpr QAngularSpeed radps = radian / second;
+constexpr QAngularSpeed rpm = (360 * degree) / minute;
 
-  inline namespace literals{
-    constexpr QAngularSpeed operator"" _rpm(long double x) {
-      return x * rpm;
-    }
-    constexpr QAngularSpeed operator"" _rpm(unsigned long long int x) {
-      return static_cast<double>(x) * rpm;
-    }
-  }
+inline namespace literals {
+constexpr QAngularSpeed operator"" _rpm(long double x) {
+  return x * rpm;
 }
+constexpr QAngularSpeed operator"" _rpm(unsigned long long int x) {
+  return static_cast<double>(x) * rpm;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QArea.hpp
+++ b/include/okapi/api/units/QArea.hpp
@@ -17,15 +17,17 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 2, 0, 0, QArea)
+namespace okapi {
+  QUANTITY_TYPE(0, 2, 0, 0, QArea)
 
-constexpr QArea kilometer2 = kilometer * kilometer;
-constexpr QArea meter2 = meter * meter;
-constexpr QArea decimeter2 = decimeter * decimeter;
-constexpr QArea centimeter2 = centimeter * centimeter;
-constexpr QArea millimeter2 = millimeter * millimeter;
-constexpr QArea inch2 = inch * inch;
-constexpr QArea foot2 = foot * foot;
-constexpr QArea mile2 = mile * mile;
+  constexpr QArea kilometer2 = kilometer * kilometer;
+  constexpr QArea meter2 = meter * meter;
+  constexpr QArea decimeter2 = decimeter * decimeter;
+  constexpr QArea centimeter2 = centimeter * centimeter;
+  constexpr QArea millimeter2 = millimeter * millimeter;
+  constexpr QArea inch2 = inch * inch;
+  constexpr QArea foot2 = foot * foot;
+  constexpr QArea mile2 = mile * mile;
+}
 
 #endif

--- a/include/okapi/api/units/QArea.hpp
+++ b/include/okapi/api/units/QArea.hpp
@@ -18,16 +18,16 @@
 #include "okapi/api/units/RQuantity.hpp"
 
 namespace okapi {
-  QUANTITY_TYPE(0, 2, 0, 0, QArea)
+QUANTITY_TYPE(0, 2, 0, 0, QArea)
 
-  constexpr QArea kilometer2 = kilometer * kilometer;
-  constexpr QArea meter2 = meter * meter;
-  constexpr QArea decimeter2 = decimeter * decimeter;
-  constexpr QArea centimeter2 = centimeter * centimeter;
-  constexpr QArea millimeter2 = millimeter * millimeter;
-  constexpr QArea inch2 = inch * inch;
-  constexpr QArea foot2 = foot * foot;
-  constexpr QArea mile2 = mile * mile;
-}
+constexpr QArea kilometer2 = kilometer * kilometer;
+constexpr QArea meter2 = meter * meter;
+constexpr QArea decimeter2 = decimeter * decimeter;
+constexpr QArea centimeter2 = centimeter * centimeter;
+constexpr QArea millimeter2 = millimeter * millimeter;
+constexpr QArea inch2 = inch * inch;
+constexpr QArea foot2 = foot * foot;
+constexpr QArea mile2 = mile * mile;
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QForce.hpp
+++ b/include/okapi/api/units/QForce.hpp
@@ -18,29 +18,33 @@
 #include "okapi/api/units/QMass.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(1, 1, -2, 0, QForce)
+namespace okapi {
+  QUANTITY_TYPE(1, 1, -2, 0, QForce)
 
-constexpr QForce newton = (kg * meter) / (second * second);
-constexpr QForce poundforce = pound * G;
-constexpr QForce kilopond = kg * G;
+  constexpr QForce newton = (kg * meter) / (second * second);
+  constexpr QForce poundforce = pound * G;
+  constexpr QForce kilopond = kg * G;
 
-constexpr QForce operator"" _n(long double x) {
-  return QForce(x);
-}
-constexpr QForce operator"" _n(unsigned long long int x) {
-  return QForce(static_cast<double>(x));
-}
-constexpr QForce operator"" _lbf(long double x) {
-  return static_cast<double>(x) * poundforce;
-}
-constexpr QForce operator"" _lbf(unsigned long long int x) {
-  return static_cast<double>(x) * poundforce;
-}
-constexpr QForce operator"" _kp(long double x) {
-  return static_cast<double>(x) * kilopond;
-}
-constexpr QForce operator"" _kp(unsigned long long int x) {
-  return static_cast<double>(x) * kilopond;
+  inline namespace literals{
+    constexpr QForce operator"" _n(long double x) {
+      return QForce(x);
+    }
+    constexpr QForce operator"" _n(unsigned long long int x) {
+      return QForce(static_cast<double>(x));
+    }
+    constexpr QForce operator"" _lbf(long double x) {
+      return static_cast<double>(x) * poundforce;
+    }
+    constexpr QForce operator"" _lbf(unsigned long long int x) {
+      return static_cast<double>(x) * poundforce;
+    }
+    constexpr QForce operator"" _kp(long double x) {
+      return static_cast<double>(x) * kilopond;
+    }
+    constexpr QForce operator"" _kp(unsigned long long int x) {
+      return static_cast<double>(x) * kilopond;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QForce.hpp
+++ b/include/okapi/api/units/QForce.hpp
@@ -19,32 +19,32 @@
 #include "okapi/api/units/RQuantity.hpp"
 
 namespace okapi {
-  QUANTITY_TYPE(1, 1, -2, 0, QForce)
+QUANTITY_TYPE(1, 1, -2, 0, QForce)
 
-  constexpr QForce newton = (kg * meter) / (second * second);
-  constexpr QForce poundforce = pound * G;
-  constexpr QForce kilopond = kg * G;
+constexpr QForce newton = (kg * meter) / (second * second);
+constexpr QForce poundforce = pound * G;
+constexpr QForce kilopond = kg * G;
 
-  inline namespace literals{
-    constexpr QForce operator"" _n(long double x) {
-      return QForce(x);
-    }
-    constexpr QForce operator"" _n(unsigned long long int x) {
-      return QForce(static_cast<double>(x));
-    }
-    constexpr QForce operator"" _lbf(long double x) {
-      return static_cast<double>(x) * poundforce;
-    }
-    constexpr QForce operator"" _lbf(unsigned long long int x) {
-      return static_cast<double>(x) * poundforce;
-    }
-    constexpr QForce operator"" _kp(long double x) {
-      return static_cast<double>(x) * kilopond;
-    }
-    constexpr QForce operator"" _kp(unsigned long long int x) {
-      return static_cast<double>(x) * kilopond;
-    }
-  }
+inline namespace literals {
+constexpr QForce operator"" _n(long double x) {
+  return QForce(x);
 }
+constexpr QForce operator"" _n(unsigned long long int x) {
+  return QForce(static_cast<double>(x));
+}
+constexpr QForce operator"" _lbf(long double x) {
+  return static_cast<double>(x) * poundforce;
+}
+constexpr QForce operator"" _lbf(unsigned long long int x) {
+  return static_cast<double>(x) * poundforce;
+}
+constexpr QForce operator"" _kp(long double x) {
+  return static_cast<double>(x) * kilopond;
+}
+constexpr QForce operator"" _kp(unsigned long long int x) {
+  return static_cast<double>(x) * kilopond;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QFrequency.hpp
+++ b/include/okapi/api/units/QFrequency.hpp
@@ -17,18 +17,18 @@
 #include "okapi/api/units/RQuantity.hpp"
 
 namespace okapi {
-  QUANTITY_TYPE(0, 0, -1, 0, QFrequency)
+QUANTITY_TYPE(0, 0, -1, 0, QFrequency)
 
-  constexpr QFrequency Hz(1.0);
+constexpr QFrequency Hz(1.0);
 
-  inline namespace literals{
-    constexpr QFrequency operator"" _Hz(long double x) {
-      return QFrequency(x);
-    }
-    constexpr QFrequency operator"" _Hz(unsigned long long int x) {
-      return QFrequency(static_cast<long double>(x));
-    }
-  }
+inline namespace literals {
+constexpr QFrequency operator"" _Hz(long double x) {
+  return QFrequency(x);
 }
+constexpr QFrequency operator"" _Hz(unsigned long long int x) {
+  return QFrequency(static_cast<long double>(x));
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QFrequency.hpp
+++ b/include/okapi/api/units/QFrequency.hpp
@@ -16,15 +16,19 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 0, -1, 0, QFrequency)
+namespace okapi {
+  QUANTITY_TYPE(0, 0, -1, 0, QFrequency)
 
-constexpr QFrequency Hz(1.0);
+  constexpr QFrequency Hz(1.0);
 
-constexpr QFrequency operator"" _Hz(long double x) {
-  return QFrequency(x);
-}
-constexpr QFrequency operator"" _Hz(unsigned long long int x) {
-  return QFrequency(static_cast<long double>(x));
+  inline namespace literals{
+    constexpr QFrequency operator"" _Hz(long double x) {
+      return QFrequency(x);
+    }
+    constexpr QFrequency operator"" _Hz(unsigned long long int x) {
+      return QFrequency(static_cast<long double>(x));
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QJerk.hpp
+++ b/include/okapi/api/units/QJerk.hpp
@@ -18,6 +18,8 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 1, -3, 0, QJerk)
+namespace okapi{
+  QUANTITY_TYPE(0, 1, -3, 0, QJerk)
+}
 
 #endif

--- a/include/okapi/api/units/QJerk.hpp
+++ b/include/okapi/api/units/QJerk.hpp
@@ -18,8 +18,8 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 1, -3, 0, QJerk)
+namespace okapi {
+QUANTITY_TYPE(0, 1, -3, 0, QJerk)
 }
 
 #endif

--- a/include/okapi/api/units/QLength.hpp
+++ b/include/okapi/api/units/QLength.hpp
@@ -16,66 +16,69 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 1, 0, 0, QLength)
+namespace okapi{
+  QUANTITY_TYPE(0, 1, 0, 0, QLength)
 
-constexpr QLength meter(1.0); // SI base unit
-constexpr QLength decimeter = meter / 10;
-constexpr QLength centimeter = meter / 100;
-constexpr QLength millimeter = meter / 1000;
-constexpr QLength kilometer = 1000 * meter;
-constexpr QLength inch = 2.54 * centimeter;
-constexpr QLength foot = 12 * inch;
-constexpr QLength yard = 3 * foot;
-constexpr QLength mile = 5280 * foot;
+  constexpr QLength meter(1.0); // SI base unit
+  constexpr QLength decimeter = meter / 10;
+  constexpr QLength centimeter = meter / 100;
+  constexpr QLength millimeter = meter / 1000;
+  constexpr QLength kilometer = 1000 * meter;
+  constexpr QLength inch = 2.54 * centimeter;
+  constexpr QLength foot = 12 * inch;
+  constexpr QLength yard = 3 * foot;
+  constexpr QLength mile = 5280 * foot;
 
-// literals for length units
-constexpr QLength operator"" _mm(long double x) {
-  return static_cast<double>(x) * millimeter;
-}
-constexpr QLength operator"" _cm(long double x) {
-  return static_cast<double>(x) * centimeter;
-}
-constexpr QLength operator"" _m(long double x) {
-  return static_cast<double>(x) * meter;
-}
-constexpr QLength operator"" _km(long double x) {
-  return static_cast<double>(x) * kilometer;
-}
-constexpr QLength operator"" _mi(long double x) {
-  return static_cast<double>(x) * mile;
-}
-constexpr QLength operator"" _yd(long double x) {
-  return static_cast<double>(x) * yard;
-}
-constexpr QLength operator"" _ft(long double x) {
-  return static_cast<double>(x) * foot;
-}
-constexpr QLength operator"" _in(long double x) {
-  return static_cast<double>(x) * inch;
-}
-constexpr QLength operator"" _mm(unsigned long long int x) {
-  return static_cast<double>(x) * millimeter;
-}
-constexpr QLength operator"" _cm(unsigned long long int x) {
-  return static_cast<double>(x) * centimeter;
-}
-constexpr QLength operator"" _m(unsigned long long int x) {
-  return static_cast<double>(x) * meter;
-}
-constexpr QLength operator"" _km(unsigned long long int x) {
-  return static_cast<double>(x) * kilometer;
-}
-constexpr QLength operator"" _mi(unsigned long long int x) {
-  return static_cast<double>(x) * mile;
-}
-constexpr QLength operator"" _yd(unsigned long long int x) {
-  return static_cast<double>(x) * yard;
-}
-constexpr QLength operator"" _ft(unsigned long long int x) {
-  return static_cast<double>(x) * foot;
-}
-constexpr QLength operator"" _in(unsigned long long int x) {
-  return static_cast<double>(x) * inch;
+  inline namespace literals{
+    constexpr QLength operator"" _mm(long double x) {
+      return static_cast<double>(x) * millimeter;
+    }
+    constexpr QLength operator"" _cm(long double x) {
+      return static_cast<double>(x) * centimeter;
+    }
+    constexpr QLength operator"" _m(long double x) {
+      return static_cast<double>(x) * meter;
+    }
+    constexpr QLength operator"" _km(long double x) {
+      return static_cast<double>(x) * kilometer;
+    }
+    constexpr QLength operator"" _mi(long double x) {
+      return static_cast<double>(x) * mile;
+    }
+    constexpr QLength operator"" _yd(long double x) {
+      return static_cast<double>(x) * yard;
+    }
+    constexpr QLength operator"" _ft(long double x) {
+      return static_cast<double>(x) * foot;
+    }
+    constexpr QLength operator"" _in(long double x) {
+      return static_cast<double>(x) * inch;
+    }
+    constexpr QLength operator"" _mm(unsigned long long int x) {
+      return static_cast<double>(x) * millimeter;
+    }
+    constexpr QLength operator"" _cm(unsigned long long int x) {
+      return static_cast<double>(x) * centimeter;
+    }
+    constexpr QLength operator"" _m(unsigned long long int x) {
+      return static_cast<double>(x) * meter;
+    }
+    constexpr QLength operator"" _km(unsigned long long int x) {
+      return static_cast<double>(x) * kilometer;
+    }
+    constexpr QLength operator"" _mi(unsigned long long int x) {
+      return static_cast<double>(x) * mile;
+    }
+    constexpr QLength operator"" _yd(unsigned long long int x) {
+      return static_cast<double>(x) * yard;
+    }
+    constexpr QLength operator"" _ft(unsigned long long int x) {
+      return static_cast<double>(x) * foot;
+    }
+    constexpr QLength operator"" _in(unsigned long long int x) {
+      return static_cast<double>(x) * inch;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QLength.hpp
+++ b/include/okapi/api/units/QLength.hpp
@@ -16,69 +16,69 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 1, 0, 0, QLength)
+namespace okapi {
+QUANTITY_TYPE(0, 1, 0, 0, QLength)
 
-  constexpr QLength meter(1.0); // SI base unit
-  constexpr QLength decimeter = meter / 10;
-  constexpr QLength centimeter = meter / 100;
-  constexpr QLength millimeter = meter / 1000;
-  constexpr QLength kilometer = 1000 * meter;
-  constexpr QLength inch = 2.54 * centimeter;
-  constexpr QLength foot = 12 * inch;
-  constexpr QLength yard = 3 * foot;
-  constexpr QLength mile = 5280 * foot;
+constexpr QLength meter(1.0); // SI base unit
+constexpr QLength decimeter = meter / 10;
+constexpr QLength centimeter = meter / 100;
+constexpr QLength millimeter = meter / 1000;
+constexpr QLength kilometer = 1000 * meter;
+constexpr QLength inch = 2.54 * centimeter;
+constexpr QLength foot = 12 * inch;
+constexpr QLength yard = 3 * foot;
+constexpr QLength mile = 5280 * foot;
 
-  inline namespace literals{
-    constexpr QLength operator"" _mm(long double x) {
-      return static_cast<double>(x) * millimeter;
-    }
-    constexpr QLength operator"" _cm(long double x) {
-      return static_cast<double>(x) * centimeter;
-    }
-    constexpr QLength operator"" _m(long double x) {
-      return static_cast<double>(x) * meter;
-    }
-    constexpr QLength operator"" _km(long double x) {
-      return static_cast<double>(x) * kilometer;
-    }
-    constexpr QLength operator"" _mi(long double x) {
-      return static_cast<double>(x) * mile;
-    }
-    constexpr QLength operator"" _yd(long double x) {
-      return static_cast<double>(x) * yard;
-    }
-    constexpr QLength operator"" _ft(long double x) {
-      return static_cast<double>(x) * foot;
-    }
-    constexpr QLength operator"" _in(long double x) {
-      return static_cast<double>(x) * inch;
-    }
-    constexpr QLength operator"" _mm(unsigned long long int x) {
-      return static_cast<double>(x) * millimeter;
-    }
-    constexpr QLength operator"" _cm(unsigned long long int x) {
-      return static_cast<double>(x) * centimeter;
-    }
-    constexpr QLength operator"" _m(unsigned long long int x) {
-      return static_cast<double>(x) * meter;
-    }
-    constexpr QLength operator"" _km(unsigned long long int x) {
-      return static_cast<double>(x) * kilometer;
-    }
-    constexpr QLength operator"" _mi(unsigned long long int x) {
-      return static_cast<double>(x) * mile;
-    }
-    constexpr QLength operator"" _yd(unsigned long long int x) {
-      return static_cast<double>(x) * yard;
-    }
-    constexpr QLength operator"" _ft(unsigned long long int x) {
-      return static_cast<double>(x) * foot;
-    }
-    constexpr QLength operator"" _in(unsigned long long int x) {
-      return static_cast<double>(x) * inch;
-    }
-  }
+inline namespace literals {
+constexpr QLength operator"" _mm(long double x) {
+  return static_cast<double>(x) * millimeter;
 }
+constexpr QLength operator"" _cm(long double x) {
+  return static_cast<double>(x) * centimeter;
+}
+constexpr QLength operator"" _m(long double x) {
+  return static_cast<double>(x) * meter;
+}
+constexpr QLength operator"" _km(long double x) {
+  return static_cast<double>(x) * kilometer;
+}
+constexpr QLength operator"" _mi(long double x) {
+  return static_cast<double>(x) * mile;
+}
+constexpr QLength operator"" _yd(long double x) {
+  return static_cast<double>(x) * yard;
+}
+constexpr QLength operator"" _ft(long double x) {
+  return static_cast<double>(x) * foot;
+}
+constexpr QLength operator"" _in(long double x) {
+  return static_cast<double>(x) * inch;
+}
+constexpr QLength operator"" _mm(unsigned long long int x) {
+  return static_cast<double>(x) * millimeter;
+}
+constexpr QLength operator"" _cm(unsigned long long int x) {
+  return static_cast<double>(x) * centimeter;
+}
+constexpr QLength operator"" _m(unsigned long long int x) {
+  return static_cast<double>(x) * meter;
+}
+constexpr QLength operator"" _km(unsigned long long int x) {
+  return static_cast<double>(x) * kilometer;
+}
+constexpr QLength operator"" _mi(unsigned long long int x) {
+  return static_cast<double>(x) * mile;
+}
+constexpr QLength operator"" _yd(unsigned long long int x) {
+  return static_cast<double>(x) * yard;
+}
+constexpr QLength operator"" _ft(unsigned long long int x) {
+  return static_cast<double>(x) * foot;
+}
+constexpr QLength operator"" _in(unsigned long long int x) {
+  return static_cast<double>(x) * inch;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QMass.hpp
+++ b/include/okapi/api/units/QMass.hpp
@@ -16,51 +16,54 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(1, 0, 0, 0, QMass)
+namespace okapi{
+  QUANTITY_TYPE(1, 0, 0, 0, QMass)
 
-constexpr QMass kg(1.0); // SI base unit
-constexpr QMass gramme = 0.001 * kg;
-constexpr QMass tonne = 1000 * kg;
-constexpr QMass ounce = 0.028349523125 * kg;
-constexpr QMass pound = 16 * ounce;
-constexpr QMass stone = 14 * pound;
+  constexpr QMass kg(1.0); // SI base unit
+  constexpr QMass gramme = 0.001 * kg;
+  constexpr QMass tonne = 1000 * kg;
+  constexpr QMass ounce = 0.028349523125 * kg;
+  constexpr QMass pound = 16 * ounce;
+  constexpr QMass stone = 14 * pound;
 
-// literals for mass units
-constexpr QMass operator"" _kg(long double x) {
-  return QMass(x);
-}
-constexpr QMass operator"" _g(long double x) {
-  return static_cast<double>(x) * gramme;
-}
-constexpr QMass operator"" _t(long double x) {
-  return static_cast<double>(x) * tonne;
-}
-constexpr QMass operator"" _oz(long double x) {
-  return static_cast<double>(x) * ounce;
-}
-constexpr QMass operator"" _lb(long double x) {
-  return static_cast<double>(x) * pound;
-}
-constexpr QMass operator"" _st(long double x) {
-  return static_cast<double>(x) * stone;
-}
-constexpr QMass operator"" _kg(unsigned long long int x) {
-  return QMass(static_cast<double>(x));
-}
-constexpr QMass operator"" _g(unsigned long long int x) {
-  return static_cast<double>(x) * gramme;
-}
-constexpr QMass operator"" _t(unsigned long long int x) {
-  return static_cast<double>(x) * tonne;
-}
-constexpr QMass operator"" _oz(unsigned long long int x) {
-  return static_cast<double>(x) * ounce;
-}
-constexpr QMass operator"" _lb(unsigned long long int x) {
-  return static_cast<double>(x) * pound;
-}
-constexpr QMass operator"" _st(unsigned long long int x) {
-  return static_cast<double>(x) * stone;
+  inline namespace okapi{
+    constexpr QMass operator"" _kg(long double x) {
+      return QMass(x);
+    }
+    constexpr QMass operator"" _g(long double x) {
+      return static_cast<double>(x) * gramme;
+    }
+    constexpr QMass operator"" _t(long double x) {
+      return static_cast<double>(x) * tonne;
+    }
+    constexpr QMass operator"" _oz(long double x) {
+      return static_cast<double>(x) * ounce;
+    }
+    constexpr QMass operator"" _lb(long double x) {
+      return static_cast<double>(x) * pound;
+    }
+    constexpr QMass operator"" _st(long double x) {
+      return static_cast<double>(x) * stone;
+    }
+    constexpr QMass operator"" _kg(unsigned long long int x) {
+      return QMass(static_cast<double>(x));
+    }
+    constexpr QMass operator"" _g(unsigned long long int x) {
+      return static_cast<double>(x) * gramme;
+    }
+    constexpr QMass operator"" _t(unsigned long long int x) {
+      return static_cast<double>(x) * tonne;
+    }
+    constexpr QMass operator"" _oz(unsigned long long int x) {
+      return static_cast<double>(x) * ounce;
+    }
+    constexpr QMass operator"" _lb(unsigned long long int x) {
+      return static_cast<double>(x) * pound;
+    }
+    constexpr QMass operator"" _st(unsigned long long int x) {
+      return static_cast<double>(x) * stone;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QMass.hpp
+++ b/include/okapi/api/units/QMass.hpp
@@ -16,54 +16,54 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(1, 0, 0, 0, QMass)
+namespace okapi {
+QUANTITY_TYPE(1, 0, 0, 0, QMass)
 
-  constexpr QMass kg(1.0); // SI base unit
-  constexpr QMass gramme = 0.001 * kg;
-  constexpr QMass tonne = 1000 * kg;
-  constexpr QMass ounce = 0.028349523125 * kg;
-  constexpr QMass pound = 16 * ounce;
-  constexpr QMass stone = 14 * pound;
+constexpr QMass kg(1.0); // SI base unit
+constexpr QMass gramme = 0.001 * kg;
+constexpr QMass tonne = 1000 * kg;
+constexpr QMass ounce = 0.028349523125 * kg;
+constexpr QMass pound = 16 * ounce;
+constexpr QMass stone = 14 * pound;
 
-  inline namespace okapi{
-    constexpr QMass operator"" _kg(long double x) {
-      return QMass(x);
-    }
-    constexpr QMass operator"" _g(long double x) {
-      return static_cast<double>(x) * gramme;
-    }
-    constexpr QMass operator"" _t(long double x) {
-      return static_cast<double>(x) * tonne;
-    }
-    constexpr QMass operator"" _oz(long double x) {
-      return static_cast<double>(x) * ounce;
-    }
-    constexpr QMass operator"" _lb(long double x) {
-      return static_cast<double>(x) * pound;
-    }
-    constexpr QMass operator"" _st(long double x) {
-      return static_cast<double>(x) * stone;
-    }
-    constexpr QMass operator"" _kg(unsigned long long int x) {
-      return QMass(static_cast<double>(x));
-    }
-    constexpr QMass operator"" _g(unsigned long long int x) {
-      return static_cast<double>(x) * gramme;
-    }
-    constexpr QMass operator"" _t(unsigned long long int x) {
-      return static_cast<double>(x) * tonne;
-    }
-    constexpr QMass operator"" _oz(unsigned long long int x) {
-      return static_cast<double>(x) * ounce;
-    }
-    constexpr QMass operator"" _lb(unsigned long long int x) {
-      return static_cast<double>(x) * pound;
-    }
-    constexpr QMass operator"" _st(unsigned long long int x) {
-      return static_cast<double>(x) * stone;
-    }
-  }
+inline namespace okapi {
+constexpr QMass operator"" _kg(long double x) {
+  return QMass(x);
 }
+constexpr QMass operator"" _g(long double x) {
+  return static_cast<double>(x) * gramme;
+}
+constexpr QMass operator"" _t(long double x) {
+  return static_cast<double>(x) * tonne;
+}
+constexpr QMass operator"" _oz(long double x) {
+  return static_cast<double>(x) * ounce;
+}
+constexpr QMass operator"" _lb(long double x) {
+  return static_cast<double>(x) * pound;
+}
+constexpr QMass operator"" _st(long double x) {
+  return static_cast<double>(x) * stone;
+}
+constexpr QMass operator"" _kg(unsigned long long int x) {
+  return QMass(static_cast<double>(x));
+}
+constexpr QMass operator"" _g(unsigned long long int x) {
+  return static_cast<double>(x) * gramme;
+}
+constexpr QMass operator"" _t(unsigned long long int x) {
+  return static_cast<double>(x) * tonne;
+}
+constexpr QMass operator"" _oz(unsigned long long int x) {
+  return static_cast<double>(x) * ounce;
+}
+constexpr QMass operator"" _lb(unsigned long long int x) {
+  return static_cast<double>(x) * pound;
+}
+constexpr QMass operator"" _st(unsigned long long int x) {
+  return static_cast<double>(x) * stone;
+}
+} // namespace okapi
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QPressure.hpp
+++ b/include/okapi/api/units/QPressure.hpp
@@ -19,29 +19,33 @@
 #include "okapi/api/units/QMass.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(1, -1, -2, 0, QPressure)
+namespace okapi{
+  QUANTITY_TYPE(1, -1, -2, 0, QPressure)
 
-constexpr QPressure pascal(1.0);
-constexpr QPressure bar = 100000 * pascal;
-constexpr QPressure psi = pound * G / inch2;
+  constexpr QPressure pascal(1.0);
+  constexpr QPressure bar = 100000 * pascal;
+  constexpr QPressure psi = pound * G / inch2;
 
-constexpr QPressure operator"" _Pa(long double x) {
-  return QPressure(x);
-}
-constexpr QPressure operator"" _Pa(unsigned long long int x) {
-  return QPressure(static_cast<double>(x));
-}
-constexpr QPressure operator"" _bar(long double x) {
-  return static_cast<double>(x) * bar;
-}
-constexpr QPressure operator"" _bar(unsigned long long int x) {
-  return static_cast<double>(x) * bar;
-}
-constexpr QPressure operator"" _psi(long double x) {
-  return static_cast<double>(x) * psi;
-}
-constexpr QPressure operator"" _psi(unsigned long long int x) {
-  return static_cast<double>(x) * psi;
+  inline namespace literals{
+    constexpr QPressure operator"" _Pa(long double x) {
+      return QPressure(x);
+    }
+    constexpr QPressure operator"" _Pa(unsigned long long int x) {
+      return QPressure(static_cast<double>(x));
+    }
+    constexpr QPressure operator"" _bar(long double x) {
+      return static_cast<double>(x) * bar;
+    }
+    constexpr QPressure operator"" _bar(unsigned long long int x) {
+      return static_cast<double>(x) * bar;
+    }
+    constexpr QPressure operator"" _psi(long double x) {
+      return static_cast<double>(x) * psi;
+    }
+    constexpr QPressure operator"" _psi(unsigned long long int x) {
+      return static_cast<double>(x) * psi;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QPressure.hpp
+++ b/include/okapi/api/units/QPressure.hpp
@@ -19,33 +19,33 @@
 #include "okapi/api/units/QMass.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(1, -1, -2, 0, QPressure)
+namespace okapi {
+QUANTITY_TYPE(1, -1, -2, 0, QPressure)
 
-  constexpr QPressure pascal(1.0);
-  constexpr QPressure bar = 100000 * pascal;
-  constexpr QPressure psi = pound * G / inch2;
+constexpr QPressure pascal(1.0);
+constexpr QPressure bar = 100000 * pascal;
+constexpr QPressure psi = pound * G / inch2;
 
-  inline namespace literals{
-    constexpr QPressure operator"" _Pa(long double x) {
-      return QPressure(x);
-    }
-    constexpr QPressure operator"" _Pa(unsigned long long int x) {
-      return QPressure(static_cast<double>(x));
-    }
-    constexpr QPressure operator"" _bar(long double x) {
-      return static_cast<double>(x) * bar;
-    }
-    constexpr QPressure operator"" _bar(unsigned long long int x) {
-      return static_cast<double>(x) * bar;
-    }
-    constexpr QPressure operator"" _psi(long double x) {
-      return static_cast<double>(x) * psi;
-    }
-    constexpr QPressure operator"" _psi(unsigned long long int x) {
-      return static_cast<double>(x) * psi;
-    }
-  }
+inline namespace literals {
+constexpr QPressure operator"" _Pa(long double x) {
+  return QPressure(x);
 }
+constexpr QPressure operator"" _Pa(unsigned long long int x) {
+  return QPressure(static_cast<double>(x));
+}
+constexpr QPressure operator"" _bar(long double x) {
+  return static_cast<double>(x) * bar;
+}
+constexpr QPressure operator"" _bar(unsigned long long int x) {
+  return static_cast<double>(x) * bar;
+}
+constexpr QPressure operator"" _psi(long double x) {
+  return static_cast<double>(x) * psi;
+}
+constexpr QPressure operator"" _psi(unsigned long long int x) {
+  return static_cast<double>(x) * psi;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QSpeed.hpp
+++ b/include/okapi/api/units/QSpeed.hpp
@@ -18,29 +18,33 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 1, -1, 0, QSpeed)
+namespace okapi{
+  QUANTITY_TYPE(0, 1, -1, 0, QSpeed)
 
-constexpr QSpeed mps = meter / second;
-constexpr QSpeed miph = mile / hour;
-constexpr QSpeed kmph = kilometer / hour;
+  constexpr QSpeed mps = meter / second;
+  constexpr QSpeed miph = mile / hour;
+  constexpr QSpeed kmph = kilometer / hour;
 
-constexpr QSpeed operator"" _mps(long double x) {
-  return static_cast<double>(x) * mps;
-}
-constexpr QSpeed operator"" _miph(long double x) {
-  return static_cast<double>(x) * mile / hour;
-}
-constexpr QSpeed operator"" _kmph(long double x) {
-  return static_cast<double>(x) * kilometer / hour;
-}
-constexpr QSpeed operator"" _mps(unsigned long long int x) {
-  return static_cast<double>(x) * mps;
-}
-constexpr QSpeed operator"" _miph(unsigned long long int x) {
-  return static_cast<double>(x) * mile / hour;
-}
-constexpr QSpeed operator"" _kmph(unsigned long long int x) {
-  return static_cast<double>(x) * kilometer / hour;
+  inline namespace literals{
+    constexpr QSpeed operator"" _mps(long double x) {
+      return static_cast<double>(x) * mps;
+    }
+    constexpr QSpeed operator"" _miph(long double x) {
+      return static_cast<double>(x) * mile / hour;
+    }
+    constexpr QSpeed operator"" _kmph(long double x) {
+      return static_cast<double>(x) * kilometer / hour;
+    }
+    constexpr QSpeed operator"" _mps(unsigned long long int x) {
+      return static_cast<double>(x) * mps;
+    }
+    constexpr QSpeed operator"" _miph(unsigned long long int x) {
+      return static_cast<double>(x) * mile / hour;
+    }
+    constexpr QSpeed operator"" _kmph(unsigned long long int x) {
+      return static_cast<double>(x) * kilometer / hour;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QSpeed.hpp
+++ b/include/okapi/api/units/QSpeed.hpp
@@ -18,33 +18,33 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 1, -1, 0, QSpeed)
+namespace okapi {
+QUANTITY_TYPE(0, 1, -1, 0, QSpeed)
 
-  constexpr QSpeed mps = meter / second;
-  constexpr QSpeed miph = mile / hour;
-  constexpr QSpeed kmph = kilometer / hour;
+constexpr QSpeed mps = meter / second;
+constexpr QSpeed miph = mile / hour;
+constexpr QSpeed kmph = kilometer / hour;
 
-  inline namespace literals{
-    constexpr QSpeed operator"" _mps(long double x) {
-      return static_cast<double>(x) * mps;
-    }
-    constexpr QSpeed operator"" _miph(long double x) {
-      return static_cast<double>(x) * mile / hour;
-    }
-    constexpr QSpeed operator"" _kmph(long double x) {
-      return static_cast<double>(x) * kilometer / hour;
-    }
-    constexpr QSpeed operator"" _mps(unsigned long long int x) {
-      return static_cast<double>(x) * mps;
-    }
-    constexpr QSpeed operator"" _miph(unsigned long long int x) {
-      return static_cast<double>(x) * mile / hour;
-    }
-    constexpr QSpeed operator"" _kmph(unsigned long long int x) {
-      return static_cast<double>(x) * kilometer / hour;
-    }
-  }
+inline namespace literals {
+constexpr QSpeed operator"" _mps(long double x) {
+  return static_cast<double>(x) * mps;
 }
+constexpr QSpeed operator"" _miph(long double x) {
+  return static_cast<double>(x) * mile / hour;
+}
+constexpr QSpeed operator"" _kmph(long double x) {
+  return static_cast<double>(x) * kilometer / hour;
+}
+constexpr QSpeed operator"" _mps(unsigned long long int x) {
+  return static_cast<double>(x) * mps;
+}
+constexpr QSpeed operator"" _miph(unsigned long long int x) {
+  return static_cast<double>(x) * mile / hour;
+}
+constexpr QSpeed operator"" _kmph(unsigned long long int x) {
+  return static_cast<double>(x) * kilometer / hour;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QTime.hpp
+++ b/include/okapi/api/units/QTime.hpp
@@ -16,43 +16,47 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 0, 1, 0, QTime)
+namespace okapi{
+  QUANTITY_TYPE(0, 0, 1, 0, QTime)
 
-constexpr QTime second(1.0); // SI base unit
-constexpr QTime millisecond = second / 1000;
-constexpr QTime minute = 60 * second;
-constexpr QTime hour = 60 * minute;
-constexpr QTime day = 24 * hour;
+  constexpr QTime second(1.0); // SI base unit
+  constexpr QTime millisecond = second / 1000;
+  constexpr QTime minute = 60 * second;
+  constexpr QTime hour = 60 * minute;
+  constexpr QTime day = 24 * hour;
 
-constexpr QTime operator"" _s(long double x) {
-  return QTime(x);
-}
-constexpr QTime operator"" _ms(long double x) {
-  return static_cast<double>(x) * millisecond;
-}
-constexpr QTime operator"" _min(long double x) {
-  return static_cast<double>(x) * minute;
-}
-constexpr QTime operator"" _h(long double x) {
-  return static_cast<double>(x) * hour;
-}
-constexpr QTime operator"" _day(long double x) {
-  return static_cast<double>(x) * day;
-}
-constexpr QTime operator"" _s(unsigned long long int x) {
-  return QTime(static_cast<double>(x));
-}
-constexpr QTime operator"" _ms(unsigned long long int x) {
-  return static_cast<double>(x) * millisecond;
-}
-constexpr QTime operator"" _min(unsigned long long int x) {
-  return static_cast<double>(x) * minute;
-}
-constexpr QTime operator"" _h(unsigned long long int x) {
-  return static_cast<double>(x) * hour;
-}
-constexpr QTime operator"" _day(unsigned long long int x) {
-  return static_cast<double>(x) * day;
+  inline namespace literals{
+    constexpr QTime operator"" _s(long double x) {
+      return QTime(x);
+    }
+    constexpr QTime operator"" _ms(long double x) {
+      return static_cast<double>(x) * millisecond;
+    }
+    constexpr QTime operator"" _min(long double x) {
+      return static_cast<double>(x) * minute;
+    }
+    constexpr QTime operator"" _h(long double x) {
+      return static_cast<double>(x) * hour;
+    }
+    constexpr QTime operator"" _day(long double x) {
+      return static_cast<double>(x) * day;
+    }
+    constexpr QTime operator"" _s(unsigned long long int x) {
+      return QTime(static_cast<double>(x));
+    }
+    constexpr QTime operator"" _ms(unsigned long long int x) {
+      return static_cast<double>(x) * millisecond;
+    }
+    constexpr QTime operator"" _min(unsigned long long int x) {
+      return static_cast<double>(x) * minute;
+    }
+    constexpr QTime operator"" _h(unsigned long long int x) {
+      return static_cast<double>(x) * hour;
+    }
+    constexpr QTime operator"" _day(unsigned long long int x) {
+      return static_cast<double>(x) * day;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QTime.hpp
+++ b/include/okapi/api/units/QTime.hpp
@@ -16,47 +16,47 @@
 
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 0, 1, 0, QTime)
+namespace okapi {
+QUANTITY_TYPE(0, 0, 1, 0, QTime)
 
-  constexpr QTime second(1.0); // SI base unit
-  constexpr QTime millisecond = second / 1000;
-  constexpr QTime minute = 60 * second;
-  constexpr QTime hour = 60 * minute;
-  constexpr QTime day = 24 * hour;
+constexpr QTime second(1.0); // SI base unit
+constexpr QTime millisecond = second / 1000;
+constexpr QTime minute = 60 * second;
+constexpr QTime hour = 60 * minute;
+constexpr QTime day = 24 * hour;
 
-  inline namespace literals{
-    constexpr QTime operator"" _s(long double x) {
-      return QTime(x);
-    }
-    constexpr QTime operator"" _ms(long double x) {
-      return static_cast<double>(x) * millisecond;
-    }
-    constexpr QTime operator"" _min(long double x) {
-      return static_cast<double>(x) * minute;
-    }
-    constexpr QTime operator"" _h(long double x) {
-      return static_cast<double>(x) * hour;
-    }
-    constexpr QTime operator"" _day(long double x) {
-      return static_cast<double>(x) * day;
-    }
-    constexpr QTime operator"" _s(unsigned long long int x) {
-      return QTime(static_cast<double>(x));
-    }
-    constexpr QTime operator"" _ms(unsigned long long int x) {
-      return static_cast<double>(x) * millisecond;
-    }
-    constexpr QTime operator"" _min(unsigned long long int x) {
-      return static_cast<double>(x) * minute;
-    }
-    constexpr QTime operator"" _h(unsigned long long int x) {
-      return static_cast<double>(x) * hour;
-    }
-    constexpr QTime operator"" _day(unsigned long long int x) {
-      return static_cast<double>(x) * day;
-    }
-  }
+inline namespace literals {
+constexpr QTime operator"" _s(long double x) {
+  return QTime(x);
 }
+constexpr QTime operator"" _ms(long double x) {
+  return static_cast<double>(x) * millisecond;
+}
+constexpr QTime operator"" _min(long double x) {
+  return static_cast<double>(x) * minute;
+}
+constexpr QTime operator"" _h(long double x) {
+  return static_cast<double>(x) * hour;
+}
+constexpr QTime operator"" _day(long double x) {
+  return static_cast<double>(x) * day;
+}
+constexpr QTime operator"" _s(unsigned long long int x) {
+  return QTime(static_cast<double>(x));
+}
+constexpr QTime operator"" _ms(unsigned long long int x) {
+  return static_cast<double>(x) * millisecond;
+}
+constexpr QTime operator"" _min(unsigned long long int x) {
+  return static_cast<double>(x) * minute;
+}
+constexpr QTime operator"" _h(unsigned long long int x) {
+  return static_cast<double>(x) * hour;
+}
+constexpr QTime operator"" _day(unsigned long long int x) {
+  return static_cast<double>(x) * day;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QTorque.hpp
+++ b/include/okapi/api/units/QTorque.hpp
@@ -18,29 +18,33 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(1, 2, -2, 0, QTorque)
+namespace okapi{
+  QUANTITY_TYPE(1, 2, -2, 0, QTorque)
 
-constexpr QTorque newtonMeter = newton * meter;
-constexpr QTorque footPound = 1.355817948 * newtonMeter;
-constexpr QTorque inchPound = 0.083333333 * footPound;
+  constexpr QTorque newtonMeter = newton * meter;
+  constexpr QTorque footPound = 1.355817948 * newtonMeter;
+  constexpr QTorque inchPound = 0.083333333 * footPound;
 
-constexpr QTorque operator"" _nM(long double x) {
-  return QTorque(x);
-}
-constexpr QTorque operator"" _nM(unsigned long long int x) {
-  return QTorque(static_cast<double>(x));
-}
-constexpr QTorque operator"" _inLb(long double x) {
-  return static_cast<double>(x) * inchPound;
-}
-constexpr QTorque operator"" _inLb(unsigned long long int x) {
-  return static_cast<double>(x) * inchPound;
-}
-constexpr QTorque operator"" _ftLb(long double x) {
-  return static_cast<double>(x) * footPound;
-}
-constexpr QTorque operator"" _ftLb(unsigned long long int x) {
-  return static_cast<double>(x) * footPound;
+  inline namespace literals{
+    constexpr QTorque operator"" _nM(long double x) {
+      return QTorque(x);
+    }
+    constexpr QTorque operator"" _nM(unsigned long long int x) {
+      return QTorque(static_cast<double>(x));
+    }
+    constexpr QTorque operator"" _inLb(long double x) {
+      return static_cast<double>(x) * inchPound;
+    }
+    constexpr QTorque operator"" _inLb(unsigned long long int x) {
+      return static_cast<double>(x) * inchPound;
+    }
+    constexpr QTorque operator"" _ftLb(long double x) {
+      return static_cast<double>(x) * footPound;
+    }
+    constexpr QTorque operator"" _ftLb(unsigned long long int x) {
+      return static_cast<double>(x) * footPound;
+    }
+  }
 }
 
 #endif

--- a/include/okapi/api/units/QTorque.hpp
+++ b/include/okapi/api/units/QTorque.hpp
@@ -18,33 +18,33 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(1, 2, -2, 0, QTorque)
+namespace okapi {
+QUANTITY_TYPE(1, 2, -2, 0, QTorque)
 
-  constexpr QTorque newtonMeter = newton * meter;
-  constexpr QTorque footPound = 1.355817948 * newtonMeter;
-  constexpr QTorque inchPound = 0.083333333 * footPound;
+constexpr QTorque newtonMeter = newton * meter;
+constexpr QTorque footPound = 1.355817948 * newtonMeter;
+constexpr QTorque inchPound = 0.083333333 * footPound;
 
-  inline namespace literals{
-    constexpr QTorque operator"" _nM(long double x) {
-      return QTorque(x);
-    }
-    constexpr QTorque operator"" _nM(unsigned long long int x) {
-      return QTorque(static_cast<double>(x));
-    }
-    constexpr QTorque operator"" _inLb(long double x) {
-      return static_cast<double>(x) * inchPound;
-    }
-    constexpr QTorque operator"" _inLb(unsigned long long int x) {
-      return static_cast<double>(x) * inchPound;
-    }
-    constexpr QTorque operator"" _ftLb(long double x) {
-      return static_cast<double>(x) * footPound;
-    }
-    constexpr QTorque operator"" _ftLb(unsigned long long int x) {
-      return static_cast<double>(x) * footPound;
-    }
-  }
+inline namespace literals {
+constexpr QTorque operator"" _nM(long double x) {
+  return QTorque(x);
 }
+constexpr QTorque operator"" _nM(unsigned long long int x) {
+  return QTorque(static_cast<double>(x));
+}
+constexpr QTorque operator"" _inLb(long double x) {
+  return static_cast<double>(x) * inchPound;
+}
+constexpr QTorque operator"" _inLb(unsigned long long int x) {
+  return static_cast<double>(x) * inchPound;
+}
+constexpr QTorque operator"" _ftLb(long double x) {
+  return static_cast<double>(x) * footPound;
+}
+constexpr QTorque operator"" _ftLb(unsigned long long int x) {
+  return static_cast<double>(x) * footPound;
+}
+} // namespace literals
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/QVolume.hpp
+++ b/include/okapi/api/units/QVolume.hpp
@@ -18,16 +18,18 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-QUANTITY_TYPE(0, 3, 0, 0, QVolume)
+namespace okapi{
+  QUANTITY_TYPE(0, 3, 0, 0, QVolume)
 
-constexpr QVolume kilometer3 = kilometer2 * kilometer;
-constexpr QVolume meter3 = meter2 * meter;
-constexpr QVolume decimeter3 = decimeter2 * decimeter;
-constexpr QVolume centimeter3 = centimeter2 * centimeter;
-constexpr QVolume millimeter3 = millimeter2 * millimeter;
-constexpr QVolume inch3 = inch2 * inch;
-constexpr QVolume foot3 = foot2 * foot;
-constexpr QVolume mile3 = mile2 * mile;
-constexpr QVolume litre = decimeter3;
+  constexpr QVolume kilometer3 = kilometer2 * kilometer;
+  constexpr QVolume meter3 = meter2 * meter;
+  constexpr QVolume decimeter3 = decimeter2 * decimeter;
+  constexpr QVolume centimeter3 = centimeter2 * centimeter;
+  constexpr QVolume millimeter3 = millimeter2 * millimeter;
+  constexpr QVolume inch3 = inch2 * inch;
+  constexpr QVolume foot3 = foot2 * foot;
+  constexpr QVolume mile3 = mile2 * mile;
+  constexpr QVolume litre = decimeter3;
+}
 
 #endif

--- a/include/okapi/api/units/QVolume.hpp
+++ b/include/okapi/api/units/QVolume.hpp
@@ -18,18 +18,18 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/RQuantity.hpp"
 
-namespace okapi{
-  QUANTITY_TYPE(0, 3, 0, 0, QVolume)
+namespace okapi {
+QUANTITY_TYPE(0, 3, 0, 0, QVolume)
 
-  constexpr QVolume kilometer3 = kilometer2 * kilometer;
-  constexpr QVolume meter3 = meter2 * meter;
-  constexpr QVolume decimeter3 = decimeter2 * decimeter;
-  constexpr QVolume centimeter3 = centimeter2 * centimeter;
-  constexpr QVolume millimeter3 = millimeter2 * millimeter;
-  constexpr QVolume inch3 = inch2 * inch;
-  constexpr QVolume foot3 = foot2 * foot;
-  constexpr QVolume mile3 = mile2 * mile;
-  constexpr QVolume litre = decimeter3;
-}
+constexpr QVolume kilometer3 = kilometer2 * kilometer;
+constexpr QVolume meter3 = meter2 * meter;
+constexpr QVolume decimeter3 = decimeter2 * decimeter;
+constexpr QVolume centimeter3 = centimeter2 * centimeter;
+constexpr QVolume millimeter3 = millimeter2 * millimeter;
+constexpr QVolume inch3 = inch2 * inch;
+constexpr QVolume foot3 = foot2 * foot;
+constexpr QVolume mile3 = mile2 * mile;
+constexpr QVolume litre = decimeter3;
+} // namespace okapi
 
 #endif

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -16,42 +16,43 @@
 
 #include <ratio>
 
-template <typename MassDim, typename LengthDim, typename TimeDim, typename AngleDim>
-class RQuantity {
+namespace okapi{
+  template <typename MassDim, typename LengthDim, typename TimeDim, typename AngleDim>
+  class RQuantity {
   public:
-  explicit constexpr RQuantity() : value(0.0) {
-  }
+    explicit constexpr RQuantity() : value(0.0) {
+    }
 
-  explicit constexpr RQuantity(double val) : value(val) {
-  }
+    explicit constexpr RQuantity(double val) : value(val) {
+    }
 
-  explicit constexpr RQuantity(long double val) : value(static_cast<double>(val)) {
-  }
+    explicit constexpr RQuantity(long double val) : value(static_cast<double>(val)) {
+    }
 
-  // The intrinsic operations for a quantity with a unit is addition and subtraction
-  constexpr RQuantity const &operator+=(const RQuantity &rhs) {
-    value += rhs.value;
-    return *this;
-  }
+    // The intrinsic operations for a quantity with a unit is addition and subtraction
+    constexpr RQuantity const &operator+=(const RQuantity &rhs) {
+      value += rhs.value;
+      return *this;
+    }
 
-  constexpr RQuantity const &operator-=(const RQuantity &rhs) {
-    value -= rhs.value;
-    return *this;
-  }
+    constexpr RQuantity const &operator-=(const RQuantity &rhs) {
+      value -= rhs.value;
+      return *this;
+    }
 
-  // Returns the value of the quantity in multiples of the specified unit
-  constexpr double convert(const RQuantity &rhs) const {
-    return value / rhs.value;
-  }
+    // Returns the value of the quantity in multiples of the specified unit
+    constexpr double convert(const RQuantity &rhs) const {
+      return value / rhs.value;
+    }
 
-  // returns the raw value of the quantity (should not be used)
-  constexpr double getValue() const {
-    return value;
-  }
+    // returns the raw value of the quantity (should not be used)
+    constexpr double getValue() const {
+      return value;
+    }
 
   private:
-  double value;
-};
+    double value;
+  };
 
 // Predefined (physical unit) quantity types:
 // ------------------------------------------
@@ -60,86 +61,89 @@ class RQuantity {
     name;
 
 // Unitless
-QUANTITY_TYPE(0, 0, 0, 0, Number)
+  QUANTITY_TYPE(0, 0, 0, 0, Number)
 
 // Standard arithmetic operators:
 // ------------------------------
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> operator+(const RQuantity<M, L, T, A> &lhs,
-                                          const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, A>(lhs.getValue() + rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> operator-(const RQuantity<M, L, T, A> &lhs,
-                                          const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, A>(lhs.getValue() - rhs.getValue());
-}
-template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
-          typename A2>
-constexpr RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
-                    std::ratio_add<A1, A2>>
-operator*(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
-  return RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
-                   std::ratio_add<A1, A2>>(lhs.getValue() * rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> operator*(const double &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, A>(lhs * rhs.getValue());
-}
-template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
-          typename A2>
-constexpr RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
-                    std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>
-operator/(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
-  return RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
-                   std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>(lhs.getValue() /
-                                                                             rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
-                    std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>
-operator/(double x, const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
-                   std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>(
-    x / rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> operator/(const RQuantity<M, L, T, A> &rhs, double x) {
-  return RQuantity<M, L, T, A>(rhs.getValue() / x);
-}
+  template <typename M, typename L, typename T, typename A>
+  constexpr RQuantity<M, L, T, A> operator+(const RQuantity<M, L, T, A> &lhs,
+                                            const RQuantity<M, L, T, A> &rhs) {
+    return RQuantity<M, L, T, A>(lhs.getValue() + rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr RQuantity<M, L, T, A> operator-(const RQuantity<M, L, T, A> &lhs,
+                                            const RQuantity<M, L, T, A> &rhs) {
+    return RQuantity<M, L, T, A>(lhs.getValue() - rhs.getValue());
+  }
+  template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
+    typename A2>
+  constexpr RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
+    std::ratio_add<A1, A2>>
+  operator*(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
+    return RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
+      std::ratio_add<A1, A2>>(lhs.getValue() * rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr RQuantity<M, L, T, A> operator*(const double &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return RQuantity<M, L, T, A>(lhs * rhs.getValue());
+  }
+  template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
+    typename A2>
+  constexpr RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
+    std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>
+  operator/(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
+    return RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
+      std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>(lhs.getValue() /
+                                                                rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
+    std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>
+  operator/(double x, const RQuantity<M, L, T, A> &rhs) {
+    return RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
+      std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>(
+      x / rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr RQuantity<M, L, T, A> operator/(const RQuantity<M, L, T, A> &rhs, double x) {
+    return RQuantity<M, L, T, A>(rhs.getValue() / x);
+  }
 
 // Comparison operators for quantities:
 // ------------------------------------
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator==(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() == rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator!=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() != rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator<=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() <= rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator>=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() >= rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator<(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() < rhs.getValue());
-}
-template <typename M, typename L, typename T, typename A>
-constexpr bool operator>(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-  return (lhs.getValue() > rhs.getValue());
-}
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator==(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() == rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator!=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() != rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator<=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() <= rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator>=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() >= rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator<(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() < rhs.getValue());
+  }
+  template <typename M, typename L, typename T, typename A>
+  constexpr bool operator>(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+    return (lhs.getValue() > rhs.getValue());
+  }
 
-constexpr long double operator"" _pi(long double x) {
-  return static_cast<double>(x) * 3.1415926535897932384626433832795;
-}
-constexpr long double operator"" _pi(unsigned long long int x) {
-  return static_cast<double>(x) * 3.1415926535897932384626433832795;
+  inline namespace literals{
+    constexpr long double operator"" _pi(long double x) {
+      return static_cast<double>(x) * 3.1415926535897932384626433832795;
+    }
+    constexpr long double operator"" _pi(unsigned long long int x) {
+      return static_cast<double>(x) * 3.1415926535897932384626433832795;
+    }
+  }
 }
 
 // Conversion macro, which utilizes the string literals

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -16,43 +16,43 @@
 
 #include <ratio>
 
-namespace okapi{
-  template <typename MassDim, typename LengthDim, typename TimeDim, typename AngleDim>
-  class RQuantity {
+namespace okapi {
+template <typename MassDim, typename LengthDim, typename TimeDim, typename AngleDim>
+class RQuantity {
   public:
-    explicit constexpr RQuantity() : value(0.0) {
-    }
+  explicit constexpr RQuantity() : value(0.0) {
+  }
 
-    explicit constexpr RQuantity(double val) : value(val) {
-    }
+  explicit constexpr RQuantity(double val) : value(val) {
+  }
 
-    explicit constexpr RQuantity(long double val) : value(static_cast<double>(val)) {
-    }
+  explicit constexpr RQuantity(long double val) : value(static_cast<double>(val)) {
+  }
 
-    // The intrinsic operations for a quantity with a unit is addition and subtraction
-    constexpr RQuantity const &operator+=(const RQuantity &rhs) {
-      value += rhs.value;
-      return *this;
-    }
+  // The intrinsic operations for a quantity with a unit is addition and subtraction
+  constexpr RQuantity const &operator+=(const RQuantity &rhs) {
+    value += rhs.value;
+    return *this;
+  }
 
-    constexpr RQuantity const &operator-=(const RQuantity &rhs) {
-      value -= rhs.value;
-      return *this;
-    }
+  constexpr RQuantity const &operator-=(const RQuantity &rhs) {
+    value -= rhs.value;
+    return *this;
+  }
 
-    // Returns the value of the quantity in multiples of the specified unit
-    constexpr double convert(const RQuantity &rhs) const {
-      return value / rhs.value;
-    }
+  // Returns the value of the quantity in multiples of the specified unit
+  constexpr double convert(const RQuantity &rhs) const {
+    return value / rhs.value;
+  }
 
-    // returns the raw value of the quantity (should not be used)
-    constexpr double getValue() const {
-      return value;
-    }
+  // returns the raw value of the quantity (should not be used)
+  constexpr double getValue() const {
+    return value;
+  }
 
   private:
-    double value;
-  };
+  double value;
+};
 
 // Predefined (physical unit) quantity types:
 // ------------------------------------------
@@ -61,90 +61,90 @@ namespace okapi{
     name;
 
 // Unitless
-  QUANTITY_TYPE(0, 0, 0, 0, Number)
+QUANTITY_TYPE(0, 0, 0, 0, Number)
 
 // Standard arithmetic operators:
 // ------------------------------
-  template <typename M, typename L, typename T, typename A>
-  constexpr RQuantity<M, L, T, A> operator+(const RQuantity<M, L, T, A> &lhs,
-                                            const RQuantity<M, L, T, A> &rhs) {
-    return RQuantity<M, L, T, A>(lhs.getValue() + rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr RQuantity<M, L, T, A> operator-(const RQuantity<M, L, T, A> &lhs,
-                                            const RQuantity<M, L, T, A> &rhs) {
-    return RQuantity<M, L, T, A>(lhs.getValue() - rhs.getValue());
-  }
-  template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
-    typename A2>
-  constexpr RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
-    std::ratio_add<A1, A2>>
-  operator*(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
-    return RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
-      std::ratio_add<A1, A2>>(lhs.getValue() * rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr RQuantity<M, L, T, A> operator*(const double &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return RQuantity<M, L, T, A>(lhs * rhs.getValue());
-  }
-  template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
-    typename A2>
-  constexpr RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
-    std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>
-  operator/(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
-    return RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
-      std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>(lhs.getValue() /
-                                                                rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
-    std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>
-  operator/(double x, const RQuantity<M, L, T, A> &rhs) {
-    return RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
-      std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>(
-      x / rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr RQuantity<M, L, T, A> operator/(const RQuantity<M, L, T, A> &rhs, double x) {
-    return RQuantity<M, L, T, A>(rhs.getValue() / x);
-  }
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> operator+(const RQuantity<M, L, T, A> &lhs,
+                                          const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(lhs.getValue() + rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> operator-(const RQuantity<M, L, T, A> &lhs,
+                                          const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(lhs.getValue() - rhs.getValue());
+}
+template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
+          typename A2>
+constexpr RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
+                    std::ratio_add<A1, A2>>
+operator*(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
+  return RQuantity<std::ratio_add<M1, M2>, std::ratio_add<L1, L2>, std::ratio_add<T1, T2>,
+                   std::ratio_add<A1, A2>>(lhs.getValue() * rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> operator*(const double &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(lhs * rhs.getValue());
+}
+template <typename M1, typename L1, typename T1, typename A1, typename M2, typename L2, typename T2,
+          typename A2>
+constexpr RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
+                    std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>
+operator/(const RQuantity<M1, L1, T1, A1> &lhs, const RQuantity<M2, L2, T2, A2> &rhs) {
+  return RQuantity<std::ratio_subtract<M1, M2>, std::ratio_subtract<L1, L2>,
+                   std::ratio_subtract<T1, T2>, std::ratio_subtract<A1, A2>>(lhs.getValue() /
+                                                                             rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
+                    std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>
+operator/(double x, const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio_subtract<std::ratio<0>, M>, std::ratio_subtract<std::ratio<0>, L>,
+                   std::ratio_subtract<std::ratio<0>, T>, std::ratio_subtract<std::ratio<0>, A>>(
+    x / rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> operator/(const RQuantity<M, L, T, A> &rhs, double x) {
+  return RQuantity<M, L, T, A>(rhs.getValue() / x);
+}
 
 // Comparison operators for quantities:
 // ------------------------------------
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator==(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() == rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator!=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() != rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator<=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() <= rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator>=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() >= rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator<(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() < rhs.getValue());
-  }
-  template <typename M, typename L, typename T, typename A>
-  constexpr bool operator>(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
-    return (lhs.getValue() > rhs.getValue());
-  }
-
-  inline namespace literals{
-    constexpr long double operator"" _pi(long double x) {
-      return static_cast<double>(x) * 3.1415926535897932384626433832795;
-    }
-    constexpr long double operator"" _pi(unsigned long long int x) {
-      return static_cast<double>(x) * 3.1415926535897932384626433832795;
-    }
-  }
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator==(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() == rhs.getValue());
 }
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator!=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() != rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator<=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() <= rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator>=(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() >= rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator<(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() < rhs.getValue());
+}
+template <typename M, typename L, typename T, typename A>
+constexpr bool operator>(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return (lhs.getValue() > rhs.getValue());
+}
+
+inline namespace literals {
+constexpr long double operator"" _pi(long double x) {
+  return static_cast<double>(x) * 3.1415926535897932384626433832795;
+}
+constexpr long double operator"" _pi(unsigned long long int x) {
+  return static_cast<double>(x) * 3.1415926535897932384626433832795;
+}
+} // namespace literals
+} // namespace okapi
 
 // Conversion macro, which utilizes the string literals
 #define ConvertTo(_x, _y) (_x).convert(1.0_##_y)

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -11,6 +11,7 @@
 
 using namespace snowhouse;
 
+namespace okapi {
 TEST(UnitTests, TimeAddition) {
   QTime start = 0_ms;
 
@@ -23,3 +24,4 @@ TEST(UnitTests, TimeAssignmentAddition) {
 
   EXPECT_DOUBLE_EQ(start.convert(millisecond), (1_ms).convert(millisecond));
 }
+} // namespace okapi


### PR DESCRIPTION
### Description of the Change

Units should be in the `okapi` namespace, and their literals should be in the `literals` inline namespace.

### Benefits

Consistent namespace usage.

### Possible Drawbacks

None.

### Verification Process

This was not verified.

### Applicable Issues

Closes #133.
