### PR TITLE
Issue #157: Fix logger test

### DIFF
--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -18,7 +18,8 @@ class LoggerTest : public ::testing::Test {
   }
 
   virtual void TearDown() {
-    fclose(logFile);
+    // Call close after every case so other tests don't end up with a NULL logfile pointer
+    Logger::instance()->close();
     free(logBuffer);
   }
 


### PR DESCRIPTION
### Description of the Change

When fixing #156 I ran into a problem where the Travis build segfaulted because the Logger test did not clean up after itself, so there was a nullptr floating around.

### Benefits

No segfaults :)

### Possible Drawbacks

None.

### Verification Process

The tests on this branch still pass, and this change fixed the build for #156.

### Applicable Issues

Closes #157.
