### PR TITLE
Issue #135: Add logging support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ add_executable(OkapiLibV5
         test/unitTests.cpp
         test/implMocks.cpp
         src/api/util/timeUtil.cpp
-        include/okapi/api/util/timeUtil.hpp include/okapi/api/chassis/model/readOnlyChassisModel.hpp src/api/chassis/model/readOnlyChassisModel.cpp)
+        include/okapi/api/util/timeUtil.hpp include/okapi/api/chassis/model/readOnlyChassisModel.hpp src/api/chassis/model/readOnlyChassisModel.cpp include/okapi/api/util/logging.hpp src/api/util/logging.cpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -11,6 +11,7 @@
 #include "okapi/api/chassis/controller/chassisController.hpp"
 #include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
@@ -117,6 +118,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
   void stop() override;
 
   protected:
+  Logger *logger;
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<AsyncPosIntegratedController> leftController;
   std::unique_ptr<AsyncPosIntegratedController> rightController;

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -12,6 +12,7 @@
 #include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
@@ -119,6 +120,7 @@ class ChassisControllerPID : public virtual ChassisController {
   void stop() override;
 
   protected:
+  Logger *logger;
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<IterativePosPIDController> distancePid;
   std::unique_ptr<IterativePosPIDController> anglePid;

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -10,6 +10,7 @@
 
 #include "okapi/api/control/async/asyncPositionController.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
@@ -85,6 +86,7 @@ class AsyncPosIntegratedController : public AsyncPositionController {
   void waitUntilSettled() override;
 
   protected:
+  Logger *logger;
   std::shared_ptr<AbstractMotor> motor;
   double lastTarget = 0;
   bool controllerIsDisabled = false;

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -10,6 +10,7 @@
 
 #include "okapi/api/control/async/asyncVelocityController.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
@@ -86,6 +87,7 @@ class AsyncVelIntegratedController : public AsyncVelocityController {
   void waitUntilSettled() override;
 
   protected:
+  Logger *logger;
   std::shared_ptr<AbstractMotor> motor;
   double lastTarget = 0;
   bool controllerIsDisabled = false;

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -15,6 +15,7 @@
 #include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/coreProsAPI.hpp"
 #include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/supplier.hpp"
 #include <memory>
 
@@ -112,6 +113,7 @@ class AsyncWrapper : virtual public AsyncController {
   void waitUntilSettled() override;
 
   protected:
+  Logger *logger;
   std::shared_ptr<ControllerInput> input;
   std::shared_ptr<ControllerOutput> output;
   std::unique_ptr<IterativeController> controller;

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -12,6 +12,7 @@
 
 #include "okapi/api/control/iterative/iterativePositionController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 
@@ -164,6 +165,7 @@ class IterativePosPIDController : public IterativePositionController {
   QTime getSampleTime() const override;
 
   protected:
+  Logger *logger;
   double kP, kI, kD, kBias;
   QTime sampleTime = 10_ms;
   double target = 0;

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -11,6 +11,7 @@
 #include "okapi/api/control/iterative/iterativeVelocityController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/filter/velMath.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 
 namespace okapi {
@@ -141,6 +142,7 @@ class IterativeVelPIDController : public IterativeVelocityController {
   virtual QAngularSpeed getVel() const;
 
   protected:
+  Logger *logger;
   double kP, kD, kF;
   QTime sampleTime = 10_ms;
   double error = 0;

--- a/include/okapi/api/control/util/controllerRunner.hpp
+++ b/include/okapi/api/control/util/controllerRunner.hpp
@@ -12,6 +12,7 @@
 #include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/control/iterative/iterativeController.hpp"
 #include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/logging.hpp"
 #include <memory>
 
 namespace okapi {
@@ -62,6 +63,7 @@ class ControllerRunner {
                                   ControllerOutput &ioutput);
 
   protected:
+  Logger *logger;
   std::unique_ptr<AbstractRate> rate;
 };
 } // namespace okapi

--- a/include/okapi/api/control/util/pidTuner.hpp
+++ b/include/okapi/api/control/util/pidTuner.hpp
@@ -13,6 +13,7 @@
 #include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/units/QTime.hpp"
+#include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <memory>
 #include <vector>
@@ -47,6 +48,7 @@ class PIDTuner {
     double bestError;
   };
 
+  Logger *logger;
   std::shared_ptr<ControllerInput> input;
   std::shared_ptr<ControllerOutput> output;
   TimeUtil timeUtil;

--- a/include/okapi/api/filter/velMath.hpp
+++ b/include/okapi/api/filter/velMath.hpp
@@ -13,6 +13,7 @@
 #include "okapi/api/units/QAngularSpeed.hpp"
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/util/abstractTimer.hpp"
+#include "okapi/api/util/logging.hpp"
 #include <memory>
 
 namespace okapi {
@@ -69,6 +70,7 @@ class VelMath {
   virtual QAngularAcceleration getAccel() const;
 
   protected:
+  Logger *logger;
   QAngularSpeed vel;
   QAngularSpeed lastVel;
   QAngularAcceleration accel;

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -1,0 +1,47 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_LOGGING_HPP_
+#define _OKAPI_LOGGING_HPP_
+
+#include "okapi/api/util/abstractTimer.hpp"
+#include <memory>
+
+namespace okapi {
+class Logger {
+  public:
+  enum class LogLevel { off = 0, info = 3, warn = 2, error = 1 };
+
+  static Logger *instance();
+
+  /**
+   * A Logger.
+   *
+   * @param itimer A timer used to get the current time for log statements.
+   * @param logfileName The name of the log file to open.
+   * @param level The log level. Log statements above this level will be disabled.
+   */
+  static void initialize(std::unique_ptr<AbstractTimer> itimer, std::string_view filename,
+                         LogLevel level) noexcept;
+
+  static void setLogLevel(LogLevel level) noexcept;
+
+  void info(std::string_view message) const noexcept;
+
+  void warn(std::string_view message) const noexcept;
+
+  void error(std::string_view message) const noexcept;
+
+  private:
+  static Logger *s_instance;
+  static std::unique_ptr<AbstractTimer> timer;
+  static LogLevel logLevel;
+  static FILE *logfile;
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -14,7 +14,7 @@
 namespace okapi {
 class Logger {
   public:
-  enum class LogLevel { off = 0, info = 3, warn = 2, error = 1 };
+  enum class LogLevel { off = 0, debug = 4, info = 3, warn = 2, error = 1 };
 
   /**
    * Initializes the logger. If the logger is not initialized when logging methods are called,
@@ -35,9 +35,11 @@ class Logger {
   /**
    * Set a new logging level. Log statements above this level will be disabled. For example, if the
    * level is set to LogLevel::warn, then LogLevel::warn and Loglevel::error will be enabled, but
-   * LogLevel::info will be disabled.
+   * LogLevel::info and LogLevel::debug will be disabled.
    */
   static void setLogLevel(LogLevel level) noexcept;
+
+  void debug(std::string_view message) const noexcept;
 
   void info(std::string_view message) const noexcept;
 

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -53,6 +53,7 @@ class Logger {
   void close() noexcept;
 
   private:
+  Logger();
   static Logger *s_instance;
   static std::unique_ptr<AbstractTimer> timer;
   static LogLevel logLevel;

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -30,11 +30,11 @@ class Logger {
   /**
    * Get the logger instance.
    */
-  static Logger *instance();
+  static Logger *instance() noexcept;
 
   /**
    * Set a new logging level. Log statements above this level will be disabled. For example, if the
-   * level is set to LogLevel::warn, then LogLevel::warn and Loglevel::error will be enabled, but
+   * level is set to LogLevel::warn, then LogLevel::warn and LogLevel::error will be enabled, but
    * LogLevel::info and LogLevel::debug will be disabled.
    */
   static void setLogLevel(LogLevel level) noexcept;

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -16,10 +16,9 @@ class Logger {
   public:
   enum class LogLevel { off = 0, info = 3, warn = 2, error = 1 };
 
-  static Logger *instance();
-
   /**
-   * A Logger.
+   * Initializes the logger. If the logger is not initialized when logging methods are called,
+   * nothing will be logged.
    *
    * @param itimer A timer used to get the current time for log statements.
    * @param logfileName The name of the log file to open.
@@ -28,6 +27,16 @@ class Logger {
   static void initialize(std::unique_ptr<AbstractTimer> itimer, std::string_view filename,
                          LogLevel level) noexcept;
 
+  /**
+   * Get the logger instance.
+   */
+  static Logger *instance();
+
+  /**
+   * Set a new logging level. Log statements above this level will be disabled. For example, if the
+   * level is set to LogLevel::warn, then LogLevel::warn and Loglevel::error will be enabled, but
+   * LogLevel::info will be disabled.
+   */
   static void setLogLevel(LogLevel level) noexcept;
 
   void info(std::string_view message) const noexcept;
@@ -35,6 +44,11 @@ class Logger {
   void warn(std::string_view message) const noexcept;
 
   void error(std::string_view message) const noexcept;
+
+  /**
+   * Closes the connection to the log file.
+   */
+  void close() noexcept;
 
   private:
   static Logger *s_instance;

--- a/include/okapi/api/util/mathUtil.hpp
+++ b/include/okapi/api/util/mathUtil.hpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <type_traits>
 
 namespace okapi {
 static constexpr double analogInToV = 286.0;
@@ -92,6 +93,13 @@ constexpr double deadband(const double value, const double min, const double max
 constexpr double remapRange(const double value, const double oldMin, const double oldMax,
                             const double newMin, const double newMax) {
   return (value - oldMin) * ((newMax - newMin) / (oldMax - oldMin)) + newMin;
+}
+
+/**
+ * Converts an enum to its value type.
+ */
+template <typename E> constexpr auto toUnderlyingType(E e) noexcept {
+  return static_cast<std::underlying_type_t<E>>(e);
 }
 } // namespace okapi
 

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -26,6 +26,7 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
   std::unique_ptr<AsyncPosIntegratedController> irightController,
   AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales)
   : ChassisController(std::move(imodel)),
+    logger(Logger::instance()),
     rate(std::move(itimeUtil.getRate())),
     leftController(std::move(ileftController)),
     rightController(std::move(irightController)),
@@ -53,6 +54,7 @@ void ChassisControllerIntegrated::moveDistance(const double itarget) {
 }
 
 void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
+  logger->info("moveDistanceAsync start");
   leftController->reset();
   rightController->reset();
   leftController->flipDisable(false);
@@ -62,6 +64,7 @@ void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
   const auto enc = model->getSensorVals();
   leftController->setTarget(newTarget + enc[0]);
   rightController->setTarget(newTarget + enc[1]);
+  logger->info("moveDistanceAsync end");
 }
 
 void ChassisControllerIntegrated::moveDistanceAsync(const double itarget) {
@@ -97,13 +100,16 @@ void ChassisControllerIntegrated::turnAngleAsync(const double idegTarget) {
 }
 
 void ChassisControllerIntegrated::waitUntilSettled() {
+  logger->info("waitUntilSettled start");
   while (!(leftController->isSettled() && rightController->isSettled())) {
+    logger->info("waitUntilSettled check");
     rate->delayUntil(10_ms);
   }
 
   leftController->flipDisable(true);
   rightController->flipDisable(true);
   model->stop();
+  logger->info("waitUntilSettled stop");
 }
 
 void ChassisControllerIntegrated::stop() {

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -16,19 +16,23 @@ AsyncPosIntegratedControllerArgs::AsyncPosIntegratedControllerArgs(
 
 AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
                                                            const TimeUtil &itimeUtil)
-  : motor(imotor),
+  : logger(Logger::instance()),
+    motor(imotor),
     settledUtil(std::move(itimeUtil.getSettledUtil())),
     rate(std::move(itimeUtil.getRate())) {
 }
 
 AsyncPosIntegratedController::AsyncPosIntegratedController(
   const AsyncPosIntegratedControllerArgs &iparams, const TimeUtil &itimeUtil)
-  : motor(iparams.motor),
+  : logger(Logger::instance()),
+    motor(iparams.motor),
     settledUtil(std::move(itimeUtil.getSettledUtil())),
     rate(std::move(itimeUtil.getRate())) {
 }
 
 void AsyncPosIntegratedController::setTarget(const double itarget) {
+  logger->info("AsyncPosIntegratedController: Set target to " + std::to_string(itarget));
+
   hasFirstTarget = true;
 
   if (!controllerIsDisabled) {
@@ -57,6 +61,7 @@ void AsyncPosIntegratedController::flipDisable() {
 }
 
 void AsyncPosIntegratedController::flipDisable(const bool iisDisabled) {
+  logger->info("AsyncPosIntegratedController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
   resumeMovement();
 }
@@ -76,8 +81,10 @@ void AsyncPosIntegratedController::resumeMovement() {
 }
 
 void AsyncPosIntegratedController::waitUntilSettled() {
+  logger->info("AsyncPosIntegratedController: Waiting to settle");
   while (!settledUtil->isSettled(getError())) {
     rate->delayUntil(motorUpdateRate);
   }
+  logger->info("AsyncPosIntegratedController: Done waiting to settle");
 }
 } // namespace okapi

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -51,6 +51,7 @@ bool AsyncPosIntegratedController::isSettled() {
 }
 
 void AsyncPosIntegratedController::reset() {
+  logger->info("AsyncPosIntegratedController: Reset");
   hasFirstTarget = false;
   settledUtil->reset();
 }

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -29,6 +29,8 @@ AsyncVelIntegratedController::AsyncVelIntegratedController(
 }
 
 void AsyncVelIntegratedController::setTarget(const double itarget) {
+  logger->info("AsyncVelIntegratedController: Set target to " + std::to_string(itarget));
+
   hasFirstTarget = true;
 
   if (!controllerIsDisabled) {
@@ -57,6 +59,7 @@ void AsyncVelIntegratedController::flipDisable() {
 }
 
 void AsyncVelIntegratedController::flipDisable(const bool iisDisabled) {
+  logger->info("AsyncVelIntegratedController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
   resumeMovement();
 }
@@ -76,8 +79,10 @@ void AsyncVelIntegratedController::resumeMovement() {
 }
 
 void AsyncVelIntegratedController::waitUntilSettled() {
+  logger->info("AsyncVelIntegratedController: Waiting to settle");
   while (!settledUtil->isSettled(getError())) {
     rate->delayUntil(motorUpdateRate);
   }
+  logger->info("AsyncVelIntegratedController: Done waiting to settle");
 }
 } // namespace okapi

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -49,6 +49,7 @@ bool AsyncVelIntegratedController::isSettled() {
 }
 
 void AsyncVelIntegratedController::reset() {
+  logger->info("AsyncVelIntegratedController: Reset");
   hasFirstTarget = false;
   settledUtil->reset();
 }

--- a/src/api/control/async/asyncWrapper.cpp
+++ b/src/api/control/async/asyncWrapper.cpp
@@ -15,7 +15,8 @@ AsyncWrapper::AsyncWrapper(std::shared_ptr<ControllerInput> iinput,
                            std::unique_ptr<IterativeController> icontroller,
                            const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
                            std::unique_ptr<SettledUtil> isettledUtil)
-  : input(iinput),
+  : logger(Logger::instance()),
+    input(iinput),
     output(ioutput),
     controller(std::move(icontroller)),
     loopRate(std::move(irateSupplier.get())),
@@ -42,6 +43,7 @@ void AsyncWrapper::trampoline(void *context) {
 }
 
 void AsyncWrapper::setTarget(const double itarget) {
+  logger->info("AsyncWrapper: Set target to " + std::to_string(itarget));
   controller->setTarget(itarget);
 }
 
@@ -66,6 +68,7 @@ void AsyncWrapper::setOutputLimits(double imax, double imin) {
 }
 
 void AsyncWrapper::reset() {
+  logger->info("AsyncWrapper: Reset");
   controller->reset();
 }
 
@@ -74,6 +77,7 @@ void AsyncWrapper::flipDisable() {
 }
 
 void AsyncWrapper::flipDisable(const bool iisDisabled) {
+  logger->info("AsyncWrapper: flipDisable " + std::to_string(iisDisabled));
   controller->flipDisable(iisDisabled);
 }
 
@@ -82,8 +86,10 @@ bool AsyncWrapper::isDisabled() const {
 }
 
 void AsyncWrapper::waitUntilSettled() {
+  logger->info("AsyncWrapper: Waiting to settle");
   while (!settledUtil->isSettled(getError())) {
     loopRate->delayUntil(motorUpdateRate);
   }
+  logger->info("AsyncWrapper: Done waiting to settle");
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -25,7 +25,8 @@ IterativePosPIDController::IterativePosPIDController(const IterativePosPIDContro
 IterativePosPIDController::IterativePosPIDController(const double ikP, const double ikI,
                                                      const double ikD, const double ikBias,
                                                      const TimeUtil &itimeUtil)
-  : loopDtTimer(std::move(itimeUtil.getTimer())),
+  : logger(Logger::instance()),
+    loopDtTimer(std::move(itimeUtil.getTimer())),
     settledUtil(std::move(itimeUtil.getSettledUtil())) {
   if (ikI != 0) {
     setIntegralLimits(-1 / ikI, 1 / ikI);
@@ -35,6 +36,7 @@ IterativePosPIDController::IterativePosPIDController(const double ikP, const dou
 }
 
 void IterativePosPIDController::setTarget(const double itarget) {
+  logger->info("IterativePosPIDController: Set target to " + std::to_string(itarget));
   target = itarget;
 }
 
@@ -145,6 +147,7 @@ void IterativePosPIDController::setGains(const double ikP, const double ikI, con
 }
 
 void IterativePosPIDController::reset() {
+  logger->info("IterativePosPIDController: Reset");
   error = 0;
   lastError = 0;
   lastReading = 0;
@@ -161,6 +164,7 @@ void IterativePosPIDController::flipDisable() {
 }
 
 void IterativePosPIDController::flipDisable(const bool iisDisabled) {
+  logger->info("IterativePosPIDController: flipDisable " + std::to_string(iisDisabled));
   isOn = !iisDisabled;
 }
 

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -15,7 +15,8 @@ IterativeVelPIDController::IterativeVelPIDController(const double ikP, const dou
                                                      const double ikF,
                                                      std::unique_ptr<VelMath> ivelMath,
                                                      const TimeUtil &itimeUtil)
-  : velMath(std::move(ivelMath)),
+  : logger(Logger::instance()),
+    velMath(std::move(ivelMath)),
     loopDtTimer(std::move(itimeUtil.getTimer())),
     settledUtil(std::move(itimeUtil.getSettledUtil())) {
   setGains(ikP, ikD, ikF);
@@ -78,6 +79,7 @@ double IterativeVelPIDController::step(const double inewReading) {
 }
 
 void IterativeVelPIDController::setTarget(const double itarget) {
+  logger->info("IterativeVelPIDController: Set target to " + std::to_string(itarget));
   target = itarget;
 }
 
@@ -98,6 +100,7 @@ bool IterativeVelPIDController::isSettled() {
 }
 
 void IterativeVelPIDController::reset() {
+  logger->info("IterativeVelPIDController: Reset");
   error = 0;
   output = 0;
 }
@@ -107,6 +110,7 @@ void IterativeVelPIDController::flipDisable() {
 }
 
 void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
+  logger->info("IterativeVelPIDController: flipDisable " + std::to_string(iisDisabled));
   isOn = !iisDisabled;
 }
 

--- a/src/api/control/util/controllerRunner.cpp
+++ b/src/api/control/util/controllerRunner.cpp
@@ -9,23 +9,29 @@
 #include <cmath>
 
 namespace okapi {
-ControllerRunner::ControllerRunner(std::unique_ptr<AbstractRate> irate) : rate(std::move(irate)) {
+ControllerRunner::ControllerRunner(std::unique_ptr<AbstractRate> irate)
+  : logger(Logger::instance()), rate(std::move(irate)) {
 }
 
 ControllerRunner::~ControllerRunner() = default;
 
 double ControllerRunner::runUntilSettled(const double itarget, AsyncController &icontroller) {
+  logger->info("ControllerRunner: runUntilSettled(AsyncController): Set target to " +
+               std::to_string(itarget));
   icontroller.setTarget(itarget);
 
   while (!icontroller.isSettled()) {
     rate->delay(10);
   }
 
+  logger->info("ControllerRunner: runUntilSettled(AsyncController): Done waiting to settle");
   return icontroller.getError();
 }
 
 double ControllerRunner::runUntilSettled(const double itarget, IterativeController &icontroller,
                                          ControllerOutput &ioutput) {
+  logger->info("ControllerRunner: runUntilSettled(IterativeController): Set target to " +
+               std::to_string(itarget));
   icontroller.setTarget(itarget);
 
   while (!icontroller.isSettled()) {
@@ -33,10 +39,13 @@ double ControllerRunner::runUntilSettled(const double itarget, IterativeControll
     rate->delay(10);
   }
 
+  logger->info("ControllerRunner: runUntilSettled(IterativeController): Done waiting to settle");
   return icontroller.getError();
 }
 
 double ControllerRunner::runUntilAtTarget(const double itarget, AsyncController &icontroller) {
+  logger->info("ControllerRunner: runUntilAtTarget(AsyncController): Set target to " +
+               std::to_string(itarget));
   icontroller.setTarget(itarget);
 
   double error = icontroller.getError();
@@ -47,11 +56,14 @@ double ControllerRunner::runUntilAtTarget(const double itarget, AsyncController 
     error = icontroller.getError();
   }
 
+  logger->info("ControllerRunner: runUntilAtTarget(AsyncController): Done waiting to settle");
   return icontroller.getError();
 }
 
 double ControllerRunner::runUntilAtTarget(const double itarget, IterativeController &icontroller,
                                           ControllerOutput &ioutput) {
+  logger->info("ControllerRunner: runUntilAtTarget(IterativeController): Set target to " +
+               std::to_string(itarget));
   icontroller.setTarget(itarget);
 
   double error = icontroller.getError();
@@ -63,6 +75,7 @@ double ControllerRunner::runUntilAtTarget(const double itarget, IterativeControl
     error = icontroller.getError();
   }
 
+  logger->info("ControllerRunner: runUntilAtTarget(IterativeController): Done waiting to settle");
   return icontroller.getError();
 }
 } // namespace okapi

--- a/src/api/filter/velMath.cpp
+++ b/src/api/filter/velMath.cpp
@@ -28,8 +28,13 @@ VelMath::VelMath(const VelMathArgs &iparams, std::unique_ptr<AbstractTimer> iloo
 
 VelMath::VelMath(const double iticksPerRev, std::shared_ptr<Filter> ifilter,
                  std::unique_ptr<AbstractTimer> iloopDtTimer)
-  : ticksPerRev(iticksPerRev), loopDtTimer(std::move(iloopDtTimer)), filter(ifilter) {
+  : logger(Logger::instance()),
+    ticksPerRev(iticksPerRev),
+    loopDtTimer(std::move(iloopDtTimer)),
+    filter(ifilter) {
   if (iticksPerRev == 0) {
+    logger->error(
+      "VelMath: The ticks per revolution cannot be zero! Check if you are using integer division.");
     throw std::invalid_argument(
       "VelMath: The ticks per revolution cannot be zero! Check if you are using integer division.");
   }

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -54,4 +54,9 @@ void Logger::error(std::string_view message) const noexcept {
             message.data());
   }
 }
+
+void Logger::close() noexcept {
+  fclose(logfile);
+  logfile = nullptr;
+}
 } // namespace okapi

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -1,0 +1,57 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/util/logging.hpp"
+#include "okapi/api/util/mathUtil.hpp"
+#include <stdio.h>
+
+namespace okapi {
+Logger *Logger::s_instance;
+std::unique_ptr<AbstractTimer> Logger::timer;
+Logger::LogLevel Logger::logLevel;
+FILE *Logger::logfile;
+
+Logger *Logger::instance() {
+  if (!s_instance) {
+    s_instance = new Logger();
+  }
+
+  return s_instance;
+}
+
+void Logger::initialize(std::unique_ptr<AbstractTimer> itimer, std::string_view filename,
+                        Logger::LogLevel level) noexcept {
+  timer = std::move(itimer);
+  logfile = fopen(filename.data(), "w");
+  logLevel = level;
+}
+
+void Logger::setLogLevel(Logger::LogLevel level) noexcept {
+  logLevel = level;
+}
+
+void Logger::info(std::string_view message) const noexcept {
+  if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info) && logfile && timer) {
+    fprintf(logfile, "%ld INFO: %s\n", static_cast<long>(timer->millis().convert(millisecond)),
+            message.data());
+  }
+}
+
+void Logger::warn(std::string_view message) const noexcept {
+  if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::warn) && logfile && timer) {
+    fprintf(logfile, "%ld WARN: %s\n", static_cast<long>(timer->millis().convert(millisecond)),
+            message.data());
+  }
+}
+
+void Logger::error(std::string_view message) const noexcept {
+  if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::error) && logfile && timer) {
+    fprintf(logfile, "%ld ERROR: %s\n", static_cast<long>(timer->millis().convert(millisecond)),
+            message.data());
+  }
+}
+} // namespace okapi

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -34,6 +34,13 @@ void Logger::setLogLevel(Logger::LogLevel level) noexcept {
   logLevel = level;
 }
 
+void Logger::debug(std::string_view message) const noexcept {
+  if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info) && logfile && timer) {
+    fprintf(logfile, "%ld DEBUG: %s\n", static_cast<long>(timer->millis().convert(millisecond)),
+            message.data());
+  }
+}
+
 void Logger::info(std::string_view message) const noexcept {
   if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info) && logfile && timer) {
     fprintf(logfile, "%ld INFO: %s\n", static_cast<long>(timer->millis().convert(millisecond)),

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -17,7 +17,7 @@ FILE *Logger::logfile;
 
 Logger::Logger() = default;
 
-Logger *Logger::instance() {
+Logger *Logger::instance() noexcept {
   if (!s_instance) {
     s_instance = new Logger();
   }

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -15,6 +15,8 @@ std::unique_ptr<AbstractTimer> Logger::timer;
 Logger::LogLevel Logger::logLevel;
 FILE *Logger::logfile;
 
+Logger::Logger() = default;
+
 Logger *Logger::instance() {
   if (!s_instance) {
     s_instance = new Logger();

--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -6,9 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/device/motor/motor.hpp"
+#include "okapi/api/util/mathUtil.hpp"
 #include "okapi/impl/device/rotarysensor/integratedEncoder.hpp"
 #include <cmath>
-#include <type_traits>
 
 namespace okapi {
 Motor::Motor(const std::int8_t port)
@@ -124,10 +124,6 @@ std::int32_t Motor::setVoltageLimit(const std::int32_t ilimit) const {
 
 std::shared_ptr<ContinuousRotarySensor> Motor::getEncoder() const {
   return std::make_shared<IntegratedEncoder>(*this);
-}
-
-template <typename E> constexpr auto toUnderlyingType(E e) noexcept {
-  return static_cast<std::underlying_type_t<E>>(e);
 }
 
 void Motor::controllerSet(const double ivalue) {

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -25,10 +25,10 @@ void opcontrol() {
 
   Logger::initialize(std::make_unique<Timer>(), "/ser/sout", Logger::LogLevel::info);
 
-  auto drive =
-    ChassisControllerFactory::create(-1, 2, AbstractMotor::gearset::red, {2.5_in, 10.5_in});
-  drive.moveDistanceAsync(2_in);
-  drive.waitUntilSettled();
+  //  auto drive =
+  //    ChassisControllerFactory::create(-1, 2, AbstractMotor::gearset::red, {2.5_in, 10.5_in});
+  //  drive.moveDistanceAsync(2_in);
+  //  drive.waitUntilSettled();
 
   //  runHeadlessTests();
   return;

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -23,7 +23,14 @@ void opcontrol() {
   using namespace okapi;
   pros::Task::delay(100);
 
-  runHeadlessTests();
+  Logger::initialize(std::make_unique<Timer>(), "/ser/sout", Logger::LogLevel::info);
+
+  auto drive =
+    ChassisControllerFactory::create(-1, 2, AbstractMotor::gearset::red, {2.5_in, 10.5_in});
+  drive.moveDistanceAsync(2_in);
+  drive.waitUntilSettled();
+
+  //  runHeadlessTests();
   return;
 
   MotorGroup leftMotors({19_mtr, 20_mtr});


### PR DESCRIPTION
### Description of the Change

This PR adds a logger class so OkapiLib's classes can log information that may help users when they are debugging their programs. Various log levels (including `off`) are supported, and the output file is configurable. Logging is disabled by default.

### Benefits

Users will have an easier time debugging OkapiLib's behavior and we will have an easier time helping them.

### Possible Drawbacks

At high log levels, it's possible that programs may slow down such that they start missing some deadlines (i.e., in tight loops). I've tested two tasks logging 70 characters each every 1 ms with no problems, but that is essentially a microbenchmark and its applicability to real programs is limited. OkapiLib's classes should be very respectful and thoughtful of the logging levels, what gets logged, and how much gets logged.

### Verification Process

This was tested on a V5 and on my desktop. On the V5, I output to `stdout` and on my desktop I output to a file in a test.

### Applicable Issues

Closes #135.
