### PR TITLE
Make IterativePosPIDController gains zero by default

### DIFF
--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -23,10 +23,10 @@ namespace okapi {
 class IterativePosPIDController : public IterativePositionController<double, double> {
   public:
   struct Gains {
-    double kP;
-    double kI;
-    double kD;
-    double kBias;
+    double kP{0};
+    double kI{0};
+    double kD{0};
+    double kBias{0};
   };
 
   /**


### PR DESCRIPTION
### Description of the Change

This makes sure the gains are zero if the user doesn't initialize them directly.

### Verification Process

This was not verified.

### Applicable Issues

None.
