### PR TITLE
Issue #172: Pull chassis width from ChassisController

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -8,6 +8,7 @@
 #ifndef _OKAPI_CHASSISCONTROLLER_HPP_
 #define _OKAPI_CHASSISCONTROLLER_HPP_
 
+#include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/chassis/model/chassisModel.hpp"
 #include "okapi/api/device/motor/abstractMotor.hpp"
 #include "okapi/api/units/QAngle.hpp"
@@ -190,6 +191,11 @@ class ChassisController : public ChassisModel {
    * result in multiple owners writing to the same set of motors.
    */
   std::shared_ptr<ChassisModel> getChassisModel() const;
+
+  /**
+   * Get the ChassisScales.
+   */
+  virtual ChassisScales getChassisScales() const = 0;
 
   protected:
   std::shared_ptr<ChassisModel> model;

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -9,7 +9,6 @@
 #define _OKAPI_CHASSISCONTROLLERINTEGRATED_HPP_
 
 #include "okapi/api/chassis/controller/chassisController.hpp"
-#include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
@@ -101,15 +100,19 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    */
   void stop() override;
 
+  /**
+   * Get the ChassisScales.
+   */
+  ChassisScales getChassisScales() const override;
+
   protected:
   Logger *logger;
   std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<AsyncPosIntegratedController> leftController;
   std::unique_ptr<AsyncPosIntegratedController> rightController;
   int lastTarget;
+  ChassisScales scales;
   const double gearRatio;
-  const double straightScale;
-  const double turnScale;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -9,7 +9,6 @@
 #define _OKAPI_CHASSISCONTROLLERPID_HPP_
 
 #include "okapi/api/chassis/controller/chassisController.hpp"
-#include "okapi/api/chassis/controller/chassisScales.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/util/abstractRate.hpp"
 #include "okapi/api/util/logging.hpp"
@@ -114,6 +113,11 @@ class ChassisControllerPID : public virtual ChassisController {
    */
   void startThread();
 
+  /**
+   * Get the ChassisScales.
+   */
+  ChassisScales getChassisScales() const override;
+
   protected:
   Logger *logger;
   std::unique_ptr<AbstractRate> rate;
@@ -121,8 +125,7 @@ class ChassisControllerPID : public virtual ChassisController {
   std::unique_ptr<IterativePosPIDController> anglePid;
   std::unique_ptr<IterativePosPIDController> turnPid;
   const double gearRatio;
-  const double straightScale;
-  const double turnScale;
+  ChassisScales scales;
   bool doneLooping{true};
   bool newMovement{false};
   std::atomic_bool dtorCalled{false};

--- a/include/okapi/api/chassis/controller/chassisScales.hpp
+++ b/include/okapi/api/chassis/controller/chassisScales.hpp
@@ -29,6 +29,8 @@ class ChassisScales {
     std::vector<double> vec(iscales);
     straight = vec.at(0);
     turn = vec.at(1);
+    wheelDiameter = (360 / (straight * 1_pi)) * meter;
+    wheelbaseWidth = turn * wheelDiameter;
   }
 
   /**
@@ -64,14 +66,18 @@ class ChassisScales {
    */
   ChassisScales(const std::initializer_list<QLength> &iwheelbase) {
     std::vector<QLength> vec(iwheelbase);
-    straight = static_cast<double>(360 / (vec.at(0).convert(meter) * 1_pi));
-    turn = vec.at(1).convert(meter) / vec.at(0).convert(meter);
+    wheelDiameter = vec.at(0);
+    wheelbaseWidth = vec.at(1);
+    straight = static_cast<double>(360 / (wheelDiameter.convert(meter) * 1_pi));
+    turn = wheelbaseWidth.convert(meter) / wheelDiameter.convert(meter);
   }
 
   virtual ~ChassisScales() = default;
 
   double straight;
   double turn;
+  QLength wheelDiameter;
+  QLength wheelbaseWidth;
 };
 } // namespace okapi
 

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -323,13 +323,11 @@ class AsyncControllerFactory {
    * @param imaxAccel The maximum possible acceleration.
    * @param imaxJerk The maximum possible jerk.
    * @param ichassis The chassis to control.
-   * @param iwidth The chassis wheelbase width.
    */
   static AsyncMotionProfileController motionProfile(double imaxVel,
                                                     double imaxAccel,
                                                     double imaxJerk,
-                                                    const ChassisController &ichassis,
-                                                    QLength iwidth);
+                                                    const ChassisController &ichassis);
 
   /**
    * A controller which generates and follows 2D motion profiles.

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -23,9 +23,8 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
     leftController(std::move(ileftController)),
     rightController(std::move(irightController)),
     lastTarget(0),
-    gearRatio(igearset.ratio),
-    straightScale(iscales.straight),
-    turnScale(iscales.turn) {
+    scales(iscales),
+    gearRatio(igearset.ratio) {
   if (igearset.ratio == 0) {
     logger->error("ChassisControllerIntegrated: The gear ratio cannot be zero! Check if you are "
                   "using integer division.");
@@ -44,7 +43,7 @@ void ChassisControllerIntegrated::moveDistance(const QLength itarget) {
 
 void ChassisControllerIntegrated::moveDistance(const double itarget) {
   // Divide by straightScale so the final result turns back into motor degrees
-  moveDistance((itarget / straightScale) * meter);
+  moveDistance((itarget / scales.straight) * meter);
 }
 
 void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
@@ -56,7 +55,7 @@ void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
   leftController->flipDisable(false);
   rightController->flipDisable(false);
 
-  const double newTarget = itarget.convert(meter) * straightScale * gearRatio;
+  const double newTarget = itarget.convert(meter) * scales.straight * gearRatio;
 
   logger->info("ChassisControllerIntegrated: moving " + std::to_string(newTarget) +
                " motor degrees");
@@ -68,7 +67,7 @@ void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
 
 void ChassisControllerIntegrated::moveDistanceAsync(const double itarget) {
   // Divide by straightScale so the final result turns back into motor degrees
-  moveDistanceAsync((itarget / straightScale) * meter);
+  moveDistanceAsync((itarget / scales.straight) * meter);
 }
 
 void ChassisControllerIntegrated::turnAngle(const QAngle idegTarget) {
@@ -78,7 +77,7 @@ void ChassisControllerIntegrated::turnAngle(const QAngle idegTarget) {
 
 void ChassisControllerIntegrated::turnAngle(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor degrees
-  turnAngle((idegTarget / turnScale) * degree);
+  turnAngle((idegTarget / scales.turn) * degree);
 }
 
 void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
@@ -90,7 +89,7 @@ void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
   leftController->flipDisable(false);
   rightController->flipDisable(false);
 
-  const double newTarget = idegTarget.convert(degree) * turnScale * gearRatio;
+  const double newTarget = idegTarget.convert(degree) * scales.turn * gearRatio;
 
   logger->info("ChassisControllerIntegrated: turning " + std::to_string(newTarget) +
                " motor degrees");
@@ -102,7 +101,7 @@ void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
 
 void ChassisControllerIntegrated::turnAngleAsync(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor degrees
-  turnAngleAsync((idegTarget / turnScale) * degree);
+  turnAngleAsync((idegTarget / scales.turn) * degree);
 }
 
 void ChassisControllerIntegrated::waitUntilSettled() {
@@ -123,5 +122,9 @@ void ChassisControllerIntegrated::stop() {
   rightController->flipDisable(true);
 
   ChassisController::stop();
+}
+
+ChassisScales ChassisControllerIntegrated::getChassisScales() const {
+  return scales;
 }
 } // namespace okapi

--- a/src/impl/control/async/asyncControllerFactory.cpp
+++ b/src/impl/control/async/asyncControllerFactory.cpp
@@ -310,9 +310,12 @@ AsyncMotionProfileController
 AsyncControllerFactory::motionProfile(double imaxVel,
                                       double imaxAccel,
                                       double imaxJerk,
-                                      const ChassisController &ichassis,
-                                      QLength iwidth) {
-  return motionProfile(imaxVel, imaxAccel, imaxJerk, ichassis.getChassisModel(), iwidth);
+                                      const ChassisController &ichassis) {
+  return motionProfile(imaxVel,
+                       imaxAccel,
+                       imaxJerk,
+                       ichassis.getChassisModel(),
+                       ichassis.getChassisScales().wheelbaseWidth);
 }
 
 AsyncMotionProfileController

--- a/test/chassisScalesTests.cpp
+++ b/test/chassisScalesTests.cpp
@@ -22,4 +22,9 @@ TEST(ChassisScalesTest, ScalesFromWheelbase) {
   ChassisScales scales({4_in, 11.5_in});
   EXPECT_FLOAT_EQ(scales.straight, 1127.8696);
   EXPECT_FLOAT_EQ(scales.turn, 2.875);
+
+  // Feed the raw scales back in to get the lengths out
+  ChassisScales reverse({1127.8696, 2.875});
+  EXPECT_NEAR(reverse.wheelDiameter.convert(meter), (4_in).convert(meter), 0.0001);
+  EXPECT_NEAR(reverse.wheelbaseWidth.convert(meter), (11.5_in).convert(meter), 0.0001);
 }


### PR DESCRIPTION
### Description of the Change

The `AsyncControllerFactory` shouldn't need to accept both a `ChassisController` and a wheelbase width. This PR adds a method `ChassisController::getChassisScales()` and adds some math to figure out the chassis dimensions from raw scales.

### Benefits

`AsyncControllerFactory::motionProfile()` is no longer needs redundant information.

### Possible Drawbacks

None.

### Verification Process

The tests pass :)
Also wrote a new test for the raw scales -> measurements math.

### Applicable Issues

Closes #172.
