### PR TITLE
Issue #150: Don't set logfile to NULL file ptr

### DIFF
--- a/src/api/util/logging.cpp
+++ b/src/api/util/logging.cpp
@@ -28,15 +28,22 @@ Logger *Logger::instance() noexcept {
 void Logger::initialize(std::unique_ptr<AbstractTimer> itimer, std::string_view filename,
                         Logger::LogLevel level) noexcept {
   timer = std::move(itimer);
-  logfile = fopen(filename.data(), "w");
   logLevel = level;
+
+  FILE *log = fopen(filename.data(), "w");
+  if (log) {
+    logfile = log;
+  }
 }
 
 void Logger::initialize(std::unique_ptr<AbstractTimer> itimer, FILE *file,
                         Logger::LogLevel level) noexcept {
   timer = std::move(itimer);
-  logfile = file;
   logLevel = level;
+
+  if (file) {
+    logfile = file;
+  }
 }
 
 void Logger::setLogLevel(Logger::LogLevel level) noexcept {


### PR DESCRIPTION
### Description of the Change

The Logger currently blindly opens files. This is usually fine since it checks for a non-null file every time something is Logged, but if the user wants to change the file, the Logger shouldn't switch from a valid file to a null file.

### Verification Process

The logger tests still pass.

### Applicable Issues

Closes #150.
