### PR TITLE
Issue #183: Add a separate voltage scale

### DIFF
--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -27,7 +27,8 @@ class SkidSteerModel : public ChassisModel {
    */
   SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                  std::shared_ptr<AbstractMotor> irightSideMotor,
-                 double imaxOutput = 127);
+                 double imaxVelocity = 127,
+                 double imaxVoltage = 12000);
 
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
@@ -42,7 +43,8 @@ class SkidSteerModel : public ChassisModel {
                  std::shared_ptr<AbstractMotor> irightSideMotor,
                  std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                  std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                 double imaxOutput = 127);
+                 double imaxVelocity = 127,
+                 double imaxVoltage = 12000);
 
   /**
    * Drive the robot forwards (using open-loop control). Uses velocity mode.
@@ -224,7 +226,8 @@ class SkidSteerModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> rightSideMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  const double maxOutput;
+  const double maxVelocity;
+  const double maxVoltage;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -28,7 +28,8 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
                              std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                              std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
                              std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                             double imaxOutput = 127);
+                             double imaxVelocity = 127,
+                             double imaxVoltage = 12000);
 
   /**
    * Read the sensors.

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -31,7 +31,8 @@ class XDriveModel : public ChassisModel {
               std::shared_ptr<AbstractMotor> itopRightMotor,
               std::shared_ptr<AbstractMotor> ibottomRightMotor,
               std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-              double imaxOutput = 127);
+              double imaxVelocity = 127,
+              double imaxVoltage = 12000);
 
   /**
    * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
@@ -50,7 +51,8 @@ class XDriveModel : public ChassisModel {
               std::shared_ptr<AbstractMotor> ibottomLeftMotor,
               std::shared_ptr<ContinuousRotarySensor> ileftEnc,
               std::shared_ptr<ContinuousRotarySensor> irightEnc,
-              double imaxOutput = 127);
+              double imaxVelocity = 127,
+              double imaxVoltage = 12000);
 
   /**
    * Drive the robot forwards (using open-loop control). Uses velocity mode.
@@ -259,7 +261,8 @@ class XDriveModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> bottomLeftMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  const double maxOutput;
+  const double maxVelocity;
+  const double maxVoltage;
 };
 } // namespace okapi
 

--- a/include/okapi/impl/chassis/model/chassisModelFactory.hpp
+++ b/include/okapi/impl/chassis/model/chassisModelFactory.hpp
@@ -28,8 +28,10 @@ class ChassisModelFactory {
    * @param ileftSideMotor left side motor
    * @param irightSideMotor right side motor
    */
-  static SkidSteerModel
-  create(Motor ileftSideMotor, Motor irightSideMotor, const double imaxOutput = 127);
+  static SkidSteerModel create(Motor ileftSideMotor,
+                               Motor irightSideMotor,
+                               double imaxVelocity = 127,
+                               double imaxVoltage = 12000);
 
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
@@ -41,8 +43,10 @@ class ChassisModelFactory {
    * @param ileftSideMotor left side motor
    * @param irightSideMotor right side motor
    */
-  static SkidSteerModel
-  create(MotorGroup ileftSideMotor, MotorGroup irightSideMotor, const double imaxOutput = 127);
+  static SkidSteerModel create(MotorGroup ileftSideMotor,
+                               MotorGroup irightSideMotor,
+                               double imaxVelocity = 127,
+                               double imaxVoltage = 12000);
 
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
@@ -58,7 +62,8 @@ class ChassisModelFactory {
                                MotorGroup irightSideMotor,
                                ADIEncoder ileftEnc,
                                ADIEncoder irightEnc,
-                               const double imaxOutput = 127);
+                               double imaxVelocity = 127,
+                               double imaxVoltage = 12000);
 
   /**
    * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
@@ -76,7 +81,8 @@ class ChassisModelFactory {
                             Motor itopRightMotor,
                             Motor ibottomRightMotor,
                             Motor ibottomLeftMotor,
-                            const double imaxOutput = 127);
+                            double imaxVelocity = 127,
+                            double imaxVoltage = 12000);
 
   /**
    * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
@@ -96,7 +102,8 @@ class ChassisModelFactory {
                             Motor ibottomLeftMotor,
                             ADIEncoder ileftEnc,
                             ADIEncoder irightEnc,
-                            const double imaxOutput = 127);
+                            double imaxVelocity = 127,
+                            double imaxVoltage = 12000);
 
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
@@ -113,7 +120,8 @@ class ChassisModelFactory {
                                            ADIEncoder ileftEnc,
                                            ADIEncoder imiddleEnc,
                                            ADIEncoder irightEnc,
-                                           const double imaxOutput = 127);
+                                           double imaxVelocity = 127,
+                                           double imaxVoltage = 12000);
 
   /**
    * Model for a skid steer drive (wheels parallel with robot's direction of motion). When all
@@ -130,7 +138,8 @@ class ChassisModelFactory {
                                            ADIEncoder ileftEnc,
                                            ADIEncoder imiddleEnc,
                                            ADIEncoder irightEnc,
-                                           const double imaxOutput = 127);
+                                           double imaxVelocity = 127,
+                                           double imaxVoltage = 12000);
 };
 } // namespace okapi
 

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -14,28 +14,32 @@ SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                std::shared_ptr<AbstractMotor> irightSideMotor,
                                std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                                std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                               const double imaxOutput)
+                               const double imaxVelocity,
+                               const double imaxVoltage)
   : leftSideMotor(ileftSideMotor),
     rightSideMotor(irightSideMotor),
     leftSensor(ileftEnc),
     rightSensor(irightEnc),
-    maxOutput(imaxOutput) {
+    maxVelocity(imaxVelocity),
+    maxVoltage(imaxVoltage) {
 }
 
 SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                std::shared_ptr<AbstractMotor> irightSideMotor,
-                               const double imaxOutput)
+                               const double imaxVelocity,
+                               const double imaxVoltage)
   : leftSideMotor(ileftSideMotor),
     rightSideMotor(irightSideMotor),
     leftSensor(ileftSideMotor->getEncoder()),
     rightSensor(irightSideMotor->getEncoder()),
-    maxOutput(imaxOutput) {
+    maxVelocity(imaxVelocity),
+    maxVoltage(imaxVoltage) {
 }
 
 void SkidSteerModel::forward(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
-  leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  rightSideMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
+  leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  rightSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
 void SkidSteerModel::driveVector(const double iySpeed, const double izRotation) const {
@@ -52,14 +56,14 @@ void SkidSteerModel::driveVector(const double iySpeed, const double izRotation) 
     rightOutput /= maxInputMag;
   }
 
-  leftSideMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxOutput));
-  rightSideMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxOutput));
+  leftSideMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVelocity));
+  rightSideMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVelocity));
 }
 
 void SkidSteerModel::rotate(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
-  leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  rightSideMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxOutput));
+  leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  rightSideMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxVelocity));
 }
 
 void SkidSteerModel::stop() {
@@ -82,8 +86,8 @@ void SkidSteerModel::tank(const double ileftSpeed,
     rightSpeed = 0;
   }
 
-  leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxOutput));
-  rightSideMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxOutput));
+  leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  rightSideMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
 }
 
 void SkidSteerModel::arcade(const double iySpeed,
@@ -123,16 +127,17 @@ void SkidSteerModel::arcade(const double iySpeed,
     }
   }
 
-  leftSideMotor->moveVoltage(static_cast<int16_t>(std::clamp(leftOutput, -1.0, 1.0) * maxOutput));
-  rightSideMotor->moveVoltage(static_cast<int16_t>(std::clamp(rightOutput, -1.0, 1.0) * maxOutput));
+  leftSideMotor->moveVoltage(static_cast<int16_t>(std::clamp(leftOutput, -1.0, 1.0) * maxVoltage));
+  rightSideMotor->moveVoltage(
+    static_cast<int16_t>(std::clamp(rightOutput, -1.0, 1.0) * maxVoltage));
 }
 
 void SkidSteerModel::left(const double ispeed) const {
-  leftSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
+  leftSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
 }
 
 void SkidSteerModel::right(const double ispeed) const {
-  rightSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
+  rightSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
 }
 
 std::valarray<std::int32_t> SkidSteerModel::getSensorVals() const {

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -14,8 +14,9 @@ ThreeEncoderSkidSteerModel::ThreeEncoderSkidSteerModel(
   std::shared_ptr<ContinuousRotarySensor> ileftEnc,
   std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
   std::shared_ptr<ContinuousRotarySensor> irightEnc,
-  const double imaxOutput)
-  : SkidSteerModel(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc, imaxOutput),
+  const double imaxVelocity,
+  const double imaxVoltage)
+  : SkidSteerModel(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc, imaxVelocity, imaxVoltage),
     middleSensor(imiddleEnc) {
 }
 

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -15,36 +15,40 @@ XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
                          std::shared_ptr<AbstractMotor> ibottomLeftMotor,
                          std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                          std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                         const double imaxOutput)
+                         const double imaxVelocity,
+                         const double imaxVoltage)
   : topLeftMotor(itopLeftMotor),
     topRightMotor(itopRightMotor),
     bottomRightMotor(ibottomRightMotor),
     bottomLeftMotor(ibottomLeftMotor),
     leftSensor(ileftEnc),
     rightSensor(irightEnc),
-    maxOutput(imaxOutput) {
+    maxVelocity(imaxVelocity),
+    maxVoltage(imaxVoltage) {
 }
 
 XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
                          std::shared_ptr<AbstractMotor> itopRightMotor,
                          std::shared_ptr<AbstractMotor> ibottomRightMotor,
                          std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-                         const double imaxOutput)
+                         const double imaxVelocity,
+                         const double imaxVoltage)
   : topLeftMotor(itopLeftMotor),
     topRightMotor(itopRightMotor),
     bottomRightMotor(ibottomRightMotor),
     bottomLeftMotor(ibottomLeftMotor),
     leftSensor(itopLeftMotor->getEncoder()),
     rightSensor(itopRightMotor->getEncoder()),
-    maxOutput(imaxOutput) {
+    maxVelocity(imaxVelocity),
+    maxVoltage(imaxVoltage) {
 }
 
 void XDriveModel::forward(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
-  topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  topRightMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
+  topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  topRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
 void XDriveModel::driveVector(const double iySpeed, const double izRotation) const {
@@ -61,18 +65,18 @@ void XDriveModel::driveVector(const double iySpeed, const double izRotation) con
     rightOutput /= maxInputMag;
   }
 
-  topLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxOutput));
-  topRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxOutput));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxOutput));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxOutput));
+  topLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVelocity));
+  topRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVelocity));
 }
 
 void XDriveModel::rotate(const double ispeed) const {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
-  topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
-  topRightMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxOutput));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxOutput));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxOutput));
+  topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  topRightMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
 void XDriveModel::stop() {
@@ -97,10 +101,10 @@ void XDriveModel::tank(const double ileftSpeed,
     rightSpeed = 0;
   }
 
-  topLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxOutput));
-  topRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxOutput));
-  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxOutput));
-  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxOutput));
+  topLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  topRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
 }
 
 void XDriveModel::arcade(const double iySpeed,
@@ -143,10 +147,10 @@ void XDriveModel::arcade(const double iySpeed,
   leftOutput = std::clamp(leftOutput, -1.0, 1.0);
   rightOutput = std::clamp(rightOutput, -1.0, 1.0);
 
-  topLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxOutput));
-  topRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxOutput));
-  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxOutput));
-  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxOutput));
+  topLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
+  topRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
 }
 
 void XDriveModel::xArcade(const double ixSpeed,
@@ -169,23 +173,23 @@ void XDriveModel::xArcade(const double ixSpeed,
   }
 
   topLeftMotor->moveVoltage(
-    static_cast<int16_t>(std::clamp(ySpeed + xSpeed + zRotation, -1.0, 1.0) * maxOutput));
+    static_cast<int16_t>(std::clamp(ySpeed + xSpeed + zRotation, -1.0, 1.0) * maxVoltage));
   topRightMotor->moveVoltage(
-    static_cast<int16_t>(std::clamp(ySpeed - xSpeed - zRotation, -1.0, 1.0) * maxOutput));
+    static_cast<int16_t>(std::clamp(ySpeed - xSpeed - zRotation, -1.0, 1.0) * maxVoltage));
   bottomRightMotor->moveVoltage(
-    static_cast<int16_t>(std::clamp(ySpeed + xSpeed - zRotation, -1.0, 1.0) * maxOutput));
+    static_cast<int16_t>(std::clamp(ySpeed + xSpeed - zRotation, -1.0, 1.0) * maxVoltage));
   bottomLeftMotor->moveVoltage(
-    static_cast<int16_t>(std::clamp(ySpeed - xSpeed + zRotation, -1.0, 1.0) * maxOutput));
+    static_cast<int16_t>(std::clamp(ySpeed - xSpeed + zRotation, -1.0, 1.0) * maxVoltage));
 }
 
 void XDriveModel::left(const double ispeed) const {
-  topLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
+  topLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
 }
 
 void XDriveModel::right(const double ispeed) const {
-  topRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxOutput));
+  topRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
 }
 
 std::valarray<std::int32_t> XDriveModel::getSensorVals() const {

--- a/src/impl/chassis/model/chassisModelFactory.cpp
+++ b/src/impl/chassis/model/chassisModelFactory.cpp
@@ -8,42 +8,52 @@
 #include "okapi/impl/chassis/model/chassisModelFactory.hpp"
 
 namespace okapi {
-SkidSteerModel
-ChassisModelFactory::create(Motor ileftSideMotor, Motor irightSideMotor, const double imaxOutput) {
-  return SkidSteerModel(
-    std::make_shared<Motor>(ileftSideMotor), std::make_shared<Motor>(irightSideMotor), imaxOutput);
+SkidSteerModel ChassisModelFactory::create(Motor ileftSideMotor,
+                                           Motor irightSideMotor,
+                                           const double imaxVelocity,
+                                           const double imaxVoltage) {
+  return SkidSteerModel(std::make_shared<Motor>(ileftSideMotor),
+                        std::make_shared<Motor>(irightSideMotor),
+                        imaxVelocity,
+                        imaxVoltage);
 }
 
 SkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor,
                                            MotorGroup irightSideMotor,
-                                           const double imaxOutput) {
+                                           const double imaxVelocity,
+                                           const double imaxVoltage) {
   return SkidSteerModel(std::make_shared<MotorGroup>(ileftSideMotor),
                         std::make_shared<MotorGroup>(irightSideMotor),
-                        imaxOutput);
+                        imaxVelocity,
+                        imaxVoltage);
 }
 
 SkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor,
                                            MotorGroup irightSideMotor,
                                            ADIEncoder ileftEnc,
                                            ADIEncoder irightEnc,
-                                           const double imaxOutput) {
+                                           const double imaxVelocity,
+                                           const double imaxVoltage) {
   return SkidSteerModel(std::make_shared<MotorGroup>(ileftSideMotor),
                         std::make_shared<MotorGroup>(irightSideMotor),
                         std::make_shared<ADIEncoder>(ileftEnc),
                         std::make_shared<ADIEncoder>(irightEnc),
-                        imaxOutput);
+                        imaxVelocity,
+                        imaxVoltage);
 }
 
 XDriveModel ChassisModelFactory::create(Motor itopLeftMotor,
                                         Motor itopRightMotor,
                                         Motor ibottomRightMotor,
                                         Motor ibottomLeftMotor,
-                                        const double imaxOutput) {
+                                        const double imaxVelocity,
+                                        const double imaxVoltage) {
   return XDriveModel(std::make_shared<Motor>(itopLeftMotor),
                      std::make_shared<Motor>(itopRightMotor),
                      std::make_shared<Motor>(ibottomRightMotor),
                      std::make_shared<Motor>(ibottomLeftMotor),
-                     imaxOutput);
+                     imaxVelocity,
+                     imaxVoltage);
 }
 
 XDriveModel ChassisModelFactory::create(Motor itopLeftMotor,
@@ -52,14 +62,16 @@ XDriveModel ChassisModelFactory::create(Motor itopLeftMotor,
                                         Motor ibottomLeftMotor,
                                         ADIEncoder ileftEnc,
                                         ADIEncoder irightEnc,
-                                        const double imaxOutput) {
+                                        const double imaxVelocity,
+                                        const double imaxVoltage) {
   return XDriveModel(std::make_shared<Motor>(itopLeftMotor),
                      std::make_shared<Motor>(itopRightMotor),
                      std::make_shared<Motor>(ibottomRightMotor),
                      std::make_shared<Motor>(ibottomLeftMotor),
                      std::make_shared<ADIEncoder>(ileftEnc),
                      std::make_shared<ADIEncoder>(irightEnc),
-                     imaxOutput);
+                     imaxVelocity,
+                     imaxVoltage);
 }
 
 ThreeEncoderSkidSteerModel ChassisModelFactory::create(Motor ileftSideMotor,
@@ -67,13 +79,15 @@ ThreeEncoderSkidSteerModel ChassisModelFactory::create(Motor ileftSideMotor,
                                                        ADIEncoder ileftEnc,
                                                        ADIEncoder imiddleEnc,
                                                        ADIEncoder irightEnc,
-                                                       const double imaxOutput) {
+                                                       const double imaxVelocity,
+                                                       const double imaxVoltage) {
   return ThreeEncoderSkidSteerModel(std::make_shared<Motor>(ileftSideMotor),
                                     std::make_shared<Motor>(irightSideMotor),
                                     std::make_shared<ADIEncoder>(ileftEnc),
                                     std::make_shared<ADIEncoder>(imiddleEnc),
                                     std::make_shared<ADIEncoder>(irightEnc),
-                                    imaxOutput);
+                                    imaxVelocity,
+                                    imaxVoltage);
 }
 
 ThreeEncoderSkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor,
@@ -81,12 +95,14 @@ ThreeEncoderSkidSteerModel ChassisModelFactory::create(MotorGroup ileftSideMotor
                                                        ADIEncoder ileftEnc,
                                                        ADIEncoder imiddleEnc,
                                                        ADIEncoder irightEnc,
-                                                       const double imaxOutput) {
+                                                       const double imaxVelocity,
+                                                       const double imaxVoltage) {
   return ThreeEncoderSkidSteerModel(std::make_shared<MotorGroup>(ileftSideMotor),
                                     std::make_shared<MotorGroup>(irightSideMotor),
                                     std::make_shared<ADIEncoder>(ileftEnc),
                                     std::make_shared<ADIEncoder>(imiddleEnc),
                                     std::make_shared<ADIEncoder>(irightEnc),
-                                    imaxOutput);
+                                    imaxVelocity,
+                                    imaxVoltage);
 }
 } // namespace okapi

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -20,7 +20,7 @@ void opcontrol() {
   Controller master;
   pros::c::lcd_initialize();
   while (true) {
-    drive.tank(0.3,0.3);
+    drive.tank(0.3, 0.3);
     // drive.forward(100);
     pros::c::lcd_print(0, "cnt %f", master.getAnalog(ControllerAnalog::rightY));
     pros::delay(50);

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -1,6 +1,5 @@
 #include "main.h"
-
-using namespace pros::literals;
+#include "okapi/api.hpp"
 
 /**
  * Runs the operator control code. This function will be started in its own task
@@ -16,20 +15,14 @@ using namespace pros::literals;
  * task, not resume it from where it left off.
  */
 void opcontrol() {
-  pros::Controller master(pros::E_CONTROLLER_MASTER);
-  auto left_mtr = 1_mtr;
-  pros::Motor right_mtr(2);
+  using namespace okapi;
+  auto drive = ChassisControllerFactory::create(-18, 19);
+  Controller master;
+  pros::c::lcd_initialize();
   while (true) {
-    pros::lcd::print(0,
-                     "%d %d %d",
-                     (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
-                     (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
-                     (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
-    int left = master.get_analog(ANALOG_LEFT_Y);
-    int right = master.get_analog(ANALOG_RIGHT_Y);
-
-    left_mtr = left;
-    right_mtr = right;
-    pros::delay(20);
+    drive.tank(0.3,0.3);
+    // drive.forward(100);
+    pros::c::lcd_print(0, "cnt %f", master.getAnalog(ControllerAnalog::rightY));
+    pros::delay(50);
   }
 }

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -96,14 +96,14 @@ TEST_F(SkidSteerModelTest, TankHalfPower) {
   model.tank(0.5, 0.5);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(63);
+  assertAllMotorsLastVoltage(6000);
 }
 
 TEST_F(SkidSteerModelTest, TankBoundsInput) {
   model.tank(10, 10);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(127);
+  assertAllMotorsLastVoltage(12000);
 }
 
 TEST_F(SkidSteerModelTest, TankThresholds) {
@@ -117,21 +117,21 @@ TEST_F(SkidSteerModelTest, ArcadeHalfPower) {
   model.arcade(0.5, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(63);
+  assertAllMotorsLastVoltage(6000);
 }
 
 TEST_F(SkidSteerModelTest, ArcadeHalfPowerTurn) {
   model.arcade(0, 0.5);
 
   assertAllMotorsLastVelocity(0);
-  assertLeftAndRightMotorsLastVoltage(63, -63);
+  assertLeftAndRightMotorsLastVoltage(6000, -6000);
 }
 
 TEST_F(SkidSteerModelTest, ArcadeBoundsInput) {
   model.arcade(10, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(127);
+  assertAllMotorsLastVoltage(12000);
 }
 
 TEST_F(SkidSteerModelTest, ArcadeThresholds) {

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -108,14 +108,14 @@ TEST_F(XDriveModelTest, TankHalfPower) {
   model.tank(0.5, 0.5);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(63);
+  assertAllMotorsLastVoltage(6000);
 }
 
 TEST_F(XDriveModelTest, TankBoundsInput) {
   model.tank(10, 10);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(127);
+  assertAllMotorsLastVoltage(12000);
 }
 
 TEST_F(XDriveModelTest, TankThresholds) {
@@ -129,21 +129,21 @@ TEST_F(XDriveModelTest, ArcadeHalfPower) {
   model.arcade(0.5, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(63);
+  assertAllMotorsLastVoltage(6000);
 }
 
 TEST_F(XDriveModelTest, ArcadeHalfPowerTurn) {
   model.arcade(0, 0.5);
 
   assertAllMotorsLastVelocity(0);
-  assertLeftAndRightMotorsLastVoltage(63, -63);
+  assertLeftAndRightMotorsLastVoltage(6000, -6000);
 }
 
 TEST_F(XDriveModelTest, ArcadeBoundsInput) {
   model.arcade(10, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(127);
+  assertAllMotorsLastVoltage(12000);
 }
 
 TEST_F(XDriveModelTest, ArcadeThresholds) {
@@ -157,14 +157,14 @@ TEST_F(XDriveModelTest, XArcadeHalfPowerForward) {
   model.xArcade(0, 0.5, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(63);
+  assertAllMotorsLastVoltage(6000);
 }
 
 TEST_F(XDriveModelTest, XArcadeForwardBoundsInput) {
   model.xArcade(0, 10, 0);
 
   assertAllMotorsLastVelocity(0);
-  assertAllMotorsLastVoltage(127);
+  assertAllMotorsLastVoltage(12000);
 }
 
 TEST_F(XDriveModelTest, XArcadeForwardThresholds) {
@@ -178,20 +178,20 @@ TEST_F(XDriveModelTest, XArcadeHalfPowerStrafe) {
   model.xArcade(0.5, 0, 0);
 
   assertAllMotorsLastVelocity(0);
-  EXPECT_EQ(topLeftMotor->lastVoltage, 63);
-  EXPECT_EQ(topRightMotor->lastVoltage, -63);
-  EXPECT_EQ(bottomRightMotor->lastVoltage, 63);
-  EXPECT_EQ(bottomLeftMotor->lastVoltage, -63);
+  EXPECT_EQ(topLeftMotor->lastVoltage, 6000);
+  EXPECT_EQ(topRightMotor->lastVoltage, -6000);
+  EXPECT_EQ(bottomRightMotor->lastVoltage, 6000);
+  EXPECT_EQ(bottomLeftMotor->lastVoltage, -6000);
 }
 
 TEST_F(XDriveModelTest, XArcadeStrafeBoundsInput) {
   model.xArcade(10, 0, 0);
 
   assertAllMotorsLastVelocity(0);
-  EXPECT_EQ(topLeftMotor->lastVoltage, 127);
-  EXPECT_EQ(topRightMotor->lastVoltage, -127);
-  EXPECT_EQ(bottomRightMotor->lastVoltage, 127);
-  EXPECT_EQ(bottomLeftMotor->lastVoltage, -127);
+  EXPECT_EQ(topLeftMotor->lastVoltage, 12000);
+  EXPECT_EQ(topRightMotor->lastVoltage, -12000);
+  EXPECT_EQ(bottomRightMotor->lastVoltage, 12000);
+  EXPECT_EQ(bottomLeftMotor->lastVoltage, -12000);
 }
 
 TEST_F(XDriveModelTest, XArcadeStrafeThresholds) {
@@ -205,14 +205,14 @@ TEST_F(XDriveModelTest, XArcadeTurnBoundsInput) {
   model.xArcade(0, 0, 10);
 
   assertAllMotorsLastVelocity(0);
-  assertLeftAndRightMotorsLastVoltage(127, -127);
+  assertLeftAndRightMotorsLastVoltage(12000, -12000);
 }
 
 TEST_F(XDriveModelTest, XArcadeTurnHalfPower) {
   model.xArcade(0, 0, 0.5);
 
   assertAllMotorsLastVelocity(0);
-  assertLeftAndRightMotorsLastVoltage(63, -63);
+  assertLeftAndRightMotorsLastVoltage(6000, -6000);
 }
 
 TEST_F(XDriveModelTest, XArcadeTurnThresholds) {
@@ -226,19 +226,19 @@ TEST_F(XDriveModelTest, XArcadeBoundsInputAllPoweredFull) {
   model.xArcade(10, 10, 10);
 
   assertAllMotorsLastVelocity(0);
-  EXPECT_EQ(topLeftMotor->lastVoltage, 127);
-  EXPECT_EQ(topRightMotor->lastVoltage, -127);
-  EXPECT_EQ(bottomRightMotor->lastVoltage, 127);
-  EXPECT_EQ(bottomLeftMotor->lastVoltage, 127);
+  EXPECT_EQ(topLeftMotor->lastVoltage, 12000);
+  EXPECT_EQ(topRightMotor->lastVoltage, -12000);
+  EXPECT_EQ(bottomRightMotor->lastVoltage, 12000);
+  EXPECT_EQ(bottomLeftMotor->lastVoltage, 12000);
 }
 
 TEST_F(XDriveModelTest, XArcadeBoundsInputAllNoTurn) {
   model.xArcade(10, 10, 0);
 
   assertAllMotorsLastVelocity(0);
-  EXPECT_EQ(topLeftMotor->lastVoltage, 127);
+  EXPECT_EQ(topLeftMotor->lastVoltage, 12000);
   EXPECT_EQ(topRightMotor->lastVoltage, 0);
-  EXPECT_EQ(bottomRightMotor->lastVoltage, 127);
+  EXPECT_EQ(bottomRightMotor->lastVoltage, 12000);
   EXPECT_EQ(bottomLeftMotor->lastVoltage, 0);
 }
 
@@ -246,8 +246,8 @@ TEST_F(XDriveModelTest, XArcadeBoundsInputAllNoForward) {
   model.xArcade(10, 0, 10);
 
   assertAllMotorsLastVelocity(0);
-  EXPECT_EQ(topLeftMotor->lastVoltage, 127);
-  EXPECT_EQ(topRightMotor->lastVoltage, -127);
+  EXPECT_EQ(topLeftMotor->lastVoltage, 12000);
+  EXPECT_EQ(topRightMotor->lastVoltage, -12000);
   EXPECT_EQ(bottomRightMotor->lastVoltage, 0);
   EXPECT_EQ(bottomLeftMotor->lastVoltage, 0);
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes #183 by adding a separate scale for voltage. This new scales is `12000` by default.

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

The `ChassisModel` tests were fixed to test for the new voltages (`6000` and `12000` instead of `63` and `127`). This change was also verified by hand.

### Applicable Issues

Closes #183.
