### PR TITLE
Issue #147: Run memcheck and massif with builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" .. # .. is now the source dir
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
   - ./OkapiLibV5
-  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --expensive-definedness-checks=yes --error-exitcode=1 ./OkapiLibV5
-  - valgrind --tool=massif --error-exitcode=1 --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
+  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --expensive-definedness-checks=yes --error-exitcode=1 --suppressions=../memcheck-suppressions.txt ./OkapiLibV5
+  - valgrind --tool=massif --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
   - ms_print massif.out.txt
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
             - gcc-arm-embedded
             - g++-7
             - lcov
+            - valgrind
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
@@ -38,7 +39,7 @@ script:
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
   - ./OkapiLibV5
   - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --expensive-definedness-checks=yes --error-exitcode=1 ./OkapiLibV5
-  - valgrind --tool=massif --error-exitcode=2 --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
+  - valgrind --tool=massif --error-exitcode=1 --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
   - ms_print massif.out.txt
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" .. # .. is now the source dir
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
   - ./OkapiLibV5
-  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes  --error-exitcode=1 --show-reachable=no --suppressions=../memcheck-suppressions.txt ./OkapiLibV5 # --expensive-definedness-checks=yes
+  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes  --error-exitcode=1 --show-reachable=no ./OkapiLibV5 # --expensive-definedness-checks=yes
   - valgrind --tool=massif --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
   - ms_print massif.out.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" .. # .. is now the source dir
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
   - ./OkapiLibV5
-  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --expensive-definedness-checks=yes --error-exitcode=1 --suppressions=../memcheck-suppressions.txt ./OkapiLibV5
+  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --error-exitcode=1 --suppressions=../memcheck-suppressions.txt ./OkapiLibV5 # --expensive-definedness-checks=yes
   - valgrind --tool=massif --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
   - ms_print massif.out.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" .. # .. is now the source dir
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
   - ./OkapiLibV5
-  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --error-exitcode=1 --suppressions=../memcheck-suppressions.txt ./OkapiLibV5 # --expensive-definedness-checks=yes
+  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes  --error-exitcode=1 --show-reachable=no --suppressions=../memcheck-suppressions.txt ./OkapiLibV5 # --expensive-definedness-checks=yes
   - valgrind --tool=massif --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
   - ms_print massif.out.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,10 @@ script:
   - cd cmake-build-debug
   - cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" .. # .. is now the source dir
   - cmake --build . --target OkapiLibV5 -- -j 2 # . is the build dir
-  - ./OkapiLibV5 # run the tests
+  - ./OkapiLibV5
+  - valgrind --tool=memcheck --leak-check=full --leak-resolution=med --show-leak-kinds=all --undef-value-errors=yes --track-origins=yes --expensive-definedness-checks=yes --error-exitcode=1 ./OkapiLibV5
+  - valgrind --tool=massif --error-exitcode=2 --stacks=yes --time-unit=B --massif-out-file=massif.out.txt ./OkapiLibV5
+  - ms_print massif.out.txt
 
 after_success:
   - lcov --directory . --capture --output-file coverage.info # capture coverage info

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -125,8 +125,8 @@ class ChassisControllerPID : public virtual ChassisController {
   bool waitForAngleSettled();
   void stopAfterSettled();
 
-  typedef enum { distance, angle } modeType;
-  modeType mode;
+  typedef enum { distance, angle, none } modeType;
+  modeType mode{none};
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -108,8 +108,7 @@ class ChassisControllerPID : public virtual ChassisController {
   void stop() override;
 
   /**
-   * Start the internal thread to loop the PID controllers. This should not be called by normal
-   * users.
+   * Starts the internal thread. This should not be called by normal users.
    */
   void startThread();
 

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -108,7 +108,8 @@ class ChassisControllerPID : public virtual ChassisController {
   void stop() override;
 
   /**
-   * Starts the internal thread. This should not be called by normal users.
+   * Starts the internal thread. This should not be called by normal users. This method is called
+   * by the ChassisControllerFactory when making a new instance of this class.
    */
   void startThread();
 

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -37,6 +37,8 @@ class ChassisControllerPID : public virtual ChassisController {
                        AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
                        const ChassisScales &iscales = ChassisScales({1, 1}));
 
+  ChassisControllerPID(ChassisControllerPID &&other) noexcept;
+
   ~ChassisControllerPID() override;
 
   /**
@@ -105,6 +107,10 @@ class ChassisControllerPID : public virtual ChassisController {
    */
   void stop() override;
 
+  /**
+   * Start the internal thread to loop the PID controllers. This should not be called by normal
+   * users.
+   */
   void startThread();
 
   protected:

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -105,6 +105,8 @@ class ChassisControllerPID : public virtual ChassisController {
    */
   void stop() override;
 
+  void startThread();
+
   protected:
   Logger *logger;
   std::unique_ptr<AbstractRate> rate;
@@ -114,7 +116,6 @@ class ChassisControllerPID : public virtual ChassisController {
   const double gearRatio;
   const double straightScale;
   const double turnScale;
-  CrossplatformThread task;
   bool doneLooping{true};
   bool dtorCalled{false};
 
@@ -127,6 +128,8 @@ class ChassisControllerPID : public virtual ChassisController {
 
   typedef enum { distance, angle, none } modeType;
   modeType mode{none};
+
+  CrossplatformThread *task{nullptr};
 };
 } // namespace okapi
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -132,7 +132,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   bool isDisabled() const override;
 
   /**
-   * Starts the internal thread. This should not be called by normal users.
+   * Starts the internal thread. This should not be called by normal users. This method is called
+   * by the AsyncControllerFactory when making a new instance of this class.
    */
   void startThread();
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -46,6 +46,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
                                std::shared_ptr<ChassisModel> imodel,
                                QLength iwidth);
 
+  AsyncMotionProfileController(AsyncMotionProfileController &&other) noexcept;
+
   ~AsyncMotionProfileController() override;
 
   /**
@@ -129,6 +131,11 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   bool isDisabled() const override;
 
+  /**
+   * Starts the internal thread. This should not be called by normal users.
+   */
+  void startThread();
+
   protected:
   struct TrajectoryPair {
     Segment *left;
@@ -136,6 +143,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
     int length;
   };
 
+  Logger *logger;
   std::map<std::string, TrajectoryPair> paths{};
   double maxVel{0};
   double maxAccel{0};
@@ -143,13 +151,12 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   std::shared_ptr<ChassisModel> model;
   QLength width{11_in};
   TimeUtil timeUtil;
-  Logger *logger;
 
-  CrossplatformThread task;
   bool dtorCalled{false};
   std::string currentPath{""};
   bool isRunning{false};
   bool disabled{false};
+  CrossplatformThread *task{nullptr};
 
   static void trampoline(void *context);
   void loop();

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -45,10 +45,26 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       input(iinput),
       output(ioutput),
       controller(std::move(icontroller)),
-      loopRate(std::move(irateSupplier.get())),
-      settledRate(std::move(irateSupplier.get())),
-      settledUtil(std::move(isettledUtil)),
-      task(trampoline, this) {
+      loopRate(irateSupplier.get()),
+      settledRate(irateSupplier.get()),
+      settledUtil(std::move(isettledUtil)) {
+  }
+
+  AsyncWrapper(AsyncWrapper<Input, Output> &&other)
+    : logger(other.logger),
+      input(std::move(other.input)),
+      output(std::move(other.output)),
+      controller(std::move(other.controller)),
+      loopRate(std::move(other.loopRate)),
+      settledRate(std::move(other.settledRate)),
+      settledUtil(std::move(other.settledUtil)),
+      dtorCalled(other.dtorCalled),
+      task(other.task) {
+  }
+
+  ~AsyncWrapper() override {
+    dtorCalled = true;
+    delete task;
   }
 
   /**
@@ -164,6 +180,15 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
     logger->info("AsyncWrapper: Done waiting to settle");
   }
 
+  /**
+   * Starts the internal thread. This should not be called by normal users.
+   */
+  void startThread() {
+    if (!task) {
+      task = new CrossplatformThread(trampoline, this);
+    }
+  }
+
   protected:
   Logger *logger;
   std::shared_ptr<ControllerInput<Input>> input;
@@ -172,7 +197,8 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   std::unique_ptr<AbstractRate> loopRate;
   std::unique_ptr<AbstractRate> settledRate;
   std::unique_ptr<SettledUtil> settledUtil;
-  CrossplatformThread task;
+  bool dtorCalled{false};
+  CrossplatformThread *task;
 
   static void trampoline(void *context) {
     if (context) {
@@ -183,7 +209,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   void loop() {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
-    while (true) {
+    while (!dtorCalled) {
       if (!controller->isDisabled()) {
         output->controllerSet(controller->step(input->controllerGet()));
       }

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -50,7 +50,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       settledUtil(std::move(isettledUtil)) {
   }
 
-  AsyncWrapper(AsyncWrapper<Input, Output> &&other)
+  AsyncWrapper(AsyncWrapper<Input, Output> &&other) noexcept
     : logger(other.logger),
       input(std::move(other.input)),
       output(std::move(other.output)),
@@ -198,7 +198,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   std::unique_ptr<AbstractRate> settledRate;
   std::unique_ptr<SettledUtil> settledUtil;
   bool dtorCalled{false};
-  CrossplatformThread *task;
+  CrossplatformThread *task{nullptr};
 
   static void trampoline(void *context) {
     if (context) {

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -181,7 +181,8 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Starts the internal thread. This should not be called by normal users.
+   * Starts the internal thread. This should not be called by normal users. This method is called
+   * by the AsyncControllerFactory when making a new instance of this class.
    */
   void startThread() {
     if (!task) {

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -322,13 +322,13 @@ class AsyncControllerFactory {
    * @param imaxVel The maximum possible velocity.
    * @param imaxAccel The maximum possible acceleration.
    * @param imaxJerk The maximum possible jerk.
-   * @param imodel The chassis model to control.
+   * @param imodel The chassis to control.
    * @param iwidth The chassis wheelbase width.
    */
   static AsyncMotionProfileController motionProfile(double imaxVel,
                                                     double imaxAccel,
                                                     double imaxJerk,
-                                                    std::shared_ptr<SkidSteerModel> imodel,
+                                                    const ChassisController &ichassis,
                                                     QLength iwidth);
 
   /**
@@ -337,13 +337,13 @@ class AsyncControllerFactory {
    * @param imaxVel The maximum possible velocity.
    * @param imaxAccel The maximum possible acceleration.
    * @param imaxJerk The maximum possible jerk.
-   * @param imodel The chassis to control.
+   * @param imodel The chassis model to control.
    * @param iwidth The chassis wheelbase width.
    */
   static AsyncMotionProfileController motionProfile(double imaxVel,
                                                     double imaxAccel,
                                                     double imaxJerk,
-                                                    const ChassisController &ichassis,
+                                                    std::shared_ptr<ChassisModel> imodel,
                                                     QLength iwidth);
 };
 } // namespace okapi

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -322,7 +322,7 @@ class AsyncControllerFactory {
    * @param imaxVel The maximum possible velocity.
    * @param imaxAccel The maximum possible acceleration.
    * @param imaxJerk The maximum possible jerk.
-   * @param imodel The chassis to control.
+   * @param ichassis The chassis to control.
    * @param iwidth The chassis wheelbase width.
    */
   static AsyncMotionProfileController motionProfile(double imaxVel,

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -232,36 +232,12 @@ class SimulatedSystem : public ControllerInput<double>, public ControllerOutput<
 
 class MockAsyncController : public AsyncPosIntegratedController {
   public:
-  MockAsyncController()
-    : AsyncPosIntegratedController(std::make_shared<MockMotor>(), createTimeUtil()) {
-  }
+  MockAsyncController();
 
-  explicit MockAsyncController(const TimeUtil &itimeUtil)
-    : AsyncPosIntegratedController(std::make_shared<MockMotor>(), itimeUtil) {
-  }
-
-  void waitUntilSettled() override;
-
-  void setTarget(double itarget) override;
-
-  double getError() const override;
+  explicit MockAsyncController(const TimeUtil &itimeUtil);
 
   bool isSettled() override;
 
-  void reset() override;
-
-  void flipDisable() override;
-
-  void flipDisable(bool iisDisabled) override;
-
-  bool isDisabled() const override;
-
-  double output{0};
-  QTime sampleTime = 10_ms;
-  double maxOutput{1};
-  double minOutput{-1};
-  double target{0};
-  bool disabled{false};
   bool isSettledOverride{true};
 };
 

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -269,44 +269,10 @@ class MockIterativeController : public IterativePosPIDController {
   public:
   MockIterativeController();
 
-  double step(double inewReading) override;
-
-  void setTarget(double itarget) override;
-
-  double getOutput() const override;
-
-  double getError() const override;
+  MockIterativeController(double ikP);
 
   bool isSettled() override;
 
-  void setGains(double ikP, double ikI, double ikD, double ikBias) override;
-
-  void setSampleTime(QTime isampleTime) override;
-
-  void setOutputLimits(double imax, double imin) override;
-
-  void setIntegralLimits(double imax, double imin) override;
-
-  void setErrorSumLimits(double imax, double imin) override;
-
-  void reset() override;
-
-  void setIntegratorReset(bool iresetOnZero) override;
-
-  void flipDisable() override;
-
-  void flipDisable(bool iisDisabled) override;
-
-  bool isDisabled() const override;
-
-  QTime getSampleTime() const override;
-
-  double output{0};
-  QTime sampleTime = 10_ms;
-  double maxOutput{1};
-  double minOutput{-1};
-  double target{0};
-  bool disabled{false};
   bool isSettledOverride{true};
 };
 

--- a/memcheck-suppressions.txt
+++ b/memcheck-suppressions.txt
@@ -1,7 +1,0 @@
-{
-   pathfinder_trajectorycandidate_saptr_laptr_leak
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:pathfinder_prepare
-}

--- a/memcheck-suppressions.txt
+++ b/memcheck-suppressions.txt
@@ -1,0 +1,7 @@
+{
+   pathfinder_trajectorycandidate_saptr_laptr_leak
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:pathfinder_prepare
+}

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -38,6 +38,7 @@ ChassisControllerPID::ChassisControllerPID(
 
 ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcept
   : ChassisController(std::move(other.model)),
+    logger(other.logger),
     rate(std::move(other.rate)),
     distancePid(std::move(other.distancePid)),
     anglePid(std::move(other.anglePid)),
@@ -45,6 +46,10 @@ ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcep
     gearRatio(other.gearRatio),
     straightScale(other.straightScale),
     turnScale(other.turnScale),
+    doneLooping(other.doneLooping),
+    dtorCalled(other.dtorCalled),
+    newMovement(other.newMovement),
+    mode(other.mode),
     task(other.task) {
   other.task = nullptr;
 }

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -25,7 +25,9 @@ ChassisControllerPID::ChassisControllerPID(
     gearRatio(igearset.ratio),
     straightScale(iscales.straight),
     turnScale(iscales.turn),
-    task(trampoline, this) {
+    task(trampoline, this),
+    doneLooping(false),
+    dtorCalled(false) {
   if (igearset.ratio == 0) {
     logger->error("ChassisControllerPID: The gear ratio cannot be zero! Check if you are using "
                   "integer division.");

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -24,10 +24,7 @@ ChassisControllerPID::ChassisControllerPID(
     turnPid(std::move(iturnController)),
     gearRatio(igearset.ratio),
     straightScale(iscales.straight),
-    turnScale(iscales.turn),
-    task(trampoline, this),
-    doneLooping(false),
-    dtorCalled(false) {
+    turnScale(iscales.turn) {
   if (igearset.ratio == 0) {
     logger->error("ChassisControllerPID: The gear ratio cannot be zero! Check if you are using "
                   "integer division.");
@@ -41,6 +38,7 @@ ChassisControllerPID::ChassisControllerPID(
 
 ChassisControllerPID::~ChassisControllerPID() {
   dtorCalled = true;
+  delete task;
 }
 
 void ChassisControllerPID::loop() {
@@ -249,5 +247,9 @@ void ChassisControllerPID::stopAfterSettled() {
 void ChassisControllerPID::stop() {
   stopAfterSettled();
   ChassisController::stop();
+}
+
+void ChassisControllerPID::startThread() {
+  task = new CrossplatformThread(trampoline, this);
 }
 } // namespace okapi

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -36,6 +36,19 @@ ChassisControllerPID::ChassisControllerPID(
   setEncoderUnits(AbstractMotor::encoderUnits::degrees);
 }
 
+ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcept
+  : ChassisController(std::move(other.model)),
+    rate(std::move(other.rate)),
+    distancePid(std::move(other.distancePid)),
+    anglePid(std::move(other.anglePid)),
+    turnPid(std::move(other.turnPid)),
+    gearRatio(other.gearRatio),
+    straightScale(other.straightScale),
+    turnScale(other.turnScale),
+    task(other.task) {
+  other.task = nullptr;
+}
+
 ChassisControllerPID::~ChassisControllerPID() {
   dtorCalled = true;
   delete task;
@@ -244,6 +257,8 @@ void ChassisControllerPID::stop() {
 }
 
 void ChassisControllerPID::startThread() {
-  task = new CrossplatformThread(trampoline, this);
+  if (!task) {
+    task = new CrossplatformThread(trampoline, this);
+  }
 }
 } // namespace okapi

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -68,7 +68,7 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
       Waypoint{point.x.convert(meter), point.y.convert(meter), point.theta.convert(radian)});
   }
 
-  TrajectoryCandidate *candidate = new TrajectoryCandidate();
+  TrajectoryCandidate candidate;
   logger->info("AsyncMotionProfileController: Preparing trajectory");
   pathfinder_prepare(points.data(),
                      static_cast<int>(points.size()),
@@ -78,9 +78,9 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                      maxVel,
                      maxAccel,
                      maxJerk,
-                     candidate);
+                     &candidate);
 
-  const int length = candidate->length;
+  const int length = candidate.length;
 
   if (length < 0) {
     auto pointToString = [](Waypoint point) {
@@ -96,13 +96,22 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                       [&](std::string a, Waypoint b) { return a + ", " + pointToString(b); });
 
     logger->error(message);
+
+    if (candidate.laptr) {
+      free(candidate.laptr);
+    }
+
+    if (candidate.saptr) {
+      free(candidate.saptr);
+    }
+
     throw std::runtime_error(message);
   }
 
   auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
 
   logger->info("AsyncMotionProfileController: Generating path");
-  pathfinder_generate(candidate, trajectory);
+  pathfinder_generate(&candidate, trajectory);
 
   auto *leftTrajectory = (Segment *)malloc(sizeof(Segment) * length);
   auto *rightTrajectory = (Segment *)malloc(sizeof(Segment) * length);
@@ -111,9 +120,6 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
   pathfinder_modify_tank(trajectory, length, leftTrajectory, rightTrajectory, width.convert(meter));
 
   free(trajectory);
-  free(candidate->laptr);
-  free(candidate->saptr);
-  delete candidate;
 
   auto oldPath = paths.find(ipathId);
   if (oldPath != paths.end()) {

--- a/src/impl/chassis/controller/chassisControllerFactory.cpp
+++ b/src/impl/chassis/controller/chassisControllerFactory.cpp
@@ -84,7 +84,7 @@ ChassisControllerFactory::create(Motor ileftSideMotor,
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
   auto rightMtr = std::make_shared<Motor>(irightSideMotor);
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
@@ -92,6 +92,8 @@ ChassisControllerFactory::create(Motor ileftSideMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -115,7 +117,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
@@ -123,6 +125,8 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -159,7 +163,7 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  const ChassisScales &iscales) {
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(leftMtr,
                                      rightMtr,
@@ -170,6 +174,8 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -202,7 +208,7 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                  const IterativePosPIDController::Gains &iturnArgs,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
@@ -210,6 +216,8 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> ileftSideMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -246,7 +254,7 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
   auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
   auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
     std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
@@ -254,6 +262,8 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -296,7 +306,7 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
   auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
   auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
   auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<XDriveModel>(topLeftMtr,
                                   topRightMtr,
@@ -309,6 +319,8 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 
 ChassisControllerPID
@@ -347,7 +359,7 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> itopLeftMotor,
                                  const IterativePosPIDController::Gains &iturnArgs,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
-  return ChassisControllerPID(
+  ChassisControllerPID out(
     TimeUtilFactory::create(),
     std::make_shared<XDriveModel>(itopLeftMotor,
                                   itopRightMotor,
@@ -360,5 +372,7 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> itopLeftMotor,
     std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
     igearset,
     iscales);
+  out.startThread();
+  return out;
 }
 } // namespace okapi

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -34,14 +34,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(imotor.getEncoder(),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(imotor.getEncoder(),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor,
@@ -51,14 +53,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(std::make_shared<ADIEncoder>(ienc),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(std::make_shared<ADIEncoder>(ienc),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor,
@@ -68,14 +72,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(Motor imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(std::make_shared<Potentiometer>(ipot),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(std::make_shared<Potentiometer>(ipot),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
@@ -84,14 +90,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(imotor.getEncoder(),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(imotor.getEncoder(),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
@@ -101,14 +109,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(std::make_shared<ADIEncoder>(ienc),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(std::make_shared<ADIEncoder>(ienc),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
@@ -118,14 +128,16 @@ AsyncPosPIDController AsyncControllerFactory::posPID(MotorGroup imotor,
                                                      const double ikD,
                                                      const double ikBias,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(std::make_shared<Potentiometer>(ipot),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(std::make_shared<Potentiometer>(ipot),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncPosPIDController
@@ -136,14 +148,16 @@ AsyncControllerFactory::posPID(std::shared_ptr<ControllerInput<double>> iinput,
                                const double ikD,
                                const double ikBias,
                                std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncPosPIDController(iinput,
-                               ioutput,
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikI,
-                               ikD,
-                               ikBias,
-                               std::move(iderivativeFilter));
+  AsyncPosPIDController out(iinput,
+                            ioutput,
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikI,
+                            ikD,
+                            ikBias,
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
@@ -153,15 +167,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(imotor.getEncoder(),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(imotor.getEncoder(),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
@@ -172,15 +188,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(std::make_shared<ADIEncoder>(ienc),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
@@ -191,15 +209,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(Motor imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(std::make_shared<Potentiometer>(ipot),
-                               std::make_shared<Motor>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(std::make_shared<Potentiometer>(ipot),
+                            std::make_shared<Motor>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
@@ -209,15 +229,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(imotor.getEncoder(),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(imotor.getEncoder(),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
@@ -228,15 +250,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(std::make_shared<ADIEncoder>(ienc),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(std::make_shared<ADIEncoder>(ienc),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
@@ -247,15 +271,17 @@ AsyncVelPIDController AsyncControllerFactory::velPID(MotorGroup imotor,
                                                      const double ikSF,
                                                      const double iTPR,
                                                      std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(std::make_shared<Potentiometer>(ipot),
-                               std::make_shared<MotorGroup>(imotor),
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(std::make_shared<Potentiometer>(ipot),
+                            std::make_shared<MotorGroup>(imotor),
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncVelPIDController
@@ -267,15 +293,17 @@ AsyncControllerFactory::velPID(std::shared_ptr<ControllerInput<double>> iinput,
                                const double ikSF,
                                const double iTPR,
                                std::unique_ptr<Filter> iderivativeFilter) {
-  return AsyncVelPIDController(iinput,
-                               ioutput,
-                               TimeUtilFactory::create(),
-                               ikP,
-                               ikD,
-                               ikF,
-                               ikSF,
-                               VelMathFactory::createPtr(iTPR),
-                               std::move(iderivativeFilter));
+  AsyncVelPIDController out(iinput,
+                            ioutput,
+                            TimeUtilFactory::create(),
+                            ikP,
+                            ikD,
+                            ikF,
+                            ikSF,
+                            VelMathFactory::createPtr(iTPR),
+                            std::move(iderivativeFilter));
+  out.startThread();
+  return out;
 }
 
 AsyncMotionProfileController

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -310,19 +310,21 @@ AsyncMotionProfileController
 AsyncControllerFactory::motionProfile(double imaxVel,
                                       double imaxAccel,
                                       double imaxJerk,
-                                      std::shared_ptr<SkidSteerModel> imodel,
+                                      const ChassisController &ichassis,
                                       QLength iwidth) {
-  return AsyncMotionProfileController(
-    TimeUtilFactory::create(), imaxVel, imaxAccel, imaxJerk, imodel, iwidth);
+  return motionProfile(imaxVel, imaxAccel, imaxJerk, ichassis.getChassisModel(), iwidth);
 }
 
 AsyncMotionProfileController
 AsyncControllerFactory::motionProfile(double imaxVel,
                                       double imaxAccel,
                                       double imaxJerk,
-                                      const ChassisController &ichassis,
+                                      std::shared_ptr<ChassisModel> imodel,
                                       QLength iwidth) {
-  return AsyncMotionProfileController(
-    TimeUtilFactory::create(), imaxVel, imaxAccel, imaxJerk, ichassis.getChassisModel(), iwidth);
+  AsyncMotionProfileController out(
+    TimeUtilFactory::create(), imaxVel, imaxAccel, imaxJerk, imodel, iwidth);
+  out.startThread();
+  return out;
 }
+
 } // namespace okapi

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -24,6 +24,7 @@ void opcontrol() {
   pros::Task::delay(100);
 
   Logger::initialize(std::make_unique<Timer>(), "/ser/sout", Logger::LogLevel::debug);
+  auto logger = Logger::instance();
 
   //  {
   //    auto model =
@@ -35,20 +36,26 @@ void opcontrol() {
   //    cnt.waitUntilSettled();
   //  }
 
-  auto drive = ChassisControllerFactory::create(-1,
-                                                2,
-                                                IterativePosPIDController::Gains{0.01, 0, 0, 0},
-                                                IterativePosPIDController::Gains{0, 0, 0, 0},
-                                                IterativePosPIDController::Gains{0.007, 0, 0, 0},
-                                                AbstractMotor::gearset::red,
-                                                {2.5_in, 10.5_in});
-  drive.startThread();
-  drive.moveDistanceAsync(2_in);
-  drive.waitUntilSettled();
-  drive.moveDistanceAsync(2_in);
-  drive.waitUntilSettled();
-  drive.moveDistanceAsync(2_in);
-  drive.waitUntilSettled();
+  auto drive = ChassisControllerFactory::create(
+    -1,
+    2,
+    //                                                IterativePosPIDController::Gains{0.01, 0, 0,
+    //                                                0}, IterativePosPIDController::Gains{0, 0, 0,
+    //                                                0}, IterativePosPIDController::Gains{0.007, 0,
+    //                                                0, 0},
+    AbstractMotor::gearset::red,
+    {2.5_in, 10.5_in});
+  //  drive.moveDistanceAsync(2_in);
+  //  drive.waitUntilSettled();
+  //  drive.moveDistanceAsync(2_in);
+  //  drive.waitUntilSettled();
+  //  drive.moveDistanceAsync(2_in);
+  //  drive.waitUntilSettled();
+
+  auto cnt = AsyncControllerFactory::posPID(2, 0.01, 0, 0);
+  cnt.setTarget(360);
+  cnt.waitUntilSettled();
+  logger->debug("opcontrol: position: " + std::to_string(Motor(2).getPosition()));
 
   //  runHeadlessTests();
   return;

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -42,6 +42,12 @@ void opcontrol() {
                                                 IterativePosPIDController::Gains{0.007, 0, 0, 0},
                                                 AbstractMotor::gearset::red,
                                                 {2.5_in, 10.5_in});
+  drive.startThread();
+  drive.moveDistanceAsync(2_in);
+  drive.waitUntilSettled();
+  drive.moveDistanceAsync(2_in);
+  drive.waitUntilSettled();
+  drive.moveDistanceAsync(2_in);
   drive.waitUntilSettled();
 
   //  runHeadlessTests();

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -580,3 +580,11 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAndStopTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
   EXPECT_TRUE(angleController->isDisabled());
 }
+
+TEST_F(ChassisControllerPIDTest, WaitUntilSettledInModeNone) {
+  controller->waitUntilSettled();
+
+  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->disabled);
+  EXPECT_TRUE(angleController->disabled);
+}

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -67,11 +67,11 @@ class ChassisControllerIntegratedTest : public ::testing::Test {
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceRawUnitsTest) {
   controller->moveDistance(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, 100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -79,11 +79,11 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceRawUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceUnitsTest) {
   controller->moveDistance(1_m);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 2);
-  EXPECT_DOUBLE_EQ(rightController->target, 2);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 2);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 2);
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -91,16 +91,16 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncRawUnitsTest) {
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, 100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -108,19 +108,19 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncRawUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncUnitsTest) {
   controller->moveDistanceAsync(1_m);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 2);
-  EXPECT_DOUBLE_EQ(rightController->target, 2);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 2);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 2);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_DOUBLE_EQ(leftController->target, 2);
-  EXPECT_DOUBLE_EQ(rightController->target, 2);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 2);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 2);
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -128,11 +128,11 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, TurnAngleRawUnitsTest) {
   controller->turnAngle(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, -100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -100);
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -140,11 +140,11 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleRawUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, TurnAngleUnitsTest) {
   controller->turnAngle(45_deg);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 90);
-  EXPECT_DOUBLE_EQ(rightController->target, -90);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 90);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -90);
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -152,16 +152,16 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncRawUnitsTest) {
   controller->turnAngleAsync(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, -100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -100);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -169,16 +169,16 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncRawUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncUnitsTest) {
   controller->turnAngleAsync(45_deg);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 90);
-  EXPECT_DOUBLE_EQ(rightController->target, -90);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 90);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -90);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -186,24 +186,24 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncUnitsTest) {
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, 100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 200);
-  EXPECT_DOUBLE_EQ(rightController->target, -200);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 200);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -200);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -211,24 +211,24 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
 TEST_F(ChassisControllerIntegratedTest, TurnAngleThenMoveDistanceAsyncTest) {
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 200);
-  EXPECT_DOUBLE_EQ(rightController->target, -200);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 200);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), -200);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(leftController->target, 100);
-  EXPECT_DOUBLE_EQ(rightController->target, 100);
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
 
-  EXPECT_FALSE(leftController->disabled);
-  EXPECT_FALSE(rightController->disabled);
+  EXPECT_FALSE(leftController->isDisabled());
+  EXPECT_FALSE(rightController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(leftController->disabled);
-  EXPECT_TRUE(rightController->disabled);
+  EXPECT_TRUE(leftController->isDisabled());
+  EXPECT_TRUE(rightController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -304,9 +304,9 @@ class ChassisControllerPIDTest : public ::testing::Test {
     leftMotor = new MockMotor();
     rightMotor = new MockMotor();
 
-    distanceController = new MockIterativeController();
-    angleController = new MockIterativeController();
-    turnController = new MockIterativeController();
+    distanceController = new MockIterativeController(0.1);
+    angleController = new MockIterativeController(0.1);
+    turnController = new MockIterativeController(0.1);
 
     model = new SkidSteerModel(std::unique_ptr<AbstractMotor>(leftMotor),
                                std::unique_ptr<AbstractMotor>(rightMotor));
@@ -319,6 +319,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
                                std::unique_ptr<IterativePosPIDController>(turnController),
                                AbstractMotor::gearset::red,
                                *scales);
+    controller->startThread();
   }
 
   void TearDown() override {
@@ -327,7 +328,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
   }
 
   ChassisScales *scales;
-  ChassisController *controller;
+  ChassisControllerPID *controller;
   MockMotor *leftMotor;
   MockMotor *rightMotor;
   MockIterativeController *distanceController;
@@ -339,12 +340,12 @@ class ChassisControllerPIDTest : public ::testing::Test {
 TEST_F(ChassisControllerPIDTest, MoveDistanceRawUnitsTest) {
   controller->moveDistance(100);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 100);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -352,12 +353,12 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, MoveDistanceUnitsTest) {
   controller->moveDistance(1_m);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 2);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 2);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -365,18 +366,18 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceUnitsTest) {
 TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncRawUnitsTest) {
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 100);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_FALSE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_FALSE(distanceController->isDisabled());
+  EXPECT_FALSE(angleController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -384,18 +385,18 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncUnitsTest) {
   controller->moveDistanceAsync(1_m);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 2);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 2);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_FALSE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_FALSE(distanceController->isDisabled());
+  EXPECT_FALSE(angleController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -403,12 +404,12 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleRawUnitsTest) {
   controller->turnAngle(100);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
-  EXPECT_DOUBLE_EQ(turnController->target, 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 100);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -416,12 +417,12 @@ TEST_F(ChassisControllerPIDTest, TurnAngleRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleUnitsTest) {
   controller->turnAngle(45_deg);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
-  EXPECT_DOUBLE_EQ(turnController->target, 90);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 90);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -429,18 +430,18 @@ TEST_F(ChassisControllerPIDTest, TurnAngleUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleAsyncRawUnitsTest) {
   controller->turnAngleAsync(100);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
-  EXPECT_DOUBLE_EQ(turnController->target, 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 100);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_FALSE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_FALSE(turnController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -448,18 +449,18 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAsyncRawUnitsTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleAsyncUnitsTest) {
   controller->turnAngleAsync(45_deg);
 
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
-  EXPECT_DOUBLE_EQ(turnController->target, 90);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 90);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_FALSE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_FALSE(turnController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -467,26 +468,26 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAsyncUnitsTest) {
 TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 100);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_FALSE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_FALSE(distanceController->isDisabled());
+  EXPECT_FALSE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(turnController->target, 200);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 200);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_FALSE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_FALSE(turnController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -494,26 +495,26 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
 TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
   controller->turnAngleAsync(200);
 
-  EXPECT_DOUBLE_EQ(turnController->target, 200);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), 200);
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_FALSE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_FALSE(turnController->isDisabled());
 
   controller->moveDistanceAsync(100);
 
-  EXPECT_DOUBLE_EQ(distanceController->target, 100);
-  EXPECT_DOUBLE_EQ(angleController->target, 0);
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
 
-  EXPECT_FALSE(distanceController->disabled);
-  EXPECT_FALSE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_FALSE(distanceController->isDisabled());
+  EXPECT_FALSE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
-  EXPECT_TRUE(turnController->disabled);
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
+  EXPECT_TRUE(turnController->isDisabled());
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
@@ -584,7 +585,7 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAndStopTest) {
 TEST_F(ChassisControllerPIDTest, WaitUntilSettledInModeNone) {
   controller->waitUntilSettled();
 
-  EXPECT_TRUE(turnController->disabled);
-  EXPECT_TRUE(distanceController->disabled);
-  EXPECT_TRUE(angleController->disabled);
+  EXPECT_TRUE(turnController->isDisabled());
+  EXPECT_TRUE(distanceController->isDisabled());
+  EXPECT_TRUE(angleController->isDisabled());
 }

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -399,6 +399,7 @@ class AsyncMotionProfileControllerTest : public ::testing::Test {
 
     controller = new AsyncMotionProfileController(
       createTimeUtil(), 1.0, 2.0, 10.0, std::shared_ptr<SkidSteerModel>(model), 10.5_in);
+    controller->startThread();
   }
 
   void TearDown() override {

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -350,7 +350,6 @@ TEST(SettledUtilTest, ZeroTime) {
 class AsyncMotionProfileControllerTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    Logger::initialize(createTimeUtil().getTimer(), "thefile.txt", Logger::LogLevel::info);
     leftMotor = new MockMotor();
     rightMotor = new MockMotor();
 

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -368,34 +368,16 @@ void SimulatedSystem::join() {
   thread.join();
 }
 
-void MockAsyncController::waitUntilSettled() {
+MockAsyncController::MockAsyncController()
+  : AsyncPosIntegratedController(std::make_shared<MockMotor>(), createTimeUtil()) {
 }
 
-void MockAsyncController::setTarget(double itarget) {
-  target = itarget;
-}
-
-double MockAsyncController::getError() const {
-  return 0;
+MockAsyncController::MockAsyncController(const TimeUtil &itimeUtil)
+  : AsyncPosIntegratedController(std::make_shared<MockMotor>(), itimeUtil) {
 }
 
 bool MockAsyncController::isSettled() {
-  return isSettledOverride;
-}
-
-void MockAsyncController::reset() {
-}
-
-void MockAsyncController::flipDisable() {
-  disabled = !disabled;
-}
-
-void MockAsyncController::flipDisable(bool iisDisabled) {
-  disabled = iisDisabled;
-}
-
-bool MockAsyncController::isDisabled() const {
-  return disabled;
+  return isSettledOverride || AsyncPosIntegratedController::isSettled();
 }
 
 MockIterativeController::MockIterativeController()

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -402,64 +402,12 @@ MockIterativeController::MockIterativeController()
   : IterativePosPIDController(0, 0, 0, 0, createTimeUtil()) {
 }
 
-double MockIterativeController::step(double inewReading) {
-  return 0;
-}
-
-void MockIterativeController::setTarget(double itarget) {
-  target = itarget;
-}
-
-double MockIterativeController::getOutput() const {
-  return output;
-}
-
-double MockIterativeController::getError() const {
-  return 0;
+MockIterativeController::MockIterativeController(const double ikP)
+  : IterativePosPIDController(ikP, 0, 0, 0, createTimeUtil()) {
 }
 
 bool MockIterativeController::isSettled() {
-  return isSettledOverride;
-}
-
-void MockIterativeController::setGains(double ikP, double ikI, double ikD, double ikBias) {
-}
-
-void MockIterativeController::setSampleTime(QTime isampleTime) {
-  sampleTime = isampleTime;
-}
-
-void MockIterativeController::setOutputLimits(double imax, double imin) {
-  maxOutput = imax;
-  minOutput = imin;
-}
-
-void MockIterativeController::setIntegralLimits(double imax, double imin) {
-}
-
-void MockIterativeController::setErrorSumLimits(double imax, double imin) {
-}
-
-void MockIterativeController::reset() {
-}
-
-void MockIterativeController::setIntegratorReset(bool iresetOnZero) {
-}
-
-void MockIterativeController::flipDisable() {
-  disabled = !disabled;
-}
-
-void MockIterativeController::flipDisable(bool iisDisabled) {
-  disabled = iisDisabled;
-}
-
-bool MockIterativeController::isDisabled() const {
-  return disabled;
-}
-
-QTime MockIterativeController::getSampleTime() const {
-  return sampleTime;
+  return isSettledOverride || IterativePosPIDController::isSettled();
 }
 
 void assertMotorsHaveBeenStopped(MockMotor *leftMotor, MockMotor *rightMotor) {


### PR DESCRIPTION
### Description of the Change

Valgrind's Memcheck and Massif tools are great for detecting undefined behavior and memory leaks, so we should run them with the CI builds.

### Benefits

Increased confidence in program correctness and stability.

### Possible Drawbacks

Longer builds :(

### Verification Process

N/A

### Applicable Issues

Closes #147.
