### PR TITLE
Issue #140: PID derivative filter

### DIFF
--- a/include/okapi/api/control/async/asyncPosPidController.hpp
+++ b/include/okapi/api/control/async/asyncPosPidController.hpp
@@ -20,10 +20,11 @@ namespace okapi {
 class AsyncPosPIDController : public AsyncWrapper<double, double>,
                               public AsyncPositionController<double, double> {
   public:
-  AsyncPosPIDController(std::shared_ptr<ControllerInput<double>> iinput,
-                        std::shared_ptr<ControllerOutput<double>> ioutput,
-                        const TimeUtil &itimeUtil, double ikP, double ikI, double ikD,
-                        double ikBias = 0);
+  AsyncPosPIDController(
+    std::shared_ptr<ControllerInput<double>> iinput,
+    std::shared_ptr<ControllerOutput<double>> ioutput, const TimeUtil &itimeUtil, double ikP,
+    double ikI, double ikD, double ikBias = 0,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 };
 } // namespace okapi
 

--- a/include/okapi/api/control/async/asyncVelPidController.hpp
+++ b/include/okapi/api/control/async/asyncVelPidController.hpp
@@ -20,10 +20,11 @@ namespace okapi {
 class AsyncVelPIDController : public AsyncWrapper<double, double>,
                               public AsyncVelocityController<double, double> {
   public:
-  AsyncVelPIDController(std::shared_ptr<ControllerInput<double>> iinput,
-                        std::shared_ptr<ControllerOutput<double>> ioutput,
-                        const TimeUtil &itimeUtil, double ikP, double ikD, double ikF,
-                        std::unique_ptr<VelMath> ivelMath);
+  AsyncVelPIDController(
+    std::shared_ptr<ControllerInput<double>> iinput,
+    std::shared_ptr<ControllerOutput<double>> ioutput, const TimeUtil &itimeUtil, double ikP,
+    double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 };
 } // namespace okapi
 

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -12,6 +12,8 @@
 
 #include "okapi/api/control/iterative/iterativePositionController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
+#include "okapi/api/filter/filter.hpp"
+#include "okapi/api/filter/passthroughFilter.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <memory>
@@ -28,14 +30,28 @@ class IterativePosPIDController : public IterativePositionController<double, dou
 
   /**
    * Position PID controller.
+   *
+   * @param ikP the proportional gain
+   * @param ikI the integration gain
+   * @param ikD the derivative gain
+   * @param ikBias the controller bias
+   * @param itimeUtil see TimeUtil docs
+   * @param iderivativeFilter a filter for filtering the derivative term
    */
-  IterativePosPIDController(double ikP, double ikI, double ikD, double ikBias,
-                            const TimeUtil &itimeUtil);
+  IterativePosPIDController(
+    double ikP, double ikI, double ikD, double ikBias, const TimeUtil &itimeUtil,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * Position PID controller.
+   *
+   * @param igains the controller gains
+   * @param itimeUtil see TimeUtil docs
+   * @param iderivativeFilter a filter for filtering the derivative term
    */
-  IterativePosPIDController(const Gains &igains, const TimeUtil &itimeUtil);
+  IterativePosPIDController(
+    const Gains &igains, const TimeUtil &itimeUtil,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * Do one iteration of the controller. Returns the reading in the range [-1, 1] unless the
@@ -165,6 +181,7 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   double lastReading = 0;
   double error = 0;
   double lastError = 0;
+  std::unique_ptr<Filter> derivativeFilter;
 
   // Integral bounds
   double integral = 0;

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -10,6 +10,7 @@
 
 #include "okapi/api/control/iterative/iterativeVelocityController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
+#include "okapi/api/filter/passthroughFilter.hpp"
 #include "okapi/api/filter/velMath.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
@@ -19,9 +20,17 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   public:
   /**
    * Velocity PD controller.
+   *
+   * @param ikP the proportional gain
+   * @param ikD the derivative gain
+   * @param ikF the feed-forward gain
+   * @param itimeUtil see TimeUtil docs
+   * @param iderivativeFilter a filter for filtering the derivative term
    */
-  IterativeVelPIDController(double ikP, double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
-                            const TimeUtil &itimeUtil);
+  IterativeVelPIDController(
+    double ikP, double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
+    const TimeUtil &itimeUtil,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * Do one iteration of the controller.
@@ -149,6 +158,7 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   bool isOn = true;
 
   std::unique_ptr<VelMath> velMath;
+  std::unique_ptr<Filter> derivativeFilter;
   std::unique_ptr<AbstractTimer> loopDtTimer;
   std::unique_ptr<SettledUtil> settledUtil;
 };

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -8,6 +8,7 @@
 #ifndef _OKAPI_ASYNCCONTROLLERFACTORY_HPP_
 #define _OKAPI_ASYNCCONTROLLERFACTORY_HPP_
 
+#include "okapi/api/chassis/controller/chassisController.hpp"
 #include "okapi/api/control/async/asyncMotionProfileController.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 #include "okapi/api/control/async/asyncPosPidController.hpp"
@@ -17,7 +18,6 @@
 #include "okapi/impl/device/motor/motor.hpp"
 #include "okapi/impl/device/motor/motorGroup.hpp"
 #include "okapi/impl/device/rotarysensor/adiEncoder.hpp"
-#include "okapi/api/chassis/controller/chassisController.hpp"
 
 namespace okapi {
 class AsyncControllerFactory {
@@ -59,8 +59,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikBias output bias (a constant added to the output)
    */
-  static AsyncPosPIDController posPID(Motor imotor, double ikP, double ikI, double ikD,
-                                      double ikBias = 0);
+  static AsyncPosPIDController
+  posPID(Motor imotor, double ikP, double ikI, double ikD, double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A position controller that uses the PID algorithm.
@@ -72,8 +73,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikBias output bias (a constant added to the output)
    */
-  static AsyncPosPIDController posPID(Motor imotor, ADIEncoder ienc, double ikP, double ikI,
-                                      double ikD, double ikBias = 0);
+  static AsyncPosPIDController
+  posPID(Motor imotor, ADIEncoder ienc, double ikP, double ikI, double ikD, double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A position controller that uses the PID algorithm.
@@ -84,8 +86,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikBias output bias (a constant added to the output)
    */
-  static AsyncPosPIDController posPID(MotorGroup imotor, double ikP, double ikI, double ikD,
-                                      double ikBias = 0);
+  static AsyncPosPIDController
+  posPID(MotorGroup imotor, double ikP, double ikI, double ikD, double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A position controller that uses the PID algorithm.
@@ -97,8 +100,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikBias output bias (a constant added to the output)
    */
-  static AsyncPosPIDController posPID(MotorGroup imotor, ADIEncoder ienc, double ikP, double ikI,
-                                      double ikD, double ikBias = 0);
+  static AsyncPosPIDController
+  posPID(MotorGroup imotor, ADIEncoder ienc, double ikP, double ikI, double ikD, double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A position controller that uses the PID algorithm.
@@ -110,9 +114,11 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikBias output bias (a constant added to the output)
    */
-  static AsyncPosPIDController posPID(std::shared_ptr<ControllerInput<double>> iinput,
-                                      std::shared_ptr<ControllerOutput<double>> ioutput, double ikP,
-                                      double ikI, double ikD, double ikBias = 0);
+  static AsyncPosPIDController
+  posPID(std::shared_ptr<ControllerInput<double>> iinput,
+         std::shared_ptr<ControllerOutput<double>> ioutput, double ikP, double ikI, double ikD,
+         double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A velocity controller that uses the PD algorithm.
@@ -122,8 +128,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static AsyncVelPIDController velPID(Motor imotor, double ikP, double ikD, double ikF = 0,
-                                      double iTPR = imev5TPR);
+  static AsyncVelPIDController
+  velPID(Motor imotor, double ikP, double ikD, double ikF = 0, double iTPR = imev5TPR,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A velocity controller that uses the PD algorithm.
@@ -134,8 +141,10 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static AsyncVelPIDController velPID(Motor imotor, ADIEncoder ienc, double ikP, double ikD,
-                                      double ikF = 0, double iTPR = imev5TPR);
+  static AsyncVelPIDController
+  velPID(Motor imotor, ADIEncoder ienc, double ikP, double ikD, double ikF = 0,
+         double iTPR = imev5TPR,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A velocity controller that uses the PD algorithm.
@@ -145,8 +154,9 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static AsyncVelPIDController velPID(MotorGroup imotor, double ikP, double ikD, double ikF = 0,
-                                      double iTPR = imev5TPR);
+  static AsyncVelPIDController
+  velPID(MotorGroup imotor, double ikP, double ikD, double ikF = 0, double iTPR = imev5TPR,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A velocity controller that uses the PD algorithm.
@@ -157,8 +167,10 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static AsyncVelPIDController velPID(MotorGroup imotor, ADIEncoder ienc, double ikP, double ikD,
-                                      double ikF = 0, double iTPR = imev5TPR);
+  static AsyncVelPIDController
+  velPID(MotorGroup imotor, ADIEncoder ienc, double ikP, double ikD, double ikF = 0,
+         double iTPR = imev5TPR,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A velocity controller that uses the PD algorithm.
@@ -169,9 +181,11 @@ class AsyncControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static AsyncVelPIDController velPID(std::shared_ptr<ControllerInput<double>> iinput,
-                                      std::shared_ptr<ControllerOutput<double>> ioutput, double ikP,
-                                      double ikD, double ikF = 0, double iTPR = imev5TPR);
+  static AsyncVelPIDController
+  velPID(std::shared_ptr<ControllerInput<double>> iinput,
+         std::shared_ptr<ControllerOutput<double>> ioutput, double ikP, double ikD, double ikF = 0,
+         double iTPR = imev5TPR,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * A controller which generates and follows 2D motion profiles.

--- a/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
+++ b/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
@@ -29,6 +29,18 @@ class IterativeControllerFactory {
   static IterativePosPIDController posPID(double ikP, double ikI, double ikD, double ikBias = 0);
 
   /**
+   * Position PID controller.
+   *
+   * @param ikP proportional gain
+   * @param ikI integral gain
+   * @param ikD derivative gain
+   * @param ikBias controller bias (constant offset added to the output)
+   * @param iderivativeFilter a filter for filtering the derivative term
+   */
+  static IterativePosPIDController posPID(double ikP, double ikI, double ikD, double ikBias,
+                                          std::unique_ptr<Filter> iderivativeFilter);
+
+  /**
    * Velocity PD controller.
    *
    * @param ikP proportional gain
@@ -36,6 +48,18 @@ class IterativeControllerFactory {
    * @param ikF feed-forward gain
    */
   static IterativeVelPIDController velPID(double ikP, double ikD, double ikF = 0,
+                                          const VelMathArgs &iparams = VelMathArgs(imev5TPR));
+
+  /**
+   * Velocity PD controller.
+   *
+   * @param ikP proportional gain
+   * @param ikD derivative gain
+   * @param ikF feed-forward gain
+   * @param iderivativeFilter a filter for filtering the derivative term
+   */
+  static IterativeVelPIDController velPID(double ikP, double ikD, double ikF,
+                                          std::unique_ptr<Filter> iderivativeFilter,
                                           const VelMathArgs &iparams = VelMathArgs(imev5TPR));
 
   /**

--- a/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
+++ b/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
@@ -26,19 +26,9 @@ class IterativeControllerFactory {
    * @param ikD derivative gain
    * @param ikBias controller bias (constant offset added to the output)
    */
-  static IterativePosPIDController posPID(double ikP, double ikI, double ikD, double ikBias = 0);
-
-  /**
-   * Position PID controller.
-   *
-   * @param ikP proportional gain
-   * @param ikI integral gain
-   * @param ikD derivative gain
-   * @param ikBias controller bias (constant offset added to the output)
-   * @param iderivativeFilter a filter for filtering the derivative term
-   */
-  static IterativePosPIDController posPID(double ikP, double ikI, double ikD, double ikBias,
-                                          std::unique_ptr<Filter> iderivativeFilter);
+  static IterativePosPIDController
+  posPID(double ikP, double ikI, double ikD, double ikBias = 0,
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * Velocity PD controller.
@@ -47,20 +37,9 @@ class IterativeControllerFactory {
    * @param ikD derivative gain
    * @param ikF feed-forward gain
    */
-  static IterativeVelPIDController velPID(double ikP, double ikD, double ikF = 0,
-                                          const VelMathArgs &iparams = VelMathArgs(imev5TPR));
-
-  /**
-   * Velocity PD controller.
-   *
-   * @param ikP proportional gain
-   * @param ikD derivative gain
-   * @param ikF feed-forward gain
-   * @param iderivativeFilter a filter for filtering the derivative term
-   */
-  static IterativeVelPIDController velPID(double ikP, double ikD, double ikF,
-                                          std::unique_ptr<Filter> iderivativeFilter,
-                                          const VelMathArgs &iparams = VelMathArgs(imev5TPR));
+  static IterativeVelPIDController
+  velPID(double ikP, double ikD, double ikF = 0, const VelMathArgs &iparams = VelMathArgs(imev5TPR),
+         std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
    * Velocity PD controller that automatically writes to the motor.

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -12,10 +12,11 @@ AsyncPosPIDController::AsyncPosPIDController(std::shared_ptr<ControllerInput<dou
                                              std::shared_ptr<ControllerOutput<double>> ioutput,
                                              const TimeUtil &itimeUtil, const double ikP,
                                              const double ikI, const double ikD,
-                                             const double ikBias)
-  : AsyncWrapper<double, double>(
-      iinput, ioutput,
-      std::make_unique<IterativePosPIDController>(ikP, ikI, ikD, ikBias, itimeUtil),
-      itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
+                                             const double ikBias,
+                                             std::unique_ptr<Filter> iderivativeFilter)
+  : AsyncWrapper<double, double>(iinput, ioutput,
+                                 std::make_unique<IterativePosPIDController>(
+                                   ikP, ikI, ikD, ikBias, itimeUtil, std::move(iderivativeFilter)),
+                                 itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
 }
 } // namespace okapi

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -13,10 +13,12 @@ AsyncVelPIDController::AsyncVelPIDController(std::shared_ptr<ControllerInput<dou
                                              std::shared_ptr<ControllerOutput<double>> ioutput,
                                              const TimeUtil &itimeUtil, const double ikP,
                                              const double ikD, const double ikF,
-                                             std::unique_ptr<VelMath> ivelMath)
+                                             std::unique_ptr<VelMath> ivelMath,
+                                             std::unique_ptr<Filter> iderivativeFilter)
   : AsyncWrapper<double, double>(
       iinput, ioutput,
-      std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, std::move(ivelMath), itimeUtil),
+      std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, std::move(ivelMath), itimeUtil,
+                                                  std::move(iderivativeFilter)),
       itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -14,10 +14,12 @@
 namespace okapi {
 IterativePosPIDController::IterativePosPIDController(const double ikP, const double ikI,
                                                      const double ikD, const double ikBias,
-                                                     const TimeUtil &itimeUtil)
+                                                     const TimeUtil &itimeUtil,
+                                                     std::unique_ptr<Filter> iderivativeFilter)
   : logger(Logger::instance()),
     loopDtTimer(std::move(itimeUtil.getTimer())),
-    settledUtil(std::move(itimeUtil.getSettledUtil())) {
+    settledUtil(std::move(itimeUtil.getSettledUtil())),
+    derivativeFilter(std::move(iderivativeFilter)) {
   if (ikI != 0) {
     setIntegralLimits(-1 / ikI, 1 / ikI);
   }
@@ -25,8 +27,10 @@ IterativePosPIDController::IterativePosPIDController(const double ikP, const dou
   setGains(ikP, ikI, ikD, ikBias);
 }
 
-IterativePosPIDController::IterativePosPIDController(const Gains &igains, const TimeUtil &itimeUtil)
-  : IterativePosPIDController(igains.kP, igains.kI, igains.kD, igains.kBias, itimeUtil) {
+IterativePosPIDController::IterativePosPIDController(const Gains &igains, const TimeUtil &itimeUtil,
+                                                     std::unique_ptr<Filter> iderivativeFilter)
+  : IterativePosPIDController(igains.kP, igains.kI, igains.kD, igains.kBias, itimeUtil,
+                              std::move(iderivativeFilter)) {
 }
 
 void IterativePosPIDController::setTarget(const double itarget) {
@@ -110,7 +114,7 @@ double IterativePosPIDController::step(const double inewReading) {
       integral = std::clamp(integral, integralMin, integralMax);
 
       // Derivative over measurement to eliminate derivative kick on setpoint change
-      derivative = inewReading - lastReading;
+      derivative = derivativeFilter->filter(inewReading - lastReading);
 
       output = std::clamp(kP * error + integral - kD * derivative + kBias, outputMin, outputMax);
 

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -14,9 +14,11 @@ namespace okapi {
 IterativeVelPIDController::IterativeVelPIDController(const double ikP, const double ikD,
                                                      const double ikF,
                                                      std::unique_ptr<VelMath> ivelMath,
-                                                     const TimeUtil &itimeUtil)
+                                                     const TimeUtil &itimeUtil,
+                                                     std::unique_ptr<Filter> iderivativeFilter)
   : logger(Logger::instance()),
     velMath(std::move(ivelMath)),
+    derivativeFilter(std::move(iderivativeFilter)),
     loopDtTimer(std::move(itimeUtil.getTimer())),
     settledUtil(std::move(itimeUtil.getSettledUtil())) {
   setGains(ikP, ikD, ikF);
@@ -62,7 +64,7 @@ double IterativeVelPIDController::step(const double inewReading) {
       error = target - velMath->getVelocity().convert(rpm);
 
       // Derivative over measurement to eliminate derivative kick on setpoint change
-      derivative = velMath->getAccel().getValue();
+      derivative = derivativeFilter->filter(velMath->getAccel().getValue());
 
       output += kP * error - kD * derivative;
       output = std::clamp(output, outputMin, outputMax);

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -30,78 +30,93 @@ AsyncVelIntegratedController AsyncControllerFactory::velIntegrated(MotorGroup im
 
 AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor, const double ikP,
                                                      const double ikI, const double ikD,
-                                                     const double ikBias) {
+                                                     const double ikBias,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncPosPIDController(imotor.getEncoder(), std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
+                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias,
+                               std::move(iderivativeFilter));
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikI,
-                                                     const double ikD, const double ikBias) {
+                                                     const double ikD, const double ikBias,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncPosPIDController(std::make_shared<ADIEncoder>(ienc), std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
+                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias,
+                               std::move(iderivativeFilter));
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikI,
-                                                     const double ikD, const double ikBias) {
+                                                     const double ikD, const double ikBias,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncPosPIDController(std::make_shared<ADIEncoder>(ienc),
                                std::make_shared<MotorGroup>(imotor), TimeUtilFactory::create(), ikP,
-                               ikI, ikD, ikBias);
+                               ikI, ikD, ikBias, std::move(iderivativeFilter));
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor, const double ikP,
                                                      const double ikI, const double ikD,
-                                                     const double ikBias) {
+                                                     const double ikBias,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncPosPIDController(imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
+                               TimeUtilFactory::create(), ikP, ikI, ikD, ikBias,
+                               std::move(iderivativeFilter));
 }
 
 AsyncPosPIDController
 AsyncControllerFactory::posPID(std::shared_ptr<ControllerInput<double>> iinput,
                                std::shared_ptr<ControllerOutput<double>> ioutput, const double ikP,
-                               const double ikI, const double ikD, const double ikBias) {
-  return AsyncPosPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikI, ikD, ikBias);
+                               const double ikI, const double ikD, const double ikBias,
+                               std::unique_ptr<Filter> iderivativeFilter) {
+  return AsyncPosPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikI, ikD, ikBias,
+                               std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, const double ikP,
                                                      const double ikD, const double ikF,
-                                                     const double iTPR) {
+                                                     const double iTPR,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<Motor>(imotor),
                                TimeUtilFactory::create(), ikP, ikD, ikF,
-                               VelMathFactory::createPtr(iTPR));
+                               VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR) {
+                                                     const double ikF, const double iTPR,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc), std::make_shared<Motor>(imotor),
                                TimeUtilFactory::create(), ikP, ikD, ikF,
-                               VelMathFactory::createPtr(iTPR));
+                               VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, const double ikP,
                                                      const double ikD, const double ikF,
-                                                     const double iTPR) {
+                                                     const double iTPR,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
                                TimeUtilFactory::create(), ikP, ikD, ikF,
-                               VelMathFactory::createPtr(iTPR));
+                               VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR) {
+                                                     const double ikF, const double iTPR,
+                                                     std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc),
                                std::make_shared<MotorGroup>(imotor), TimeUtilFactory::create(), ikP,
-                               ikD, ikF, VelMathFactory::createPtr(iTPR));
+                               ikD, ikF, VelMathFactory::createPtr(iTPR),
+                               std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController
 AsyncControllerFactory::velPID(std::shared_ptr<ControllerInput<double>> iinput,
                                std::shared_ptr<ControllerOutput<double>> ioutput, const double ikP,
-                               const double ikD, const double ikF, const double iTPR) {
+                               const double ikD, const double ikF, const double iTPR,
+                               std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikD, ikF,
-                               VelMathFactory::createPtr(iTPR));
+                               VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncMotionProfileController

--- a/src/impl/control/iterative/iterativeControllerFactory.cpp
+++ b/src/impl/control/iterative/iterativeControllerFactory.cpp
@@ -16,9 +16,24 @@ IterativePosPIDController IterativeControllerFactory::posPID(const double ikP, c
   return IterativePosPIDController(ikP, ikI, ikD, ikBias, TimeUtilFactory::create());
 }
 
+IterativePosPIDController
+IterativeControllerFactory::posPID(const double ikP, const double ikI, const double ikD,
+                                   const double ikBias, std::unique_ptr<Filter> iderivativeFilter) {
+  return IterativePosPIDController(ikP, ikI, ikD, ikBias, TimeUtilFactory::create(),
+                                   std::move(iderivativeFilter));
+}
+
 IterativeVelPIDController IterativeControllerFactory::velPID(const double ikP, const double ikD,
                                                              const double ikF,
                                                              const VelMathArgs &iparams) {
+  return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
+                                   TimeUtilFactory::create());
+}
+
+IterativeVelPIDController
+IterativeControllerFactory::velPID(const double ikP, const double ikD, const double ikF,
+                                   std::unique_ptr<Filter> iderivativeFilter,
+                                   const VelMathArgs &iparams) {
   return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
                                    TimeUtilFactory::create());
 }

--- a/src/impl/control/iterative/iterativeControllerFactory.cpp
+++ b/src/impl/control/iterative/iterativeControllerFactory.cpp
@@ -10,12 +10,6 @@
 #include "okapi/impl/util/timeUtilFactory.hpp"
 
 namespace okapi {
-IterativePosPIDController IterativeControllerFactory::posPID(const double ikP, const double ikI,
-                                                             const double ikD,
-                                                             const double ikBias) {
-  return IterativePosPIDController(ikP, ikI, ikD, ikBias, TimeUtilFactory::create());
-}
-
 IterativePosPIDController
 IterativeControllerFactory::posPID(const double ikP, const double ikI, const double ikD,
                                    const double ikBias, std::unique_ptr<Filter> iderivativeFilter) {
@@ -23,19 +17,12 @@ IterativeControllerFactory::posPID(const double ikP, const double ikI, const dou
                                    std::move(iderivativeFilter));
 }
 
-IterativeVelPIDController IterativeControllerFactory::velPID(const double ikP, const double ikD,
-                                                             const double ikF,
-                                                             const VelMathArgs &iparams) {
-  return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
-                                   TimeUtilFactory::create());
-}
-
 IterativeVelPIDController
 IterativeControllerFactory::velPID(const double ikP, const double ikD, const double ikF,
-                                   std::unique_ptr<Filter> iderivativeFilter,
-                                   const VelMathArgs &iparams) {
+                                   const VelMathArgs &iparams,
+                                   std::unique_ptr<Filter> iderivativeFilter) {
   return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
-                                   TimeUtilFactory::create());
+                                   TimeUtilFactory::create(), std::move(iderivativeFilter));
 }
 
 IterativeMotorVelocityController


### PR DESCRIPTION
### Description of the Change

Advanced users have been asking to have the ability to filter the derivative error out of the box. This PR adds this feature and makes the filter a `PassthroughFilter` by default.

### Verification Process

The tests still pass.

### Applicable Issues

Closes #140.
