### PR TITLE
RQuantity unary minus operator overload

### DIFF
--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -40,9 +40,8 @@ class RQuantity {
     return *this;
   }
 
-  constexpr RQuantity const &operator-() {
-    value *= -1;
-    return *this;
+  constexpr RQuantity operator-() {
+    return RQuantity(value * -1);
   }
 
   // Returns the value of the quantity in multiples of the specified unit

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -40,6 +40,11 @@ class RQuantity {
     return *this;
   }
 
+  constexpr RQuantity const &operator-() {
+    value *= -1;
+    return *this;
+  }
+
   // Returns the value of the quantity in multiples of the specified unit
   constexpr double convert(const RQuantity &rhs) const {
     return value / rhs.value;

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -5,6 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QTime.hpp"
 #include "test/crossPlatformTestRunner.hpp"
 #include <gtest/gtest.h>
@@ -23,5 +24,11 @@ TEST(UnitTests, TimeAssignmentAddition) {
   start += 1_ms;
 
   EXPECT_DOUBLE_EQ(start.convert(millisecond), (1_ms).convert(millisecond));
+}
+
+TEST(UnitTests, UnaryMinusTest) {
+  EXPECT_EQ((1_ft - -4_ft).convert(foot), 5);
+  EXPECT_EQ((1_ft - 4_ft).convert(foot), -3);
+  EXPECT_EQ((1_s + -500_ms).convert(millisecond), 500);
 }
 } // namespace okapi

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -30,5 +30,10 @@ TEST(UnitTests, UnaryMinusTest) {
   EXPECT_EQ((1_ft - -4_ft).convert(foot), 5);
   EXPECT_EQ((1_ft - 4_ft).convert(foot), -3);
   EXPECT_EQ((1_s + -500_ms).convert(millisecond), 500);
+
+  // Make sure there are no side-effects
+  auto test = 5_in;
+  -test;
+  EXPECT_NE(test.convert(inch), -5);
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

To get around C++'s inability to handle code such as `-4_ft`, we can overload `operator-` to negate the underlying value like normal.

### Benefits

People want to write `-4_ft` naturally instead of `-1 * 4_ft` so this will help get rid of some errors.

### Possible Drawbacks

None.

### Verification Process

Some small new test cases were added for sanity checks.

### Applicable Issues

Closes #201.
