### PR TITLE
Issue #164: Fix CCPID

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -114,9 +114,9 @@ class ChassisControllerPID : public virtual ChassisController {
   const double gearRatio;
   const double straightScale;
   const double turnScale;
-  CrossplatformThread task;
   bool doneLooping{true};
   bool dtorCalled{false};
+  bool newMovement{false};
 
   static void trampoline(void *context);
   void loop();
@@ -125,8 +125,10 @@ class ChassisControllerPID : public virtual ChassisController {
   bool waitForAngleSettled();
   void stopAfterSettled();
 
-  typedef enum { distance, angle } modeType;
-  modeType mode;
+  typedef enum { distance, angle, none } modeType;
+  modeType mode{none};
+
+  CrossplatformThread task;
 };
 } // namespace okapi
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -109,7 +109,8 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
 
   logger->info("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor degrees");
 
-  distancePid->setTarget(newTarget);
+  const auto enc = model->getSensorVals();
+  distancePid->setTarget(newTarget + ((enc[0] + enc[1]) / 2.0));
   anglePid->setTarget(0);
 
   doneLooping = false;
@@ -144,6 +145,7 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
 
   logger->info("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
 
+  const auto enc = model->getSensorVals();
   turnPid->setTarget(newTarget);
 
   doneLooping = false;

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -53,14 +53,9 @@ void ChassisControllerPID::loop() {
      * waitUntilSettled
      */
     if (!doneLooping) {
-      if (mode != pastMode) {
-        logger->debug("ChassisControllerPID: Changed mode");
-
+      if (mode != pastMode || newMovement) {
         encStartVals = model->getSensorVals();
-        distancePid->reset();
-        anglePid->reset();
-        turnPid->reset();
-        model->stop();
+        newMovement = false;
       }
 
       switch (mode) {
@@ -69,14 +64,14 @@ void ChassisControllerPID::loop() {
         distanceElapsed = static_cast<double>((encVals[0] + encVals[1])) / 2.0;
         angleChange = static_cast<double>(encVals[0] - encVals[1]);
         model->driveVector(distancePid->step(distanceElapsed), anglePid->step(angleChange));
-
         break;
+
       case angle:
         encVals = model->getSensorVals() - encStartVals;
         angleChange = static_cast<double>(encVals[0] - encVals[1]);
         model->rotate(turnPid->step(angleChange));
-
         break;
+
       default:
         break;
       }
@@ -109,11 +104,11 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
 
   logger->info("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor degrees");
 
-  const auto enc = model->getSensorVals();
-  distancePid->setTarget(newTarget + ((enc[0] + enc[1]) / 2.0));
+  distancePid->setTarget(newTarget);
   anglePid->setTarget(0);
 
   doneLooping = false;
+  newMovement = true;
 }
 
 void ChassisControllerPID::moveDistanceAsync(const double itarget) {
@@ -145,10 +140,10 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
 
   logger->info("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
 
-  const auto enc = model->getSensorVals();
   turnPid->setTarget(newTarget);
 
   doneLooping = false;
+  newMovement = true;
 }
 
 void ChassisControllerPID::turnAngleAsync(const double idegTarget) {
@@ -174,30 +169,21 @@ void ChassisControllerPID::waitUntilSettled() {
     switch (mode) {
     case distance:
       completelySettled = waitForDistanceSettled();
-
-      // Only disable the controllers and stop if we are totally settled and won't try again
-      if (completelySettled) {
-        stopAfterSettled();
-      }
-
       break;
 
     case angle:
       completelySettled = waitForAngleSettled();
-
-      // Only disable the controllers and stop if we are totally settled and won't try again
-      if (completelySettled) {
-        stopAfterSettled();
-      }
-
       break;
 
     default:
+      completelySettled = true;
       break;
     }
-
-    logger->info("ChassisControllerPID: Done waiting to settle");
   }
+
+  stopAfterSettled();
+  mode = none;
+  logger->info("ChassisControllerPID: Done waiting to settle");
 }
 
 /**
@@ -245,23 +231,10 @@ bool ChassisControllerPID::waitForAngleSettled() {
 }
 
 void ChassisControllerPID::stopAfterSettled() {
-  switch (mode) {
-  case distance:
-    doneLooping = true;
-    distancePid->flipDisable(true);
-    anglePid->flipDisable(true);
-    model->stop();
-    break;
-
-  case angle:
-    doneLooping = true;
-    turnPid->flipDisable(true);
-    model->stop();
-    break;
-
-  default:
-    break;
-  }
+  distancePid->flipDisable(true);
+  anglePid->flipDisable(true);
+  turnPid->flipDisable(true);
+  model->stop();
 }
 
 void ChassisControllerPID::stop() {

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -160,6 +160,7 @@ void IterativePosPIDController::reset() {
   lastReading = 0;
   integral = 0;
   output = 0;
+  settledUtil->reset();
 }
 
 void IterativePosPIDController::setIntegratorReset(bool iresetOnZero) {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -112,6 +112,7 @@ void IterativeVelPIDController::reset() {
   logger->info("IterativeVelPIDController: Reset");
   error = 0;
   output = 0;
+  settledUtil->reset();
 }
 
 void IterativeVelPIDController::flipDisable() {

--- a/src/api/control/util/settledUtil.cpp
+++ b/src/api/control/util/settledUtil.cpp
@@ -44,5 +44,6 @@ bool SettledUtil::isSettled(const double ierror) {
 
 void SettledUtil::reset() {
   atTargetTimer->clearHardMark();
+  lastError = 0;
 }
 } // namespace okapi

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -25,19 +25,28 @@ void opcontrol() {
 
   Logger::initialize(std::make_unique<Timer>(), "/ser/sout", Logger::LogLevel::debug);
 
-  {
-    auto model =
-      std::make_shared<SkidSteerModel>(std::make_shared<Motor>(-1), std::make_shared<Motor>(2));
-    auto cnt = AsyncControllerFactory::motionProfile(1.0, 2.0, 10.0, model, 10.5_in);
+  //  {
+  //    auto model =
+  //      std::make_shared<SkidSteerModel>(std::make_shared<Motor>(-1), std::make_shared<Motor>(2));
+  //    auto cnt = AsyncControllerFactory::motionProfile(1.0, 2.0, 10.0, model, 10.5_in);
+  //
+  //    cnt.generatePath({Point{0_ft, 0_ft, 0_deg}, Point{3_ft, 0_ft, 0_deg}}, "A");
+  //    cnt.setTarget("B");
+  //    cnt.waitUntilSettled();
+  //  }
 
-    cnt.generatePath({Point{0_ft, 0_ft, 0_deg}, Point{3_ft, 0_ft, 0_deg}}, "A");
-    cnt.setTarget("B");
-    cnt.waitUntilSettled();
-  }
-
-  auto drive =
-    ChassisControllerFactory::create(-1, 2, AbstractMotor::gearset::red, {2.5_in, 10.5_in});
-  drive.moveDistanceAsync(2_in);
+  auto drive = ChassisControllerFactory::create(-1,
+                                                2,
+                                                IterativePosPIDController::Gains{0.01, 0, 0},
+                                                IterativePosPIDController::Gains{0, 0, 0},
+                                                IterativePosPIDController::Gains{0.01, 0, 0},
+                                                AbstractMotor::gearset::red,
+                                                {2.5_in, 10.5_in});
+  drive.turnAngleAsync(20_deg);
+  drive.waitUntilSettled();
+  drive.turnAngleAsync(20_deg);
+  drive.waitUntilSettled();
+  drive.turnAngleAsync(20_deg);
   drive.waitUntilSettled();
 
   //  runHeadlessTests();

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -37,16 +37,11 @@ void opcontrol() {
 
   auto drive = ChassisControllerFactory::create(-1,
                                                 2,
-                                                IterativePosPIDController::Gains{0.01, 0, 0},
-                                                IterativePosPIDController::Gains{0, 0, 0},
-                                                IterativePosPIDController::Gains{0.01, 0, 0},
+                                                IterativePosPIDController::Gains{0.01, 0, 0, 0},
+                                                IterativePosPIDController::Gains{0, 0, 0, 0},
+                                                IterativePosPIDController::Gains{0.007, 0, 0, 0},
                                                 AbstractMotor::gearset::red,
                                                 {2.5_in, 10.5_in});
-  drive.turnAngleAsync(20_deg);
-  drive.waitUntilSettled();
-  drive.turnAngleAsync(20_deg);
-  drive.waitUntilSettled();
-  drive.turnAngleAsync(20_deg);
   drive.waitUntilSettled();
 
   //  runHeadlessTests();


### PR DESCRIPTION
### Description of the Change

This PR fixes CCPID not handling repeated movements correctly by addressing the two points brought up in the issue:

1. CCPID `moveDistanceAsync` and `turnAngleAsync` do not account for the current position when generating a new target
2. `IterativePosPIDController::reset` does not call `SettledUtil::reset`

This PR also refactors the `loop`/`waitUntilSettled` logic to be cleaner.

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

A variety of programs were tested, including the problematic program in the issue.

### Applicable Issues

Closes #164.
