### PR TITLE
Issue #142: Add another PID controller for turns

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -32,6 +32,7 @@ class ChassisControllerPID : public virtual ChassisController {
   ChassisControllerPID(const TimeUtil &itimeUtil, std::shared_ptr<ChassisModel> imodel,
                        std::unique_ptr<IterativePosPIDController> idistanceController,
                        std::unique_ptr<IterativePosPIDController> iangleController,
+                       std::unique_ptr<IterativePosPIDController> iturnController,
                        AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
                        const ChassisScales &iscales = ChassisScales({1, 1}));
 
@@ -108,6 +109,7 @@ class ChassisControllerPID : public virtual ChassisController {
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<IterativePosPIDController> distancePid;
   std::unique_ptr<IterativePosPIDController> anglePid;
+  std::unique_ptr<IterativePosPIDController> turnPid;
   const double gearRatio;
   const double straightScale;
   const double turnScale;

--- a/include/okapi/impl/chassis/controller/chassisControllerFactory.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerFactory.hpp
@@ -96,9 +96,49 @@ class ChassisControllerFactory {
    * @param iscales see ChassisScales docs
    */
   static ChassisControllerPID
+  create(Motor ileftSideMotor, Motor irightSideMotor,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
   create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
          const IterativePosPIDController::Gains &idistanceArgs,
          const IterativePosPIDController::Gains &iangleArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
          const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
 
@@ -130,6 +170,28 @@ class ChassisControllerFactory {
    *
    * @param ileftSideMotor left side motor
    * @param irightSideMotor right side motor
+   * @param ileftEnc left side encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor, ADIEncoder ileftEnc,
+         ADIEncoder irightEnc, const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
    * @param idistanceArgs distance PID controller params
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param igearset motor internal gearset and gear ratio
@@ -140,6 +202,50 @@ class ChassisControllerFactory {
          std::shared_ptr<AbstractMotor> irightSideMotor,
          std::shared_ptr<ContinuousRotarySensor> ileftEnc,
          std::shared_ptr<ContinuousRotarySensor> irightEnc,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(std::shared_ptr<AbstractMotor> ileftSideMotor,
+         std::shared_ptr<AbstractMotor> irightSideMotor,
+         std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+         std::shared_ptr<ContinuousRotarySensor> irightEnc,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor (also used for controller input)
+   * @param itopRightMotor top right motor (also used for controller input)
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
          const IterativePosPIDController::Gains &idistanceArgs,
          const IterativePosPIDController::Gains &iangleArgs,
          const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
@@ -163,6 +269,7 @@ class ChassisControllerFactory {
   create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
          const IterativePosPIDController::Gains &idistanceArgs,
          const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
          const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
 
@@ -209,6 +316,32 @@ class ChassisControllerFactory {
    * @param iscales see ChassisScales docs
    */
   static ChassisControllerPID
+  create(Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+         ADIEncoder itopLeftEnc, ADIEncoder itopRightEnc,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
   create(std::shared_ptr<AbstractMotor> itopLeftMotor,
          std::shared_ptr<AbstractMotor> itopRightMotor,
          std::shared_ptr<AbstractMotor> ibottomRightMotor,
@@ -217,6 +350,36 @@ class ChassisControllerFactory {
          std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
          const IterativePosPIDController::Gains &idistanceArgs,
          const IterativePosPIDController::Gains &iangleArgs,
+         const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+         const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static ChassisControllerPID
+  create(std::shared_ptr<AbstractMotor> itopLeftMotor,
+         std::shared_ptr<AbstractMotor> itopRightMotor,
+         std::shared_ptr<AbstractMotor> ibottomRightMotor,
+         std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+         std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+         std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+         const IterativePosPIDController::Gains &idistanceArgs,
+         const IterativePosPIDController::Gains &iangleArgs,
+         const IterativePosPIDController::Gains &iturnArgs,
          const AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
 };

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -13,11 +13,13 @@ ChassisControllerPID::ChassisControllerPID(
   const TimeUtil &itimeUtil, std::shared_ptr<ChassisModel> imodel,
   std::unique_ptr<IterativePosPIDController> idistanceController,
   std::unique_ptr<IterativePosPIDController> iangleController,
+  std::unique_ptr<IterativePosPIDController> iturnController,
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales)
   : ChassisController(imodel),
     rate(std::move(itimeUtil.getRate())),
     distancePid(std::move(idistanceController)),
     anglePid(std::move(iangleController)),
+    turnPid(std::move(iturnController)),
     gearRatio(igearset.ratio),
     straightScale(iscales.straight),
     turnScale(iscales.turn),
@@ -55,6 +57,7 @@ void ChassisControllerPID::loop() {
         encStartVals = model->getSensorVals();
         distancePid->reset();
         anglePid->reset();
+        turnPid->reset();
         model->stop();
       }
 
@@ -69,7 +72,7 @@ void ChassisControllerPID::loop() {
       case angle:
         encVals = model->getSensorVals() - encStartVals;
         angleChange = static_cast<double>(encVals[0] - encVals[1]);
-        model->rotate(anglePid->step(angleChange));
+        model->rotate(turnPid->step(angleChange));
 
         break;
       default:
@@ -97,6 +100,7 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   anglePid->reset();
   distancePid->flipDisable(false);
   anglePid->flipDisable(false);
+  turnPid->flipDisable(true);
   mode = distance;
 
   const double newTarget = itarget.convert(meter) * straightScale * gearRatio;
@@ -128,16 +132,17 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   logger->info("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
                " degrees");
 
-  anglePid->reset();
-  anglePid->flipDisable(false);
+  turnPid->reset();
+  turnPid->flipDisable(false);
   distancePid->flipDisable(true);
+  anglePid->flipDisable(true);
   mode = angle;
 
   const double newTarget = idegTarget.convert(degree) * turnScale * gearRatio;
 
   logger->info("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
 
-  anglePid->setTarget(newTarget);
+  turnPid->setTarget(newTarget);
 
   doneLooping = false;
 }
@@ -221,7 +226,7 @@ bool ChassisControllerPID::waitForDistanceSettled() {
 bool ChassisControllerPID::waitForAngleSettled() {
   logger->info("ChassisControllerPID: Waiting to settle in angle mode");
 
-  while (!anglePid->isSettled()) {
+  while (!turnPid->isSettled()) {
     if (mode == distance) {
       // False will cause the loop to re-enter the switch
       logger->warn("ChassisControllerPID: Mode changed to distance while waiting in angle!");
@@ -246,7 +251,7 @@ void ChassisControllerPID::stopAfterSettled() {
 
   case angle:
     doneLooping = true;
-    anglePid->flipDisable(true);
+    turnPid->flipDisable(true);
     model->stop();
     break;
 

--- a/src/impl/chassis/controller/chassisControllerFactory.cpp
+++ b/src/impl/chassis/controller/chassisControllerFactory.cpp
@@ -58,12 +58,24 @@ ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
                                  const IterativePosPIDController::Gains &iangleArgs,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
+  return create(ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset,
+                iscales);
+}
+
+ChassisControllerPID
+ChassisControllerFactory::create(Motor ileftSideMotor, Motor irightSideMotor,
+                                 const IterativePosPIDController::Gains &idistanceArgs,
+                                 const IterativePosPIDController::Gains &iangleArgs,
+                                 const IterativePosPIDController::Gains &iturnArgs,
+                                 const AbstractMotor::GearsetRatioPair igearset,
+                                 const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
   auto rightMtr = std::make_shared<Motor>(irightSideMotor);
   return ChassisControllerPID(
     TimeUtilFactory::create(), std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -73,12 +85,24 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSid
                                  const IterativePosPIDController::Gains &iangleArgs,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
+  return create(ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset,
+                iscales);
+}
+
+ChassisControllerPID
+ChassisControllerFactory::create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor,
+                                 const IterativePosPIDController::Gains &idistanceArgs,
+                                 const IterativePosPIDController::Gains &iangleArgs,
+                                 const IterativePosPIDController::Gains &iturnArgs,
+                                 const AbstractMotor::GearsetRatioPair igearset,
+                                 const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
   return ChassisControllerPID(
     TimeUtilFactory::create(), std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -89,12 +113,25 @@ ChassisControllerPID ChassisControllerFactory::create(
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  return create(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc, idistanceArgs, iangleArgs,
+                iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  MotorGroup ileftSideMotor, MotorGroup irightSideMotor, ADIEncoder ileftEnc, ADIEncoder irightEnc,
+  const IterativePosPIDController::Gains &idistanceArgs,
+  const IterativePosPIDController::Gains &iangleArgs,
+  const IterativePosPIDController::Gains &iturnArgs, const AbstractMotor::GearsetRatioPair igearset,
+  const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
   return ChassisControllerPID(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(leftMtr, rightMtr, std::make_shared<ADIEncoder>(ileftEnc),
                                      std::make_shared<ADIEncoder>(irightEnc)),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -105,11 +142,24 @@ ChassisControllerPID ChassisControllerFactory::create(
   const IterativePosPIDController::Gains &idistanceArgs,
   const IterativePosPIDController::Gains &iangleArgs,
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales) {
+  return create(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc, idistanceArgs, iangleArgs,
+                iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  std::shared_ptr<AbstractMotor> ileftSideMotor, std::shared_ptr<AbstractMotor> irightSideMotor,
+  std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+  std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  const IterativePosPIDController::Gains &idistanceArgs,
+  const IterativePosPIDController::Gains &iangleArgs,
+  const IterativePosPIDController::Gains &iturnArgs, const AbstractMotor::GearsetRatioPair igearset,
+  const ChassisScales &iscales) {
   return ChassisControllerPID(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -118,6 +168,16 @@ ChassisControllerPID ChassisControllerFactory::create(
   const IterativePosPIDController::Gains &idistanceArgs,
   const IterativePosPIDController::Gains &iangleArgs,
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales) {
+  return create(itopLeftMotor, itopRightMotor, ibottomRightMotor, ibottomLeftMotor, idistanceArgs,
+                iangleArgs, iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+  const IterativePosPIDController::Gains &idistanceArgs,
+  const IterativePosPIDController::Gains &iangleArgs,
+  const IterativePosPIDController::Gains &iturnArgs, const AbstractMotor::GearsetRatioPair igearset,
+  const ChassisScales &iscales) {
   auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
   auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
@@ -126,7 +186,8 @@ ChassisControllerPID ChassisControllerFactory::create(
     TimeUtilFactory::create(),
     std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -136,6 +197,17 @@ ChassisControllerPID ChassisControllerFactory::create(
   const IterativePosPIDController::Gains &idistanceArgs,
   const IterativePosPIDController::Gains &iangleArgs,
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales) {
+  return create(itopLeftMotor, itopRightMotor, ibottomRightMotor, ibottomLeftMotor, itopLeftEnc,
+                itopRightEnc, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  Motor itopLeftMotor, Motor itopRightMotor, Motor ibottomRightMotor, Motor ibottomLeftMotor,
+  ADIEncoder itopLeftEnc, ADIEncoder itopRightEnc,
+  const IterativePosPIDController::Gains &idistanceArgs,
+  const IterativePosPIDController::Gains &iangleArgs,
+  const IterativePosPIDController::Gains &iturnArgs, const AbstractMotor::GearsetRatioPair igearset,
+  const ChassisScales &iscales) {
   auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
   auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
@@ -146,7 +218,8 @@ ChassisControllerPID ChassisControllerFactory::create(
                                   std::make_shared<ADIEncoder>(itopLeftEnc),
                                   std::make_shared<ADIEncoder>(itopRightEnc)),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 
@@ -158,12 +231,26 @@ ChassisControllerPID ChassisControllerFactory::create(
   const IterativePosPIDController::Gains &idistanceArgs,
   const IterativePosPIDController::Gains &iangleArgs,
   const AbstractMotor::GearsetRatioPair igearset, const ChassisScales &iscales) {
+  return create(itopLeftMotor, itopRightMotor, ibottomRightMotor, ibottomLeftMotor, itopLeftEnc,
+                itopRightEnc, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
+}
+
+ChassisControllerPID ChassisControllerFactory::create(
+  std::shared_ptr<AbstractMotor> itopLeftMotor, std::shared_ptr<AbstractMotor> itopRightMotor,
+  std::shared_ptr<AbstractMotor> ibottomRightMotor, std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+  std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+  std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+  const IterativePosPIDController::Gains &idistanceArgs,
+  const IterativePosPIDController::Gains &iangleArgs,
+  const IterativePosPIDController::Gains &iturnArgs, const AbstractMotor::GearsetRatioPair igearset,
+  const ChassisScales &iscales) {
   return ChassisControllerPID(
     TimeUtilFactory::create(),
     std::make_shared<XDriveModel>(itopLeftMotor, itopRightMotor, ibottomRightMotor,
                                   ibottomLeftMotor, itopLeftEnc, itopRightEnc),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
-    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()), igearset,
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()), igearset,
     iscales);
 }
 } // namespace okapi

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -304,6 +304,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
 
     distanceController = new MockIterativeController();
     angleController = new MockIterativeController();
+    turnController = new MockIterativeController();
 
     model = new SkidSteerModel(std::unique_ptr<AbstractMotor>(leftMotor),
                                std::unique_ptr<AbstractMotor>(rightMotor));
@@ -312,6 +313,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
       new ChassisControllerPID(createTimeUtil(), std::shared_ptr<ChassisModel>(model),
                                std::unique_ptr<IterativePosPIDController>(distanceController),
                                std::unique_ptr<IterativePosPIDController>(angleController),
+                               std::unique_ptr<IterativePosPIDController>(turnController),
                                AbstractMotor::gearset::red, *scales);
   }
 
@@ -326,6 +328,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
   MockMotor *rightMotor;
   MockIterativeController *distanceController;
   MockIterativeController *angleController;
+  MockIterativeController *turnController;
   SkidSteerModel *model;
 };
 
@@ -335,6 +338,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceRawUnitsTest) {
   EXPECT_DOUBLE_EQ(distanceController->target, 100);
   EXPECT_DOUBLE_EQ(angleController->target, 0);
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
 
@@ -347,6 +351,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceUnitsTest) {
   EXPECT_DOUBLE_EQ(distanceController->target, 2);
   EXPECT_DOUBLE_EQ(angleController->target, 0);
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
 
@@ -359,11 +364,13 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncRawUnitsTest) {
   EXPECT_DOUBLE_EQ(distanceController->target, 100);
   EXPECT_DOUBLE_EQ(angleController->target, 0);
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_FALSE(distanceController->disabled);
   EXPECT_FALSE(angleController->disabled);
 
   controller->waitUntilSettled();
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
 
@@ -376,11 +383,13 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncUnitsTest) {
   EXPECT_DOUBLE_EQ(distanceController->target, 2);
   EXPECT_DOUBLE_EQ(angleController->target, 0);
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_FALSE(distanceController->disabled);
   EXPECT_FALSE(angleController->disabled);
 
   controller->waitUntilSettled();
 
+  EXPECT_TRUE(turnController->disabled);
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
 
@@ -390,9 +399,12 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleRawUnitsTest) {
   controller->turnAngle(100);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 100);
+  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(turnController->target, 100);
 
+  EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -400,9 +412,12 @@ TEST_F(ChassisControllerPIDTest, TurnAngleRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleUnitsTest) {
   controller->turnAngle(45_deg);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 90);
+  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(turnController->target, 90);
 
+  EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -410,13 +425,18 @@ TEST_F(ChassisControllerPIDTest, TurnAngleUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleAsyncRawUnitsTest) {
   controller->turnAngleAsync(100);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 100);
+  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(turnController->target, 100);
 
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(distanceController->disabled);
+  EXPECT_TRUE(angleController->disabled);
+  EXPECT_FALSE(turnController->disabled);
 
   controller->waitUntilSettled();
 
+  EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -424,13 +444,18 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAsyncRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleAsyncUnitsTest) {
   controller->turnAngleAsync(45_deg);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 90);
+  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(turnController->target, 90);
 
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(distanceController->disabled);
+  EXPECT_TRUE(angleController->disabled);
+  EXPECT_FALSE(turnController->disabled);
 
   controller->waitUntilSettled();
 
+  EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -443,18 +468,21 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
 
   EXPECT_FALSE(distanceController->disabled);
   EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 200);
+  EXPECT_DOUBLE_EQ(turnController->target, 200);
 
   EXPECT_TRUE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(angleController->disabled);
+  EXPECT_FALSE(turnController->disabled);
 
   controller->waitUntilSettled();
 
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -462,10 +490,11 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 200);
+  EXPECT_DOUBLE_EQ(turnController->target, 200);
 
   EXPECT_TRUE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(angleController->disabled);
+  EXPECT_FALSE(turnController->disabled);
 
   controller->moveDistanceAsync(100);
 
@@ -474,11 +503,13 @@ TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
 
   EXPECT_FALSE(distanceController->disabled);
   EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   controller->waitUntilSettled();
 
   EXPECT_TRUE(distanceController->disabled);
   EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->disabled);
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a third PID controller to `ChassisControllerPID` so there are separate PID controllers for turns and for angle correction. By default, the turn PID controller and the angle correction PID controller will share the same set of gains, as was the case before this change.

### Benefits

Often times having one set of gains for both turns and angle correction does not work optimally in both cases. This change lets users have a different set of gains for each case.

### Possible Drawbacks

None.

### Verification Process

The existing tests were extended to test the new controller.

### Applicable Issues

Closes #142.
