### PR TITLE
Issue #149: Change default error sum bounds

### DIFF
--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -14,6 +14,7 @@
 #include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
+#include <limits>
 #include <memory>
 
 namespace okapi {
@@ -108,8 +109,9 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   virtual void setIntegralLimits(double imax, double imin);
 
   /**
-   * Set the error sum bounds. Default bounds are [500, 1250]. Error will only be added to the
-   * integral term when its absolute value between these bounds of either side of the target.
+   * Set the error sum bounds. Default bounds are [0, std::numeric_limits<double>::max()]. Error
+   * will only be added to the integral term when its absolute value is between these bounds of
+   * either side of the target.
    *
    * @param imax max error value that will be summed
    * @param imin min error value that will be summed
@@ -172,8 +174,8 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   double integralMin = -1;
 
   // Error will only be added to the integral term within these bounds on either side of the target
-  double errorSumMin = 500;
-  double errorSumMax = 1250;
+  double errorSumMin = 0;
+  double errorSumMax = std::numeric_limits<double>::max();
 
   double derivative = 0;
 

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -174,6 +174,8 @@ std::unique_ptr<SettledUtil> createSettledUtilPtr(double iatTargetError = 50,
 
 TimeUtil createTimeUtil();
 
+TimeUtil createConstantTimeUtil(QTime idt);
+
 TimeUtil createTimeUtil(const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier);
 
 TimeUtil createTimeUtil(const Supplier<std::unique_ptr<SettledUtil>> &isettledUtilSupplier);

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -86,6 +86,36 @@ TEST_F(IterativeControllerTest, IterativeVelPIDControllerFeedForwardOnly) {
   }
 }
 
+class IterativePosPIDControllerTest : public ::testing::Test {
+  protected:
+  virtual void SetUp() {
+    controller = new IterativePosPIDController(0.1, 0, 0, 0, createConstantTimeUtil(10_ms));
+  }
+
+  virtual void TearDown() {
+    delete controller;
+  }
+
+  IterativePosPIDController *controller;
+};
+
+TEST_F(IterativePosPIDControllerTest, BasicKpTest) {
+  EXPECT_DOUBLE_EQ(controller->step(1), 0.1 * -1);
+}
+
+TEST_F(IterativePosPIDControllerTest, DefaultErrorBounds_ErrorOfZero) {
+  EXPECT_DOUBLE_EQ(controller->step(0), 0);
+}
+
+TEST_F(IterativePosPIDControllerTest, DefaultErrorBounds_ErrorOfOne) {
+  EXPECT_DOUBLE_EQ(controller->step(1), 0.1 * -1);
+}
+
+TEST_F(IterativePosPIDControllerTest, DefaultErrorBounds_LargeError) {
+  const double largeError = 10000000000000;
+  EXPECT_DOUBLE_EQ(controller->step(largeError), -1);
+}
+
 TEST_F(IterativeControllerTest, IterativeMotorVelocityController) {
   class MockIterativeVelPIDController : public IterativeVelPIDController {
     public:

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -255,6 +255,14 @@ TimeUtil createTimeUtil() {
     Supplier<std::unique_ptr<SettledUtil>>([]() { return createSettledUtilPtr(); }));
 }
 
+TimeUtil createConstantTimeUtil(const QTime idt) {
+  return TimeUtil(
+    Supplier<std::unique_ptr<AbstractTimer>>(
+      [=]() { return std::make_unique<ConstantMockTimer>(idt); }),
+    Supplier<std::unique_ptr<AbstractRate>>([]() { return std::make_unique<MockRate>(); }),
+    Supplier<std::unique_ptr<SettledUtil>>([]() { return createSettledUtilPtr(); }));
+}
+
 TimeUtil createTimeUtil(const Supplier<std::unique_ptr<AbstractTimer>> &itimerSupplier) {
   return TimeUtil(itimerSupplier, Supplier<std::unique_ptr<AbstractRate>>([]() {
                     return std::make_unique<MockRate>();


### PR DESCRIPTION
### Description of the Change

Lachlan pointed out to me that the current error sum bounds of `(500, 1250)` make no sense. For the record, these came out of a conversation I had with Jason and made sense for the Cortex platform, but they aren't relevant anymore for V5. The new bounds are `(0, std::numeric_limits<double>::max())`  so the controller always integrates. Users can them if they want better performance.

### Benefits

The integrator should behave closer to what people expect.

### Possible Drawbacks

None.

### Verification Process

Some new tests were added for the integrator bounds.

### Applicable Issues

Closes #149.
