### PR TITLE
#199: Fix QMass literals namespace

### DIFF
--- a/include/okapi/api/units/QMass.hpp
+++ b/include/okapi/api/units/QMass.hpp
@@ -26,7 +26,7 @@ constexpr QMass ounce = 0.028349523125 * kg;
 constexpr QMass pound = 16 * ounce;
 constexpr QMass stone = 14 * pound;
 
-inline namespace okapi {
+inline namespace literals {
 constexpr QMass operator"" _kg(long double x) {
   return QMass(x);
 }

--- a/include/okapi/api/units/QMass.hpp
+++ b/include/okapi/api/units/QMass.hpp
@@ -63,7 +63,7 @@ constexpr QMass operator"" _lb(unsigned long long int x) {
 constexpr QMass operator"" _st(unsigned long long int x) {
   return static_cast<double>(x) * stone;
 }
-} // namespace okapi
+} // namespace literals
 } // namespace okapi
 
 #endif


### PR DESCRIPTION
### Description of the Change

`QMass.hpp` had `inline namespace okapi` when it should have had `inline namespace literals`. I don't know why this wasn't a problem until Manas tried using intellisense under vscode.

### Applicable Issues

Closes #199.
