### PR TITLE
Issue #195: Add createPtr versions of all the CCF methods

### DIFF
--- a/include/okapi/impl/chassis/controller/chassisControllerFactory.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerFactory.hpp
@@ -43,11 +43,43 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerIntegrated>
+  createPtr(Motor ileftSideMotor,
+            Motor irightSideMotor,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
+   * steer layout. Puts the motors into degree units. Throws a std::invalid_argument exception if
+   * the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerIntegrated
   create(MotorGroup ileftSideMotor,
          MotorGroup irightSideMotor,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using the V5 motor's integrated control. This constructor assumes a skid
+   * steer layout. Puts the motors into degree units. Throws a std::invalid_argument exception if
+   * the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerIntegrated>
+  createPtr(MotorGroup ileftSideMotor,
+            MotorGroup irightSideMotor,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
@@ -70,6 +102,26 @@ class ChassisControllerFactory {
          const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
+   * ChassisController using V5 motor's integrated control. This constructor assumes an x-drive
+   * layout. Puts the motors into degree units. Throws a std::invalid_argument exception if the gear
+   * ratio is zero.
+   *
+   * @param itopLeftMotor top left motor (also used for controller input)
+   * @param itopRightMotor top right motor (also used for controller input)
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerIntegrated>
+  createPtr(Motor itopLeftMotor,
+            Motor itopRightMotor,
+            Motor ibottomRightMotor,
+            Motor ibottomLeftMotor,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
    * ChassisController using PID control. This constructor assumes a skid
    * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
    * exception if the gear ratio is zero.
@@ -88,6 +140,26 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iangleArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor ileftSideMotor,
+            Motor irightSideMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -122,6 +194,27 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor ileftSideMotor,
+            Motor irightSideMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerPID
   create(MotorGroup ileftSideMotor,
          MotorGroup irightSideMotor,
@@ -129,6 +222,26 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iangleArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(MotorGroup ileftSideMotor,
+            MotorGroup irightSideMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -150,6 +263,27 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iturnArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor (also used for controller input)
+   * @param irightSideMotor right side motor (also used for controller input)
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(MotorGroup ileftSideMotor,
+            MotorGroup irightSideMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -189,6 +323,30 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(MotorGroup ileftSideMotor,
+            MotorGroup irightSideMotor,
+            ADIEncoder ileftEnc,
+            ADIEncoder irightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param ileftEnc left side encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerPID
   create(MotorGroup ileftSideMotor,
          MotorGroup irightSideMotor,
@@ -207,6 +365,31 @@ class ChassisControllerFactory {
    *
    * @param ileftSideMotor left side motor
    * @param irightSideMotor right side motor
+   * @param ileftEnc left side encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(MotorGroup ileftSideMotor,
+            MotorGroup irightSideMotor,
+            ADIEncoder ileftEnc,
+            ADIEncoder irightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
    * @param idistanceArgs distance PID controller params
    * @param iangleArgs angle PID controller params (keeps the robot straight)
    * @param igearset motor internal gearset and gear ratio
@@ -221,6 +404,28 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iangleArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(std::shared_ptr<AbstractMotor> ileftSideMotor,
+            std::shared_ptr<AbstractMotor> irightSideMotor,
+            std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+            std::shared_ptr<ContinuousRotarySensor> irightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -250,6 +455,29 @@ class ChassisControllerFactory {
    * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
    * exception if the gear ratio is zero.
    *
+   * @param ileftSideMotor left side motor
+   * @param irightSideMotor right side motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(std::shared_ptr<AbstractMotor> ileftSideMotor,
+            std::shared_ptr<AbstractMotor> irightSideMotor,
+            std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+            std::shared_ptr<ContinuousRotarySensor> irightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
    * @param itopLeftMotor top left motor (also used for controller input)
    * @param itopRightMotor top right motor (also used for controller input)
    * @param ibottomRightMotor bottom right motor
@@ -283,6 +511,30 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor itopLeftMotor,
+            Motor itopRightMotor,
+            Motor ibottomRightMotor,
+            Motor ibottomLeftMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor (also used for controller input)
+   * @param itopRightMotor top right motor (also used for controller input)
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerPID
   create(Motor itopLeftMotor,
          Motor itopRightMotor,
@@ -293,6 +545,31 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iturnArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor (also used for controller input)
+   * @param itopRightMotor top right motor (also used for controller input)
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor itopLeftMotor,
+            Motor itopRightMotor,
+            Motor ibottomRightMotor,
+            Motor ibottomLeftMotor,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -340,6 +617,35 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor itopLeftMotor,
+            Motor itopRightMotor,
+            Motor ibottomRightMotor,
+            Motor ibottomLeftMotor,
+            ADIEncoder itopLeftEnc,
+            ADIEncoder itopRightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerPID
   create(Motor itopLeftMotor,
          Motor itopRightMotor,
@@ -370,6 +676,36 @@ class ChassisControllerFactory {
    * @param igearset motor internal gearset and gear ratio
    * @param iscales see ChassisScales docs
    */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(Motor itopLeftMotor,
+            Motor itopRightMotor,
+            Motor ibottomRightMotor,
+            Motor ibottomLeftMotor,
+            ADIEncoder itopLeftEnc,
+            ADIEncoder itopRightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
   static ChassisControllerPID
   create(std::shared_ptr<AbstractMotor> itopLeftMotor,
          std::shared_ptr<AbstractMotor> itopRightMotor,
@@ -381,6 +717,35 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iangleArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(std::shared_ptr<AbstractMotor> itopLeftMotor,
+            std::shared_ptr<AbstractMotor> itopRightMotor,
+            std::shared_ptr<AbstractMotor> ibottomRightMotor,
+            std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+            std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+            std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 
   /**
    * ChassisController using PID control. This constructor assumes a skid
@@ -411,6 +776,36 @@ class ChassisControllerFactory {
          const IterativePosPIDController::Gains &iturnArgs,
          AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
          const ChassisScales &iscales = ChassisScales({1, 1}));
+
+  /**
+   * ChassisController using PID control. This constructor assumes a skid
+   * steer layout. Puts the motors into encoder degree units. Throws a std::invalid_argument
+   * exception if the gear ratio is zero.
+   *
+   * @param itopLeftMotor top left motor
+   * @param itopRightMotor top right motor
+   * @param ibottomRightMotor bottom right motor
+   * @param ibottomLeftMotor bottom left motor
+   * @param itopLeftEnc top left encoder
+   * @param itopRightEnc top right encoder
+   * @param irightEnc right side encoder
+   * @param idistanceArgs distance PID controller params
+   * @param iangleArgs angle PID controller params (keeps the robot straight)
+   * @param igearset motor internal gearset and gear ratio
+   * @param iscales see ChassisScales docs
+   */
+  static std::shared_ptr<ChassisControllerPID>
+  createPtr(std::shared_ptr<AbstractMotor> itopLeftMotor,
+            std::shared_ptr<AbstractMotor> itopRightMotor,
+            std::shared_ptr<AbstractMotor> ibottomRightMotor,
+            std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+            std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+            std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+            const IterativePosPIDController::Gains &idistanceArgs,
+            const IterativePosPIDController::Gains &iangleArgs,
+            const IterativePosPIDController::Gains &iturnArgs,
+            AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,
+            const ChassisScales &iscales = ChassisScales({1, 1}));
 };
 } // namespace okapi
 

--- a/src/impl/chassis/controller/chassisControllerFactory.cpp
+++ b/src/impl/chassis/controller/chassisControllerFactory.cpp
@@ -27,6 +27,22 @@ ChassisControllerFactory::create(Motor ileftSideMotor,
     iscales);
 }
 
+std::shared_ptr<ChassisControllerIntegrated>
+ChassisControllerFactory::createPtr(Motor ileftSideMotor,
+                                    Motor irightSideMotor,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
+  auto rightMtr = std::make_shared<Motor>(irightSideMotor);
+  return std::make_shared<ChassisControllerIntegrated>(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+    std::make_unique<AsyncPosIntegratedController>(leftMtr, TimeUtilFactory::create()),
+    std::make_unique<AsyncPosIntegratedController>(rightMtr, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+}
+
 ChassisControllerIntegrated
 ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  MotorGroup irightSideMotor,
@@ -35,6 +51,22 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
   auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
   auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
   return ChassisControllerIntegrated(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+    std::make_unique<AsyncPosIntegratedController>(leftMtr, TimeUtilFactory::create()),
+    std::make_unique<AsyncPosIntegratedController>(rightMtr, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+}
+
+std::shared_ptr<ChassisControllerIntegrated>
+ChassisControllerFactory::createPtr(MotorGroup ileftSideMotor,
+                                    MotorGroup irightSideMotor,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  return std::make_shared<ChassisControllerIntegrated>(
     TimeUtilFactory::create(),
     std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
     std::make_unique<AsyncPosIntegratedController>(leftMtr, TimeUtilFactory::create()),
@@ -63,6 +95,26 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
     iscales);
 }
 
+std::shared_ptr<ChassisControllerIntegrated>
+ChassisControllerFactory::createPtr(Motor itopLeftMotor,
+                                    Motor itopRightMotor,
+                                    Motor ibottomRightMotor,
+                                    Motor ibottomLeftMotor,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
+  auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
+  auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
+  auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
+  return std::make_shared<ChassisControllerIntegrated>(
+    TimeUtilFactory::create(),
+    std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
+    std::make_unique<AsyncPosIntegratedController>(topLeftMtr, TimeUtilFactory::create()),
+    std::make_unique<AsyncPosIntegratedController>(topRightMtr, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(Motor ileftSideMotor,
                                  Motor irightSideMotor,
@@ -71,6 +123,17 @@ ChassisControllerFactory::create(Motor ileftSideMotor,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
   return create(
+    ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor ileftSideMotor,
+                                    Motor irightSideMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(
     ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
 }
 
@@ -96,6 +159,28 @@ ChassisControllerFactory::create(Motor ileftSideMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor ileftSideMotor,
+                                    Motor irightSideMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<Motor>(ileftSideMotor);
+  auto rightMtr = std::make_shared<Motor>(irightSideMotor);
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  MotorGroup irightSideMotor,
@@ -104,6 +189,17 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  const AbstractMotor::GearsetRatioPair igearset,
                                  const ChassisScales &iscales) {
   return create(
+    ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(MotorGroup ileftSideMotor,
+                                    MotorGroup irightSideMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(
     ileftSideMotor, irightSideMotor, idistanceArgs, iangleArgs, iangleArgs, igearset, iscales);
 }
 
@@ -129,6 +225,28 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(MotorGroup ileftSideMotor,
+                                    MotorGroup irightSideMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(leftMtr, rightMtr),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                                  MotorGroup irightSideMotor,
@@ -149,6 +267,28 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
                 iangleArgs,
                 igearset,
                 iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(MotorGroup ileftSideMotor,
+                                    MotorGroup irightSideMotor,
+                                    ADIEncoder ileftEnc,
+                                    ADIEncoder irightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  return createPtr(ileftSideMotor,
+                   irightSideMotor,
+                   ileftEnc,
+                   irightEnc,
+                   idistanceArgs,
+                   iangleArgs,
+                   iangleArgs,
+                   igearset,
+                   iscales);
 }
 
 ChassisControllerPID
@@ -178,6 +318,33 @@ ChassisControllerFactory::create(MotorGroup ileftSideMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(MotorGroup ileftSideMotor,
+                                    MotorGroup irightSideMotor,
+                                    ADIEncoder ileftEnc,
+                                    ADIEncoder irightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto leftMtr = std::make_shared<MotorGroup>(ileftSideMotor);
+  auto rightMtr = std::make_shared<MotorGroup>(irightSideMotor);
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(leftMtr,
+                                     rightMtr,
+                                     std::make_shared<ADIEncoder>(ileftEnc),
+                                     std::make_shared<ADIEncoder>(irightEnc)),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                  std::shared_ptr<AbstractMotor> irightSideMotor,
@@ -196,6 +363,26 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> ileftSideMotor,
                 iangleArgs,
                 igearset,
                 iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(std::shared_ptr<AbstractMotor> ileftSideMotor,
+                                    std::shared_ptr<AbstractMotor> irightSideMotor,
+                                    std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+                                    std::shared_ptr<ContinuousRotarySensor> irightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(ileftSideMotor,
+                   irightSideMotor,
+                   ileftEnc,
+                   irightEnc,
+                   idistanceArgs,
+                   iangleArgs,
+                   iangleArgs,
+                   igearset,
+                   iscales);
 }
 
 ChassisControllerPID
@@ -220,6 +407,28 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> ileftSideMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(std::shared_ptr<AbstractMotor> ileftSideMotor,
+                                    std::shared_ptr<AbstractMotor> irightSideMotor,
+                                    std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+                                    std::shared_ptr<ContinuousRotarySensor> irightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<SkidSteerModel>(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(Motor itopLeftMotor,
                                  Motor itopRightMotor,
@@ -238,6 +447,26 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
                 iangleArgs,
                 igearset,
                 iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor itopLeftMotor,
+                                    Motor itopRightMotor,
+                                    Motor ibottomRightMotor,
+                                    Motor ibottomLeftMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(itopLeftMotor,
+                   itopRightMotor,
+                   ibottomRightMotor,
+                   ibottomLeftMotor,
+                   idistanceArgs,
+                   iangleArgs,
+                   iangleArgs,
+                   igearset,
+                   iscales);
 }
 
 ChassisControllerPID
@@ -266,6 +495,32 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor itopLeftMotor,
+                                    Motor itopRightMotor,
+                                    Motor ibottomRightMotor,
+                                    Motor ibottomLeftMotor,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
+  auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
+  auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
+  auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<XDriveModel>(topLeftMtr, topRightMtr, bottomRightMtr, bottomLeftMtr),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(Motor itopLeftMotor,
                                  Motor itopRightMotor,
@@ -288,6 +543,30 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
                 iangleArgs,
                 igearset,
                 iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor itopLeftMotor,
+                                    Motor itopRightMotor,
+                                    Motor ibottomRightMotor,
+                                    Motor ibottomLeftMotor,
+                                    ADIEncoder itopLeftEnc,
+                                    ADIEncoder itopRightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(itopLeftMotor,
+                   itopRightMotor,
+                   ibottomRightMotor,
+                   ibottomLeftMotor,
+                   itopLeftEnc,
+                   itopRightEnc,
+                   idistanceArgs,
+                   iangleArgs,
+                   iangleArgs,
+                   igearset,
+                   iscales);
 }
 
 ChassisControllerPID
@@ -323,6 +602,39 @@ ChassisControllerFactory::create(Motor itopLeftMotor,
   return out;
 }
 
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(Motor itopLeftMotor,
+                                    Motor itopRightMotor,
+                                    Motor ibottomRightMotor,
+                                    Motor ibottomLeftMotor,
+                                    ADIEncoder itopLeftEnc,
+                                    ADIEncoder itopRightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  auto topLeftMtr = std::make_shared<Motor>(itopLeftMotor);
+  auto topRightMtr = std::make_shared<Motor>(itopRightMotor);
+  auto bottomRightMtr = std::make_shared<Motor>(ibottomRightMotor);
+  auto bottomLeftMtr = std::make_shared<Motor>(ibottomLeftMotor);
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<XDriveModel>(topLeftMtr,
+                                  topRightMtr,
+                                  bottomRightMtr,
+                                  bottomLeftMtr,
+                                  std::make_shared<ADIEncoder>(itopLeftEnc),
+                                  std::make_shared<ADIEncoder>(itopRightEnc)),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
+  return out;
+}
+
 ChassisControllerPID
 ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> itopLeftMotor,
                                  std::shared_ptr<AbstractMotor> itopRightMotor,
@@ -345,6 +657,30 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> itopLeftMotor,
                 iangleArgs,
                 igearset,
                 iscales);
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(std::shared_ptr<AbstractMotor> itopLeftMotor,
+                                    std::shared_ptr<AbstractMotor> itopRightMotor,
+                                    std::shared_ptr<AbstractMotor> ibottomRightMotor,
+                                    std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+                                    std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+                                    std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  return createPtr(itopLeftMotor,
+                   itopRightMotor,
+                   ibottomRightMotor,
+                   ibottomLeftMotor,
+                   itopLeftEnc,
+                   itopRightEnc,
+                   idistanceArgs,
+                   iangleArgs,
+                   iangleArgs,
+                   igearset,
+                   iscales);
 }
 
 ChassisControllerPID
@@ -373,6 +709,35 @@ ChassisControllerFactory::create(std::shared_ptr<AbstractMotor> itopLeftMotor,
     igearset,
     iscales);
   out.startThread();
+  return out;
+}
+
+std::shared_ptr<ChassisControllerPID>
+ChassisControllerFactory::createPtr(std::shared_ptr<AbstractMotor> itopLeftMotor,
+                                    std::shared_ptr<AbstractMotor> itopRightMotor,
+                                    std::shared_ptr<AbstractMotor> ibottomRightMotor,
+                                    std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+                                    std::shared_ptr<ContinuousRotarySensor> itopLeftEnc,
+                                    std::shared_ptr<ContinuousRotarySensor> itopRightEnc,
+                                    const IterativePosPIDController::Gains &idistanceArgs,
+                                    const IterativePosPIDController::Gains &iangleArgs,
+                                    const IterativePosPIDController::Gains &iturnArgs,
+                                    const AbstractMotor::GearsetRatioPair igearset,
+                                    const ChassisScales &iscales) {
+  std::shared_ptr<ChassisControllerPID> out = std::make_shared<ChassisControllerPID>(
+    TimeUtilFactory::create(),
+    std::make_shared<XDriveModel>(itopLeftMotor,
+                                  itopRightMotor,
+                                  ibottomRightMotor,
+                                  ibottomLeftMotor,
+                                  itopLeftEnc,
+                                  itopRightEnc),
+    std::make_unique<IterativePosPIDController>(idistanceArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iangleArgs, TimeUtilFactory::create()),
+    std::make_unique<IterativePosPIDController>(iturnArgs, TimeUtilFactory::create()),
+    igearset,
+    iscales);
+  out->startThread();
   return out;
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

Some users are trying to share a `ChassisController` directly between files (instead of wrapping it in another class) and then, of course, run into the problem that the two existing `ChassisController` implementations are not copyable. This PR adds`createPtr()` methods in addition to the `create()` methods of `ChassisControllerFactory`.

### Benefits

Sharing a pointer between files is easier for a lot of users compared to writing a "drive" class that can be shared instead.

### Possible Drawbacks

None.

### Verification Process

This was verified by hand.

### Applicable Issues

Closes #195.
