### PR TITLE
Add IMVC tests and fix IVPIDC getOutput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ add_executable(OkapiLibV5
         src/pathfinder/followers/distance.c
         src/pathfinder/followers/encoder.c
         src/pathfinder/modifiers/swerve.c
-        src/pathfinder/modifiers/tank.c)
+        src/pathfinder/modifiers/tank.c test/iterativeMotorVelocityControllerTest.cpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ add_executable(OkapiLibV5
         test/asyncVelIntegratedControllerTests.cpp
         test/asyncMotionProfileControllerTests.cpp
         test/iterativeVelPIDControllerTests.cpp
+        test/iterativeMotorVelocityControllerTest.cpp
         test/iterativePosPIDControllerTests.cpp
         test/asyncWrapperTests.cpp
         src/pathfinder/generator.c
@@ -180,7 +181,7 @@ add_executable(OkapiLibV5
         src/pathfinder/followers/distance.c
         src/pathfinder/followers/encoder.c
         src/pathfinder/modifiers/swerve.c
-        src/pathfinder/modifiers/tank.c test/iterativeMotorVelocityControllerTest.cpp)
+        src/pathfinder/modifiers/tank.c)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -166,6 +166,7 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   double error = 0;
   double derivative = 0;
   double target = 0;
+  double outputSum = 0;
   double output = 0;
   double outputMax = 1;
   double outputMin = -1;

--- a/src/api/control/iterative/iterativeMotorVelocityController.cpp
+++ b/src/api/control/iterative/iterativeMotorVelocityController.cpp
@@ -13,8 +13,9 @@ IterativeMotorVelocityController::IterativeMotorVelocityController(
   std::shared_ptr<IterativeVelocityController<double, double>> icontroller)
   : motor(imotor), controller(icontroller) {
 }
+
 double IterativeMotorVelocityController::step(const double ireading) {
-  motor->moveVelocity(static_cast<std::int16_t>(controller->step(ireading) * 127));
+  motor->controllerSet(controller->step(ireading));
   return controller->getOutput();
 }
 

--- a/test/controllerTests.cpp
+++ b/test/controllerTests.cpp
@@ -90,45 +90,6 @@ TEST_F(IterativeControllerWithSimulatorTest, IterativeVelPIDControllerFeedForwar
   }
 }
 
-TEST(IterativeMotorVelocityControllerTest, IterativeMotorVelocityController) {
-  class MockIterativeVelPIDController : public IterativeVelPIDController {
-    public:
-    MockIterativeVelPIDController()
-      : IterativeVelPIDController(
-          0,
-          0,
-          0,
-          0,
-          std::make_unique<VelMath>(imev5TPR,
-                                    std::make_shared<AverageFilter<2>>(),
-                                    std::make_unique<ConstantMockTimer>(10_ms)),
-          createTimeUtil(Supplier<std::unique_ptr<AbstractTimer>>(
-            []() { return std::make_unique<ConstantMockTimer>(10_ms); }))) {
-    }
-
-    double step(const double inewReading) override {
-      return inewReading;
-    }
-  };
-
-  auto motor = std::make_shared<MockMotor>();
-
-  IterativeMotorVelocityController controller(motor,
-                                              std::make_shared<MockIterativeVelPIDController>());
-
-  controller.step(0);
-  EXPECT_NEAR(motor->lastVelocity, 0, 0.01);
-
-  controller.step(0.5);
-  EXPECT_NEAR(motor->lastVelocity, 63, 0.01);
-
-  controller.step(1);
-  EXPECT_NEAR(motor->lastVelocity, 127, 0.01);
-
-  controller.step(-0.5);
-  EXPECT_NEAR(motor->lastVelocity, -63, 0.01);
-}
-
 TEST(FilteredControllerInputTest, InputShouldBePassedThrough) {
   class MockControllerInput : public ControllerInput<double> {
     public:


### PR DESCRIPTION
### Description of the Change

This PR adds tests for the `IterativeMotorVelocityController` and fixes a bug with the `IterativeVelPIDController` where `getOutput()` would return the output _sum_, but not the full output (which includes two feed-forward terms).

### Benefits

:)

### Possible Drawbacks

:(

### Verification Process

:)

### Applicable Issues

None.
