### PR TITLE
Issue #166: Call isSettled in waitUntilSettled

### DIFF
--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -119,7 +119,7 @@ void AsyncMotionProfileController::loop() {
   auto rate = timeUtil.getRate();
 
   while (!dtorCalled) {
-    if (!disabled && isRunning) {
+    if (isRunning && !isDisabled()) {
       logger->info("AsyncMotionProfileController: Running with path: " + currentPath);
       auto path = paths.find(currentPath);
 
@@ -146,7 +146,7 @@ void AsyncMotionProfileController::loop() {
 
 void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
                                                      std::unique_ptr<AbstractRate> rate) {
-  for (int i = 0; i < path.length && !disabled; ++i) {
+  for (int i = 0; i < path.length && !isDisabled(); ++i) {
     model->left(path.left[i].velocity / maxVel);
     model->right(path.right[i].velocity / maxVel);
     rate->delayUntil(1_ms);
@@ -163,7 +163,7 @@ void AsyncMotionProfileController::waitUntilSettled() {
   logger->info("AsyncMotionProfileController: Waiting to settle");
 
   auto rate = timeUtil.getRate();
-  while (isRunning) {
+  while (!isSettled()) {
     rate->delayUntil(10_ms);
   }
 
@@ -175,7 +175,7 @@ Point AsyncMotionProfileController::getError() const {
 }
 
 bool AsyncMotionProfileController::isSettled() {
-  return !isRunning;
+  return isDisabled() || !isRunning;
 }
 
 void AsyncMotionProfileController::reset() {

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -38,7 +38,7 @@ double AsyncPosIntegratedController::getError() const {
 }
 
 bool AsyncPosIntegratedController::isSettled() {
-  return isDisabled() ? true : settledUtil->isSettled(getError());
+  return isDisabled() || settledUtil->isSettled(getError());
 }
 
 void AsyncPosIntegratedController::reset() {
@@ -74,7 +74,7 @@ void AsyncPosIntegratedController::resumeMovement() {
 
 void AsyncPosIntegratedController::waitUntilSettled() {
   logger->info("AsyncPosIntegratedController: Waiting to settle");
-  while (!settledUtil->isSettled(getError())) {
+  while (!isSettled()) {
     rate->delayUntil(motorUpdateRate);
   }
   logger->info("AsyncPosIntegratedController: Done waiting to settle");

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -35,7 +35,7 @@ double AsyncVelIntegratedController::getError() const {
 }
 
 bool AsyncVelIntegratedController::isSettled() {
-  return isDisabled() ? true : settledUtil->isSettled(getError());
+  return isDisabled() || settledUtil->isSettled(getError());
 }
 
 void AsyncVelIntegratedController::reset() {
@@ -71,7 +71,7 @@ void AsyncVelIntegratedController::resumeMovement() {
 
 void AsyncVelIntegratedController::waitUntilSettled() {
   logger->info("AsyncVelIntegratedController: Waiting to settle");
-  while (!settledUtil->isSettled(getError())) {
+  while (!isSettled()) {
     rate->delayUntil(motorUpdateRate);
   }
   logger->info("AsyncVelIntegratedController: Done waiting to settle");

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -259,7 +259,7 @@ class AsyncVelIntegratedControllerTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    Test::TearDown();
+    delete controller;
   }
 
   MockMotor *motor;


### PR DESCRIPTION
### Description of the Change

All `waitUntilSettled()` implementations should call that class' `isSettled()` method instead of directly calling to their `SettledUtil`. `isSettled()` often provides other logic which should be captured by `waitUntilSettled()`, such as being settled when the controller is disabled. These implementations should also call `isDisabled()` instead of checking the `disabled` flag directly for the same reason.

### Benefits

More correctness :)

### Possible Drawbacks

None.

### Verification Process

A few tests were added (not that they help particularly much) and the change was verified by hand.

### Applicable Issues

Closes #166.
