### PR TITLE
Issue #177: Controller enums

### DIFF
--- a/include/okapi/impl/device/button/controllerButton.hpp
+++ b/include/okapi/impl/device/button/controllerButton.hpp
@@ -10,19 +10,20 @@
 
 #include "api.h"
 #include "okapi/api/device/button/buttonBase.hpp"
+#include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
 class ControllerButton : public ButtonBase {
   public:
-  ControllerButton(const controller_digital_e_t ibtn, const bool iinverted = false);
+  ControllerButton(const ControllerDigital ibtn, const bool iinverted = false);
 
-  ControllerButton(const controller_id_e_t icontroller,
-                   const controller_digital_e_t ibtn,
+  ControllerButton(const ControllerId icontroller,
+                   const ControllerDigital ibtn,
                    const bool iinverted = false);
 
   protected:
   pros::Controller controller;
-  const controller_digital_e_t btn;
+  const ControllerDigital btn;
 
   virtual bool currentlyPressed() override;
 };

--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -10,11 +10,12 @@
 
 #include "api.h"
 #include "okapi/impl/device/button/controllerButton.hpp"
+#include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
 class Controller {
   public:
-  Controller(const controller_id_e_t iid = E_CONTROLLER_MASTER);
+  Controller(ControllerId iid = ControllerId::master);
 
   virtual ~Controller();
 
@@ -42,7 +43,7 @@ class Controller {
    * @param ichannel the channel to read
    * @return the value of that channel in the range [-1, 1]
    */
-  virtual float getAnalog(const controller_analog_e_t ichannel);
+  virtual float getAnalog(ControllerAnalog ichannel);
 
   /**
    * Returns whether the digital button is currently pressed. Returns false if the controller is
@@ -51,7 +52,7 @@ class Controller {
    * @param ibutton the button to check
    * @return true if the button is pressed, false if the controller is not connected
    */
-  virtual bool getDigital(const controller_digital_e_t ibutton);
+  virtual bool getDigital(ControllerDigital ibutton);
 
   /**
    * Returns a ControllerButton for the given button on this controller.
@@ -59,10 +60,10 @@ class Controller {
    * @param ibtn the button
    * @return a ControllerButton on this controller
    */
-  virtual ControllerButton operator[](const controller_digital_e_t ibtn);
+  virtual ControllerButton operator[](ControllerDigital ibtn);
 
   protected:
-  const controller_id_e_t id;
+  const ControllerId m_id;
   pros::Controller controller;
 };
 } // namespace okapi

--- a/include/okapi/impl/device/controllerUtil.hpp
+++ b/include/okapi/impl/device/controllerUtil.hpp
@@ -1,0 +1,61 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_CONTROLLERUTIL_HPP_
+#define _OKAPI_CONTROLLERUTIL_HPP_
+
+#include "api.h"
+
+namespace okapi {
+/**
+ * Which controller role this has.
+ */
+enum class ControllerId { master = 0, partner = 1 };
+
+/**
+ * The analog sticks.
+ */
+enum class ControllerAnalog { leftX = 0, leftY = 1, rightX = 2, rightY = 3 };
+
+/**
+ * Various buttons.
+ */
+enum class ControllerDigital {
+  L1 = 6,
+  L2 = 7,
+  R1 = 8,
+  R2 = 9,
+  up = 10,
+  down = 11,
+  left = 12,
+  right = 13,
+  X = 14,
+  B = 15,
+  Y = 16,
+  A = 17
+};
+
+class ControllerUtil {
+  public:
+  /**
+   * Maps an `id` to the PROS enum equivalent.
+   */
+  static controller_id_e_t idToProsEnum(ControllerId in);
+
+  /**
+   * Maps an `analog` to the PROS enum equivalent.
+   */
+  static controller_analog_e_t analogToProsEnum(ControllerAnalog in);
+
+  /**
+   * Maps a `digital` to the PROS enum equivalent.
+   */
+  static controller_digital_e_t digitalToProsEnum(ControllerDigital in);
+};
+} // namespace okapi
+
+#endif

--- a/src/impl/device/button/controllerButton.cpp
+++ b/src/impl/device/button/controllerButton.cpp
@@ -8,18 +8,20 @@
 #include "okapi/impl/device/button/controllerButton.hpp"
 
 namespace okapi {
-ControllerButton::ControllerButton(const controller_digital_e_t ibtn, const bool iinverted)
-  : ButtonBase(iinverted), controller(E_CONTROLLER_MASTER), btn(ibtn) {
+ControllerButton::ControllerButton(const ControllerDigital ibtn, const bool iinverted)
+  : ButtonBase(iinverted),
+    controller(ControllerUtil::idToProsEnum(ControllerId::master)),
+    btn(ibtn) {
 }
 
-ControllerButton::ControllerButton(const controller_id_e_t icontroller,
-                                   const controller_digital_e_t ibtn,
+ControllerButton::ControllerButton(const ControllerId icontroller,
+                                   const ControllerDigital ibtn,
                                    const bool iinverted)
-  : ButtonBase(iinverted), controller(icontroller), btn(ibtn) {
+  : ButtonBase(iinverted), controller(ControllerUtil::idToProsEnum(icontroller)), btn(ibtn) {
 }
 
 bool ControllerButton::currentlyPressed() {
-  const bool pressed = controller.get_digital(btn) != 0;
+  const bool pressed = controller.get_digital(ControllerUtil::digitalToProsEnum(btn)) != 0;
   return inverted ? !pressed : pressed;
 }
 } // namespace okapi

--- a/src/impl/device/controller.cpp
+++ b/src/impl/device/controller.cpp
@@ -6,9 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/device/controller.hpp"
+#include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
-Controller::Controller(const controller_id_e_t iid) : id(iid), controller(iid) {
+Controller::Controller(const ControllerId iid)
+  : m_id(iid), controller(ControllerUtil::idToProsEnum(iid)) {
 }
 
 Controller::~Controller() = default;
@@ -22,8 +24,8 @@ std::int32_t Controller::getConnectionState() {
   return controller.is_connected();
 }
 
-float Controller::getAnalog(const controller_analog_e_t ichannel) {
-  const auto val = controller.get_analog(ichannel);
+float Controller::getAnalog(const ControllerAnalog ichannel) {
+  const auto val = controller.get_analog(ControllerUtil::analogToProsEnum(ichannel));
   if (val == PROS_ERR) {
     return 0;
   }
@@ -31,11 +33,11 @@ float Controller::getAnalog(const controller_analog_e_t ichannel) {
   return static_cast<float>(val) / static_cast<float>(127);
 }
 
-bool Controller::getDigital(const controller_digital_e_t ibutton) {
-  return controller.get_digital(ibutton) == 1;
+bool Controller::getDigital(const ControllerDigital ibutton) {
+  return controller.get_digital(ControllerUtil::digitalToProsEnum(ibutton)) == 1;
 }
 
-ControllerButton Controller::operator[](const controller_digital_e_t ibtn) {
-  return ControllerButton(id, ibtn);
+ControllerButton Controller::operator[](const ControllerDigital ibtn) {
+  return ControllerButton(m_id, ibtn);
 }
 } // namespace okapi

--- a/src/impl/device/controllerUtil.cpp
+++ b/src/impl/device/controllerUtil.cpp
@@ -1,0 +1,36 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/impl/device/controllerUtil.hpp"
+
+namespace okapi {
+controller_id_e_t ControllerUtil::idToProsEnum(ControllerId in) {
+  switch (in) {
+  case ControllerId::master:
+    return E_CONTROLLER_MASTER;
+  case ControllerId::partner:
+    return E_CONTROLLER_PARTNER;
+  }
+}
+
+controller_analog_e_t ControllerUtil::analogToProsEnum(ControllerAnalog in) {
+  switch (in) {
+  case ControllerAnalog::leftX:
+    return E_CONTROLLER_ANALOG_LEFT_X;
+  case ControllerAnalog::leftY:
+    return E_CONTROLLER_ANALOG_LEFT_Y;
+  case ControllerAnalog::rightX:
+    return E_CONTROLLER_ANALOG_RIGHT_X;
+  case ControllerAnalog::rightY:
+    return E_CONTROLLER_ANALOG_RIGHT_Y;
+  }
+}
+
+controller_digital_e_t ControllerUtil::digitalToProsEnum(ControllerDigital in) {
+  // TODO: Implement this
+}
+} // namespace okapi

--- a/src/impl/device/controllerUtil.cpp
+++ b/src/impl/device/controllerUtil.cpp
@@ -31,6 +31,31 @@ controller_analog_e_t ControllerUtil::analogToProsEnum(ControllerAnalog in) {
 }
 
 controller_digital_e_t ControllerUtil::digitalToProsEnum(ControllerDigital in) {
-  // TODO: Implement this
+  switch (in) {
+  case ControllerDigital::L1:
+    return E_CONTROLLER_DIGITAL_L1;
+  case ControllerDigital::L2:
+    return E_CONTROLLER_DIGITAL_L2;
+  case ControllerDigital::R1:
+    return E_CONTROLLER_DIGITAL_R1;
+  case ControllerDigital::R2:
+    return E_CONTROLLER_DIGITAL_R2;
+  case ControllerDigital::up:
+    return E_CONTROLLER_DIGITAL_UP;
+  case ControllerDigital::down:
+    return E_CONTROLLER_DIGITAL_DOWN;
+  case ControllerDigital::left:
+    return E_CONTROLLER_DIGITAL_LEFT;
+  case ControllerDigital::right:
+    return E_CONTROLLER_DIGITAL_RIGHT;
+  case ControllerDigital::X:
+    return E_CONTROLLER_DIGITAL_X;
+  case ControllerDigital::B:
+    return E_CONTROLLER_DIGITAL_B;
+  case ControllerDigital::Y:
+    return E_CONTROLLER_DIGITAL_Y;
+  case ControllerDigital::A:
+    return E_CONTROLLER_DIGITAL_A;
+  }
 }
 } // namespace okapi

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -95,14 +95,14 @@ void opcontrol() {
     ChassisControllerFactory::create({19, 20}, {-14}, AbstractMotor::gearset::red, {4_in, 11.5_in});
 
   Controller controller;
-  ControllerButton btn1(E_CONTROLLER_DIGITAL_A);
-  ControllerButton btn2(E_CONTROLLER_DIGITAL_B);
-  ControllerButton btn3(E_CONTROLLER_DIGITAL_Y);
-  ControllerButton btn4(E_CONTROLLER_DIGITAL_X);
+  ControllerButton btn1(ControllerDigital::A);
+  ControllerButton btn2(ControllerDigital::B);
+  ControllerButton btn3(ControllerDigital::Y);
+  ControllerButton btn4(ControllerDigital::X);
 
   while (true) {
-    chassis.arcade(controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_Y),
-                   controller.getAnalog(E_CONTROLLER_ANALOG_LEFT_X));
+    chassis.arcade(controller.getAnalog(ControllerAnalog::leftY),
+                   controller.getAnalog(ControllerAnalog::leftX));
 
     if (btn1.changedToPressed()) {
       printf("move distance\n");


### PR DESCRIPTION
### Description of the Change

`Controller` got enum classes for `id`, `analog`, and `digital` which directly map to the PROS equivalent.

### Benefits

The API is more consistent. There shouldn't be a need to intermix PROS and Okapi namespaces.

### Possible Drawbacks

Small API break.

### Verification Process

This change was not verified.

### Applicable Issues

Closes #177.
