### PR TITLE
Issue #189: Make ChassisModel left and right bound inputs

### DIFF
--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -133,11 +133,11 @@ void SkidSteerModel::arcade(const double iySpeed,
 }
 
 void SkidSteerModel::left(const double ispeed) const {
-  leftSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  leftSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
 void SkidSteerModel::right(const double ispeed) const {
-  rightSideMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  rightSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
 std::valarray<std::int32_t> SkidSteerModel::getSensorVals() const {

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -183,13 +183,13 @@ void XDriveModel::xArcade(const double ixSpeed,
 }
 
 void XDriveModel::left(const double ispeed) const {
-  topLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  topLeftMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
 void XDriveModel::right(const double ispeed) const {
-  topRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(ispeed * maxVelocity));
+  topRightMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
 std::valarray<std::int32_t> XDriveModel::getSensorVals() const {

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -183,13 +183,15 @@ void XDriveModel::xArcade(const double ixSpeed,
 }
 
 void XDriveModel::left(const double ispeed) const {
-  topLeftMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
+  const double speed = std::clamp(ispeed, -1.0, 1.0);
+  topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
 void XDriveModel::right(const double ispeed) const {
-  topRightMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
+  const double speed = std::clamp(ispeed, -1.0, 1.0);
+  topRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
 std::valarray<std::int32_t> XDriveModel::getSensorVals() const {

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -87,9 +87,19 @@ TEST_F(SkidSteerModelTest, LeftHalfPower) {
   assertLeftAndRightMotorsLastVelocity(63, 0);
 }
 
+TEST_F(SkidSteerModelTest, LeftBoundsInput) {
+  model.left(10);
+  assertLeftAndRightMotorsLastVelocity(127, 0);
+}
+
 TEST_F(SkidSteerModelTest, RightHalfPower) {
   model.right(0.5);
   assertLeftAndRightMotorsLastVelocity(0, 63);
+}
+
+TEST_F(SkidSteerModelTest, RightBoundsInput) {
+  model.right(10);
+  assertLeftAndRightMotorsLastVelocity(0, 127);
 }
 
 TEST_F(SkidSteerModelTest, TankHalfPower) {

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -99,9 +99,19 @@ TEST_F(XDriveModelTest, LeftHalfPower) {
   assertLeftAndRightMotorsLastVelocity(63, 0);
 }
 
+TEST_F(XDriveModelTest, LeftBoundsInput) {
+  model.left(10);
+  assertLeftAndRightMotorsLastVelocity(127, 0);
+}
+
 TEST_F(XDriveModelTest, RightHalfPower) {
   model.right(0.5);
   assertLeftAndRightMotorsLastVelocity(0, 63);
+}
+
+TEST_F(XDriveModelTest, RightBoundsInput) {
+  model.right(10);
+  assertLeftAndRightMotorsLastVelocity(0, 127);
 }
 
 TEST_F(XDriveModelTest, TankHalfPower) {


### PR DESCRIPTION
### Description of the Change

The `SkidSteerModel` and `XDriveModel` implementations of `left()` and `right()` did not bound their inputs. This PR fixes that bug and adds tests for it.

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

New tests were added to check for bounding.

### Applicable Issues

Closes #189.
