### PR TITLE
Issue #153: Add a constant to VelPID for static friction

### DIFF
--- a/include/okapi/api/control/async/asyncVelPidController.hpp
+++ b/include/okapi/api/control/async/asyncVelPidController.hpp
@@ -23,7 +23,7 @@ class AsyncVelPIDController : public AsyncWrapper<double, double>,
   AsyncVelPIDController(
     std::shared_ptr<ControllerInput<double>> iinput,
     std::shared_ptr<ControllerOutput<double>> ioutput, const TimeUtil &itimeUtil, double ikP,
-    double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
+    double ikD, double ikF, double ikSF, std::unique_ptr<VelMath> ivelMath,
     std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 };
 } // namespace okapi

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -24,11 +24,12 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
    * @param ikP the proportional gain
    * @param ikD the derivative gain
    * @param ikF the feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    * @param itimeUtil see TimeUtil docs
    * @param iderivativeFilter a filter for filtering the derivative term
    */
   IterativeVelPIDController(
-    double ikP, double ikD, double ikF, std::unique_ptr<VelMath> ivelMath,
+    double ikP, double ikD, double ikF, double ikSF, std::unique_ptr<VelMath> ivelMath,
     const TimeUtil &itimeUtil,
     std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
@@ -129,9 +130,10 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
    *
    * @param ikP proportional gain
    * @param ikD derivative gain
-   * @param ikBias controller bias
+   * @param ikF the feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
-  virtual void setGains(double ikP, double ikD, double ikF);
+  virtual void setGains(double ikP, double ikD, double ikF, double ikSF);
 
   /**
    * Sets the number of encoder ticks per revolution. Default is 1800.
@@ -147,7 +149,7 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
 
   protected:
   Logger *logger;
-  double kP, kD, kF;
+  double kP, kD, kF, kSF;
   QTime sampleTime = 10_ms;
   double error = 0;
   double derivative = 0;

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -157,9 +157,11 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
-  velPID(Motor imotor, double ikP, double ikD, double ikF = 0, double iTPR = imev5TPR,
+  velPID(Motor imotor, double ikP, double ikD, double ikF = 0, double ikSF = 0,
+         double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
@@ -170,9 +172,10 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
-  velPID(Motor imotor, ADIEncoder ienc, double ikP, double ikD, double ikF = 0,
+  velPID(Motor imotor, ADIEncoder ienc, double ikP, double ikD, double ikF = 0, double ikSF = 0,
          double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
@@ -184,9 +187,10 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
-  velPID(Motor imotor, Potentiometer ipot, double ikP, double ikD, double ikF = 0,
+  velPID(Motor imotor, Potentiometer ipot, double ikP, double ikD, double ikF = 0, double ikSF = 0,
          double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
@@ -197,9 +201,11 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
-  velPID(MotorGroup imotor, double ikP, double ikD, double ikF = 0, double iTPR = imev5TPR,
+  velPID(MotorGroup imotor, double ikP, double ikD, double ikF = 0, double ikSF = 0,
+         double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
@@ -210,10 +216,11 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
   velPID(MotorGroup imotor, ADIEncoder ienc, double ikP, double ikD, double ikF = 0,
-         double iTPR = imev5TPR,
+         double ikSF = 0, double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
@@ -224,10 +231,11 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
   velPID(MotorGroup imotor, Potentiometer ipot, double ikP, double ikD, double ikF = 0,
-         double iTPR = imev5TPR,
+         double ikSF = 0, double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
@@ -238,11 +246,12 @@ class AsyncControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static AsyncVelPIDController
   velPID(std::shared_ptr<ControllerInput<double>> iinput,
          std::shared_ptr<ControllerOutput<double>> ioutput, double ikP, double ikD, double ikF = 0,
-         double iTPR = imev5TPR,
+         double ikSF = 0, double iTPR = imev5TPR,
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**

--- a/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
+++ b/include/okapi/impl/control/iterative/iterativeControllerFactory.hpp
@@ -36,9 +36,11 @@ class IterativeControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static IterativeVelPIDController
-  velPID(double ikP, double ikD, double ikF = 0, const VelMathArgs &iparams = VelMathArgs(imev5TPR),
+  velPID(double ikP, double ikD, double ikF = 0, double ikSF = 0,
+         const VelMathArgs &iparams = VelMathArgs(imev5TPR),
          std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>());
 
   /**
@@ -48,9 +50,10 @@ class IterativeControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static IterativeMotorVelocityController
-  motorVelocity(Motor imotor, double ikP, double ikD, double ikF = 0,
+  motorVelocity(Motor imotor, double ikP, double ikD, double ikF = 0, double ikSF = 0,
                 const VelMathArgs &iparams = VelMathArgs(imev5TPR));
 
   /**
@@ -60,9 +63,10 @@ class IterativeControllerFactory {
    * @param ikP proportional gain
    * @param ikD derivative gain
    * @param ikF feed-forward gain
+   * @param ikSF a feed-forward gain to counteract static friction
    */
   static IterativeMotorVelocityController
-  motorVelocity(MotorGroup imotor, double ikP, double ikD, double ikF = 0,
+  motorVelocity(MotorGroup imotor, double ikP, double ikD, double ikF = 0, double ikSF = 0,
                 const VelMathArgs &iparams = VelMathArgs(imev5TPR));
 
   /**

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -12,13 +12,13 @@ namespace okapi {
 AsyncVelPIDController::AsyncVelPIDController(std::shared_ptr<ControllerInput<double>> iinput,
                                              std::shared_ptr<ControllerOutput<double>> ioutput,
                                              const TimeUtil &itimeUtil, const double ikP,
-                                             const double ikD, const double ikF,
+                                             const double ikD, const double ikF, const double ikSF,
                                              std::unique_ptr<VelMath> ivelMath,
                                              std::unique_ptr<Filter> iderivativeFilter)
   : AsyncWrapper<double, double>(
       iinput, ioutput,
-      std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, std::move(ivelMath), itimeUtil,
-                                                  std::move(iderivativeFilter)),
+      std::make_unique<IterativeVelPIDController>(ikP, ikD, ikF, ikSF, std::move(ivelMath),
+                                                  itimeUtil, std::move(iderivativeFilter)),
       itimeUtil.getRateSupplier(), itimeUtil.getSettledUtil()) {
 }
 } // namespace okapi

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -93,66 +93,71 @@ AsyncControllerFactory::posPID(std::shared_ptr<ControllerInput<double>> iinput,
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, const double ikP,
                                                      const double ikD, const double ikF,
-                                                     const double iTPR,
+                                                     const double ikSF, const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(), ikP, ikD, ikF,
+                               TimeUtilFactory::create(), ikP, ikD, ikF, ikSF,
                                VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR,
+                                                     const double ikF, const double ikSF,
+                                                     const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc), std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(), ikP, ikD, ikF,
+                               TimeUtilFactory::create(), ikP, ikD, ikF, ikSF,
                                VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor, Potentiometer ipot,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR,
+                                                     const double ikF, const double ikSF,
+                                                     const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<Potentiometer>(ipot),
                                std::make_shared<Motor>(imotor), TimeUtilFactory::create(), ikP, ikD,
-                               ikF, VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
+                               ikF, ikSF, VelMathFactory::createPtr(iTPR),
+                               std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, const double ikP,
                                                      const double ikD, const double ikF,
-                                                     const double iTPR,
+                                                     const double ikSF, const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(imotor.getEncoder(), std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(), ikP, ikD, ikF,
+                               TimeUtilFactory::create(), ikP, ikD, ikF, ikSF,
                                VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, ADIEncoder ienc,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR,
+                                                     const double ikF, const double ikSF,
+                                                     const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc),
                                std::make_shared<MotorGroup>(imotor), TimeUtilFactory::create(), ikP,
-                               ikD, ikF, VelMathFactory::createPtr(iTPR),
+                               ikD, ikF, ikSF, VelMathFactory::createPtr(iTPR),
                                std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor, Potentiometer ipot,
                                                      const double ikP, const double ikD,
-                                                     const double ikF, const double iTPR,
+                                                     const double ikF, const double ikSF,
+                                                     const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
   return AsyncVelPIDController(std::make_shared<Potentiometer>(ipot),
                                std::make_shared<MotorGroup>(imotor), TimeUtilFactory::create(), ikP,
-                               ikD, ikF, VelMathFactory::createPtr(iTPR),
+                               ikD, ikF, ikSF, VelMathFactory::createPtr(iTPR),
                                std::move(iderivativeFilter));
 }
 
 AsyncVelPIDController
 AsyncControllerFactory::velPID(std::shared_ptr<ControllerInput<double>> iinput,
                                std::shared_ptr<ControllerOutput<double>> ioutput, const double ikP,
-                               const double ikD, const double ikF, const double iTPR,
+                               const double ikD, const double ikF, const double ikSF, const double iTPR,
                                std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikD, ikF,
+  return AsyncVelPIDController(iinput, ioutput, TimeUtilFactory::create(), ikP, ikD, ikF, ikSF,
                                VelMathFactory::createPtr(iTPR), std::move(iderivativeFilter));
 }
 

--- a/src/impl/control/iterative/iterativeControllerFactory.cpp
+++ b/src/impl/control/iterative/iterativeControllerFactory.cpp
@@ -19,26 +19,28 @@ IterativeControllerFactory::posPID(const double ikP, const double ikI, const dou
 
 IterativeVelPIDController
 IterativeControllerFactory::velPID(const double ikP, const double ikD, const double ikF,
-                                   const VelMathArgs &iparams,
+                                   const double ikSF, const VelMathArgs &iparams,
                                    std::unique_ptr<Filter> iderivativeFilter) {
-  return IterativeVelPIDController(ikP, ikD, ikF, VelMathFactory::createPtr(iparams),
+  return IterativeVelPIDController(ikP, ikD, ikF, ikSF, VelMathFactory::createPtr(iparams),
                                    TimeUtilFactory::create(), std::move(iderivativeFilter));
 }
 
 IterativeMotorVelocityController
-IterativeControllerFactory::motorVelocity(Motor imotor, double ikP, double ikD, double ikF,
+IterativeControllerFactory::motorVelocity(Motor imotor, const double ikP, const double ikD,
+                                          const double ikF, const double ikSF,
                                           const VelMathArgs &iparams) {
   return IterativeMotorVelocityController(
     std::make_shared<Motor>(imotor),
-    std::make_shared<IterativeVelPIDController>(velPID(ikP, ikD, ikF, iparams)));
+    std::make_shared<IterativeVelPIDController>(velPID(ikP, ikD, ikF, ikSF, iparams)));
 }
 
 IterativeMotorVelocityController
-IterativeControllerFactory::motorVelocity(MotorGroup imotor, double ikP, double ikD, double ikF,
+IterativeControllerFactory::motorVelocity(MotorGroup imotor, const double ikP, const double ikD,
+                                          const double ikF, const double ikSF,
                                           const VelMathArgs &iparams) {
   return IterativeMotorVelocityController(
     std::make_shared<MotorGroup>(imotor),
-    std::make_shared<IterativeVelPIDController>(velPID(ikP, ikD, ikF, iparams)));
+    std::make_shared<IterativeVelPIDController>(velPID(ikP, ikD, ikF, ikSF, iparams)));
 }
 
 IterativeMotorVelocityController IterativeControllerFactory::motorVelocity(

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -36,7 +36,7 @@ void assertControllerIsSettledWhenDisabled(ClosedLoopController<double, double> 
   EXPECT_TRUE(controller.isSettled());
 }
 
-class IterativeControllerTest : public ::testing::Test {
+class IterativeControllerWithSimulatorTest : public ::testing::Test {
   protected:
   virtual void SetUp() {
     sim.setExternalTorqueFunction([](double, double, double) { return 0; });
@@ -53,7 +53,7 @@ class IterativeControllerTest : public ::testing::Test {
   FlywheelSimulator sim;
 };
 
-TEST_F(IterativeControllerTest, IterativePosPIDControllerTest) {
+TEST_F(IterativeControllerWithSimulatorTest, IterativePosPIDControllerTest) {
   IterativePosPIDController controller(
     0.004, 0, 0, 0, createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>([]() {
       return std::make_unique<ConstantMockTimer>(10_ms);
@@ -65,9 +65,9 @@ TEST_F(IterativeControllerTest, IterativePosPIDControllerTest) {
   EXPECT_NE(controller.getError(), 0);
 }
 
-TEST_F(IterativeControllerTest, IterativeVelPIDController) {
+TEST_F(IterativeControllerWithSimulatorTest, IterativeVelPIDController) {
   IterativeVelPIDController controller(
-    0.000015, 0, 0,
+    0.000015, 0, 0, 0,
     std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
                               std::make_unique<ConstantMockTimer>(10_ms)),
     createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
@@ -79,9 +79,9 @@ TEST_F(IterativeControllerTest, IterativeVelPIDController) {
   EXPECT_NE(controller.getError(), 0);
 }
 
-TEST_F(IterativeControllerTest, IterativeVelPIDControllerFeedForwardOnly) {
+TEST_F(IterativeControllerWithSimulatorTest, IterativeVelPIDControllerFeedForwardOnly) {
   IterativeVelPIDController controller(
-    0, 0, 0.1,
+    0, 0, 0.1, 0,
     std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
                               std::make_unique<ConstantMockTimer>(10_ms)),
     createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
@@ -128,12 +128,12 @@ TEST_F(IterativePosPIDControllerTest, SettledWhenDisabled) {
   assertControllerIsSettledWhenDisabled(*controller);
 }
 
-TEST_F(IterativeControllerTest, IterativeMotorVelocityController) {
+TEST(IterativeMotorVelocityControllerTest, IterativeMotorVelocityController) {
   class MockIterativeVelPIDController : public IterativeVelPIDController {
     public:
     MockIterativeVelPIDController()
       : IterativeVelPIDController(
-          0, 0, 0,
+          0, 0, 0, 0,
           std::make_unique<VelMath>(imev5TPR, std::make_shared<AverageFilter<2>>(),
                                     std::make_unique<ConstantMockTimer>(10_ms)),
           createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
@@ -219,15 +219,45 @@ TEST_F(AsyncControllerTest, AsyncVelIntegratedController) {
   assertControllerFollowsTargetLifecycle(AsyncVelIntegratedController(motor, createTimeUtil()));
 }
 
-TEST(IterativeVelPIDControllerTest, SettledWhenDisabled) {
-  IterativeVelPIDController controller(
-    0, 0, 0.1,
-    std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
-                              std::make_unique<ConstantMockTimer>(10_ms)),
-    createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
-      []() { return std::make_unique<ConstantMockTimer>(10_ms); })));
+class IterativeVelPIDControllerTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    controller = new IterativeVelPIDController(
+      0, 0, 0, 0,
+      std::make_unique<VelMath>(1800, std::make_shared<PassthroughFilter>(),
+                                std::make_unique<ConstantMockTimer>(10_ms)),
+      createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
+        []() { return std::make_unique<ConstantMockTimer>(10_ms); })));
+  }
 
-  assertControllerIsSettledWhenDisabled(controller);
+  void TearDown() override {
+    delete controller;
+  }
+
+  IterativeVelPIDController *controller;
+};
+
+TEST_F(IterativeVelPIDControllerTest, SettledWhenDisabled) {
+  controller->setGains(0.1, 0.1, 0.1, 0.1);
+  assertControllerIsSettledWhenDisabled(*controller);
+}
+
+TEST_F(IterativeVelPIDControllerTest, StaticFrictionGainUsesTargetSign) {
+  controller->setGains(0, 0, 0, 0.1);
+
+  controller->setTarget(1);
+  EXPECT_DOUBLE_EQ(controller->step(0), 1 * 0.1);
+
+  // Use the same target but send the error to 0 to make sure the gain is applied to the target and
+  // not the error
+  EXPECT_DOUBLE_EQ(controller->step(1), 1 * 0.1);
+
+  controller->setTarget(-1);
+  EXPECT_DOUBLE_EQ(controller->step(0), -1 * 0.1);
+
+  // Use the same target but send the error to 0 to make sure the gain is applied to the target and
+  // not the error
+  EXPECT_DOUBLE_EQ(controller->step(-1), -1 * 0.1);
 }
 
 TEST(AsyncPosIntegratedControllerTest, SettledWhenDisabled) {


### PR DESCRIPTION
### Description of the Change

A more correct form of feed-forward control in the velocity domain is:
`kV * targetVel + kConst * sign(targetVel)`. This PR adds that extra gain and calls it `kSF` for Static Friction.

This is covered in this paper https://www.chiefdelphi.com/media/papers/download/5212

### Benefits

Better velocity control for those who want to configure it.

### Possible Drawbacks

A small API break.

### Verification Process

New tests were added.

### Applicable Issues

Closes #153.
