### PR TITLE
Add Logger tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ add_executable(OkapiLibV5
         test/unitTests.cpp
         test/implMocks.cpp
         src/api/util/timeUtil.cpp
-        include/okapi/api/util/timeUtil.hpp include/okapi/api/chassis/model/readOnlyChassisModel.hpp src/api/chassis/model/readOnlyChassisModel.cpp include/okapi/api/util/logging.hpp src/api/util/logging.cpp)
+        include/okapi/api/util/timeUtil.hpp include/okapi/api/chassis/model/readOnlyChassisModel.hpp src/api/chassis/model/readOnlyChassisModel.cpp include/okapi/api/util/logging.hpp src/api/util/logging.cpp test/loggerTests.cpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -28,6 +28,17 @@ class Logger {
                          LogLevel level) noexcept;
 
   /**
+   * Initializes the logger. If the logger is not initialized when logging methods are called,
+   * nothing will be logged.
+   *
+   * @param itimer A timer used to get the current time for log statements.
+   * @param logfileName The name of the log file to open.
+   * @param level The log level. Log statements above this level will be disabled.
+   */
+  static void initialize(std::unique_ptr<AbstractTimer> itimer, FILE *file,
+                         LogLevel level) noexcept;
+
+  /**
    * Get the logger instance.
    */
   static Logger *instance() noexcept;

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -96,7 +96,9 @@ void ChassisControllerPID::loop() {
 }
 
 void ChassisControllerPID::trampoline(void *context) {
-  static_cast<ChassisControllerPID *>(context)->loop();
+  if (context) {
+    static_cast<ChassisControllerPID *>(context)->loop();
+  }
 }
 
 void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {

--- a/src/api/control/async/asyncWrapper.cpp
+++ b/src/api/control/async/asyncWrapper.cpp
@@ -39,7 +39,9 @@ void AsyncWrapper::loop() {
 }
 
 void AsyncWrapper::trampoline(void *context) {
-  static_cast<AsyncWrapper *>(context)->loop();
+  if (context) {
+    static_cast<AsyncWrapper *>(context)->loop();
+  }
 }
 
 void AsyncWrapper::setTarget(const double itarget) {

--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -32,6 +32,13 @@ void Logger::initialize(std::unique_ptr<AbstractTimer> itimer, std::string_view 
   logLevel = level;
 }
 
+void Logger::initialize(std::unique_ptr<AbstractTimer> itimer, FILE *file,
+                        Logger::LogLevel level) noexcept {
+  timer = std::move(itimer);
+  logfile = file;
+  logLevel = level;
+}
+
 void Logger::setLogLevel(Logger::LogLevel level) noexcept {
   logLevel = level;
 }

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -291,7 +291,9 @@ void SimulatedSystem::step() {
 }
 
 void SimulatedSystem::trampoline(void *system) {
-  static_cast<SimulatedSystem *>(system)->step();
+  if (system) {
+    static_cast<SimulatedSystem *>(system)->step();
+  }
 }
 
 void SimulatedSystem::join() {

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -1,0 +1,138 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/util/logging.hpp"
+#include "test/tests/api/implMocks.hpp"
+#include <gtest/gtest.h>
+
+using namespace okapi;
+
+class LoggerTest : public ::testing::Test {
+  protected:
+  virtual void SetUp() {
+    logFile = open_memstream(&logBuffer, &logSize);
+  }
+
+  virtual void TearDown() {
+    fclose(logFile);
+    free(logBuffer);
+  }
+
+  void logData(Logger *logger) const {
+    logger->error("MSG");
+    logger->warn("MSG");
+    logger->info("MSG");
+    logger->debug("MSG");
+  }
+
+  FILE *logFile;
+  char *logBuffer;
+  size_t logSize;
+};
+
+TEST_F(LoggerTest, OffLevel) {
+  Logger::initialize(std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::off);
+  auto logger = Logger::instance();
+
+  logData(logger);
+
+  char *line = nullptr;
+  size_t len;
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "");
+
+  if (line) {
+    free(line);
+  }
+}
+
+TEST_F(LoggerTest, ErrorLevel) {
+  Logger::initialize(std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::error);
+  auto logger = Logger::instance();
+
+  logData(logger);
+
+  char *line = nullptr;
+  size_t len;
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+
+  if (line) {
+    free(line);
+  }
+}
+
+TEST_F(LoggerTest, WarningLevel) {
+  Logger::initialize(std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::warn);
+  auto logger = Logger::instance();
+
+  logData(logger);
+
+  char *line = nullptr;
+  size_t len;
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 WARN: MSG\n");
+
+  if (line) {
+    free(line);
+  }
+}
+
+TEST_F(LoggerTest, InfoLevel) {
+  Logger::initialize(std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::info);
+  auto logger = Logger::instance();
+
+  logData(logger);
+
+  char *line = nullptr;
+  size_t len;
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 WARN: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 INFO: MSG\n");
+
+  if (line) {
+    free(line);
+  }
+}
+
+TEST_F(LoggerTest, DebugLevel) {
+  Logger::initialize(std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::debug);
+  auto logger = Logger::instance();
+
+  logData(logger);
+
+  char *line = nullptr;
+  size_t len;
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 WARN: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 INFO: MSG\n");
+
+  getline(&line, &len, logFile);
+  EXPECT_STREQ(line, "0 DEBUG: MSG\n");
+
+  if (line) {
+    free(line);
+  }
+}

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -43,8 +43,10 @@ TEST_F(LoggerTest, OffLevel) {
   char *line = nullptr;
   size_t len;
 
+  fputs("EMPTY_FILE", logFile);
+
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "");
+  EXPECT_STREQ(line, "EMPTY_FILE");
 
   if (line) {
     free(line);


### PR DESCRIPTION
### Description of the Change

When I made the Logger PR I didn't think it would be reasonable to test it; however, I just learned that you can open an in-memory file using `open_memstream`, so here are some tests using that. Certified leak-free using Valgrind :)

### Applicable Issues

None.
