### PR TITLE
1D Motion Profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(OkapiLibV5
         include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
         include/okapi/api/chassis/model/xDriveModel.hpp
         include/okapi/api/control/async/asyncController.hpp
+        include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
         include/okapi/api/control/async/asyncMotionProfileController.hpp
         include/okapi/api/control/async/asyncPosIntegratedController.hpp
         include/okapi/api/control/async/asyncPositionController.hpp
@@ -125,6 +126,7 @@ add_executable(OkapiLibV5
         src/api/chassis/model/readOnlyChassisModel.cpp
         src/api/chassis/model/threeEncoderSkidSteerModel.cpp
         src/api/chassis/model/xDriveModel.cpp
+        src/api/control/async/asyncLinearMotionProfileController.cpp
         src/api/control/async/asyncMotionProfileController.cpp
         src/api/control/async/asyncPosIntegratedController.cpp
         src/api/control/async/asyncPosPidController.cpp
@@ -169,6 +171,7 @@ add_executable(OkapiLibV5
         test/asyncPosIntegratedControllerTests.cpp
         test/asyncVelIntegratedControllerTests.cpp
         test/asyncMotionProfileControllerTests.cpp
+        test/asyncLinearMotionProfileControllerTests.cpp
         test/iterativeVelPIDControllerTests.cpp
         test/iterativeMotorVelocityControllerTest.cpp
         test/iterativePosPIDControllerTests.cpp

--- a/include/main.h
+++ b/include/main.h
@@ -54,7 +54,7 @@
 /**
  * You should add more #includes here
  */
-//#include "okapi/api.hpp"
+#include "okapi/api.hpp"
 //#include "pros/api_legacy.h"
 
 #ifdef __cplusplus

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -18,6 +18,7 @@
 #include "okapi/impl/chassis/controller/chassisControllerFactory.hpp"
 #include "okapi/impl/chassis/model/chassisModelFactory.hpp"
 
+#include "okapi/api/control/async/asyncLinearMotionProfileController.hpp"
 #include "okapi/api/control/async/asyncMotionProfileController.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 #include "okapi/api/control/async/asyncPosPidController.hpp"

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -9,7 +9,7 @@
 #define _OKAPI_ASYNCLINEARMOTIONPROFILECONTROLLER_HPP_
 
 #include "okapi/api/control/async/asyncPositionController.hpp"
-#include "okapi/api/control/async/asyncVelocityController.hpp"
+#include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/units/QAngle.hpp"
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/util/logging.hpp"
@@ -32,12 +32,11 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param imaxJerk The maximum possible jerk.
    * @param ioutput The output to control.
    */
-  AsyncLinearMotionProfileController(
-    const TimeUtil &itimeUtil,
-    double imaxVel,
-    double imaxAccel,
-    double imaxJerk,
-    std::shared_ptr<AsyncVelocityController<double, double>> ioutput);
+  AsyncLinearMotionProfileController(const TimeUtil &itimeUtil,
+                                     double imaxVel,
+                                     double imaxAccel,
+                                     double imaxJerk,
+                                     std::shared_ptr<ControllerOutput<double>> ioutput);
 
   AsyncLinearMotionProfileController(AsyncLinearMotionProfileController &&other) noexcept;
 
@@ -165,7 +164,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   double maxVel{0};
   double maxAccel{0};
   double maxJerk{0};
-  std::shared_ptr<AsyncVelocityController<double, double>> output;
+  std::shared_ptr<ControllerOutput<double>> output;
   TimeUtil timeUtil;
 
   std::string currentPath{""};

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -22,7 +22,7 @@ extern "C" {
 }
 
 namespace okapi {
-class AsyncLinearMotionProfileController : public AsyncPositionController<std::string, QLength> {
+class AsyncLinearMotionProfileController : public AsyncPositionController<std::string, double> {
   public:
   /**
    * An Async Controller which generates and follows 1D motion profiles.
@@ -53,7 +53,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param iwaypoints The waypoints to hit on the path.
    * @param ipathId A unique identifier to save the path with.
    */
-  void generatePath(std::initializer_list<QLength> iwaypoints, const std::string &ipathId);
+  void generatePath(std::initializer_list<double> iwaypoints, const std::string &ipathId);
 
   /**
    * Removes a path and frees the memory it used.
@@ -110,7 +110,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param iposition The starting position.
    * @param itarget The target position.
    */
-  void moveTo(QLength iposition, QLength itarget);
+  void moveTo(double iposition, double itarget);
 
   /**
    * Returns the last error of the controller. Returns zero if there is no path currently being
@@ -118,7 +118,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    *
    * @return the last error
    */
-  QLength getError() const override;
+  double getError() const override;
 
   /**
    * Returns whether the controller has settled at the target. Determining what settling means is
@@ -177,7 +177,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   double maxAccel{0};
   double maxJerk{0};
   std::shared_ptr<ControllerOutput<double>> output;
-  QLength currentProfilePosition{0_m};
+  double currentProfilePosition{0};
   TimeUtil timeUtil;
 
   std::string currentPath{""};

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -78,6 +78,12 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   void setTarget(std::string ipathId) override;
 
   /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. This just calls setTarget().
+   */
+  void controllerSet(std::string ivalue) override;
+
+  /**
    * Gets the last set target, or the default target if none was set.
    *
    * @return the last target

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -30,7 +30,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param imaxVel The maximum possible velocity.
    * @param imaxAccel The maximum possible acceleration.
    * @param imaxJerk The maximum possible jerk.
-   * @param ioutput The output to control.
+   * @param ioutput The output to write velocity targets to.
    */
   AsyncLinearMotionProfileController(const TimeUtil &itimeUtil,
                                      double imaxVel,

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -91,6 +91,13 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   std::string getTarget() override;
 
   /**
+   * Gets the last set target, or the default target if none was set.
+   *
+   * @return the last target
+   */
+  std::string getTarget() const;
+
+  /**
    * Blocks the current task until the controller has settled. This controller is settled when
    * it has finished following a path. If no path is being followed, it is settled.
    */
@@ -106,9 +113,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   void moveTo(QLength iposition, QLength itarget);
 
   /**
-   * Returns the last error of the controller. This implementation always returns zero since the
-   * robot is assumed to perfectly follow the path. Subclasses can override this to be more
-   * accurate using odometry information.
+   * Returns the last error of the controller. Returns zero if there is no path currently being
+   * followed.
    *
    * @return the last error
    */
@@ -171,6 +177,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   double maxAccel{0};
   double maxJerk{0};
   std::shared_ptr<ControllerOutput<double>> output;
+  QLength currentProfilePosition{0_m};
   TimeUtil timeUtil;
 
   std::string currentPath{""};

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -1,0 +1,178 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#ifndef _OKAPI_ASYNCLINEARMOTIONPROFILECONTROLLER_HPP_
+#define _OKAPI_ASYNCLINEARMOTIONPROFILECONTROLLER_HPP_
+
+#include "okapi/api/control/async/asyncPositionController.hpp"
+#include "okapi/api/control/async/asyncVelocityController.hpp"
+#include "okapi/api/units/QAngle.hpp"
+#include "okapi/api/units/QLength.hpp"
+#include "okapi/api/util/logging.hpp"
+#include "okapi/api/util/timeUtil.hpp"
+#include <atomic>
+#include <map>
+
+extern "C" {
+#include "okapi/pathfinder/include/pathfinder.h"
+}
+
+namespace okapi {
+class AsyncLinearMotionProfileController : public AsyncPositionController<std::string, QLength> {
+  public:
+  /**
+   * An Async Controller which generates and follows 2D motion profiles.
+   *
+   * @param imaxVel The maximum possible velocity.
+   * @param imaxAccel The maximum possible acceleration.
+   * @param imaxJerk The maximum possible jerk.
+   * @param ioutput The output to control.
+   */
+  AsyncLinearMotionProfileController(
+    const TimeUtil &itimeUtil,
+    double imaxVel,
+    double imaxAccel,
+    double imaxJerk,
+    std::shared_ptr<AsyncVelocityController<double, double>> ioutput);
+
+  AsyncLinearMotionProfileController(AsyncLinearMotionProfileController &&other) noexcept;
+
+  ~AsyncLinearMotionProfileController() override;
+
+  /**
+   * Generates a path which intersects the given waypoints and saves it internally with a key of
+   * pathId. Call executePath() with the same pathId to run it.
+   *
+   * If the waypoints form a path which is impossible to achieve, an instance of std::runtime_error
+   * is thrown (and an error is logged) which describes the waypoints. If there are no waypoints,
+   * no path is generated.
+   *
+   * @param iwaypoints The waypoints to hit on the path.
+   * @param ipathId A unique identifier to save the path with.
+   */
+  void generatePath(std::initializer_list<QLength> iwaypoints, const std::string &ipathId);
+
+  /**
+   * Removes a path and frees the memory it used.
+   *
+   * @param ipathId A unique identifier for the path, previously passed to generatePath()
+   */
+  void removePath(const std::string &ipathId);
+
+  /**
+   * Gets the identifiers of all paths saved in this AsyncMotionProfileController.
+   *
+   * @return The identifiers of all paths
+   */
+  std::vector<std::string> getPaths();
+
+  /**
+   * Executes a path with the given ID. If there is no path matching the ID, the method will
+   * return. Any targets set while a path is being followed will be ignored.
+   *
+   * @param ipathId A unique identifier for the path, previously passed to generatePath().
+   */
+  void setTarget(std::string ipathId) override;
+
+  /**
+   * Gets the last set target, or the default target if none was set.
+   *
+   * @return the last target
+   */
+  std::string getTarget() override;
+
+  /**
+   * Blocks the current task until the controller has settled. This controller is settled when
+   * it has finished following a path. If no path is being followed, it is settled.
+   */
+  void waitUntilSettled() override;
+
+  /**
+   * Returns the last error of the controller. This implementation always returns zero since the
+   * robot is assumed to perfectly follow the path. Subclasses can override this to be more
+   * accurate using odometry information.
+   *
+   * @return the last error
+   */
+  QLength getError() const override;
+
+  /**
+   * Returns whether the controller has settled at the target. Determining what settling means is
+   * implementation-dependent.
+   *
+   * If the controller is disabled, this method must return true.
+   *
+   * @return whether the controller is settled
+   */
+  bool isSettled() override;
+
+  /**
+   * Resets the controller so it can start from 0 again properly. Keeps configuration from
+   * before.
+   *
+   * This implementation does nothing.
+   */
+  void reset() override;
+
+  /**
+   * Changes whether the controller is off or on. Turning the controller on after it was off will
+   * NOT cause the controller to move to its last set target.
+   */
+  void flipDisable() override;
+
+  /**
+   * Sets whether the controller is off or on. Turning the controller on after it was off will
+   * NOT cause the controller to move to its last set target, unless it was reset in that time.
+   *
+   * @param iisDisabled whether the controller is disabled
+   */
+  void flipDisable(bool iisDisabled) override;
+
+  /**
+   * Returns whether the controller is currently disabled.
+   *
+   * @return whether the controller is currently disabled
+   */
+  bool isDisabled() const override;
+
+  /**
+   * Starts the internal thread. This should not be called by normal users. This method is called
+   * by the AsyncControllerFactory when making a new instance of this class.
+   */
+  void startThread();
+
+  protected:
+  struct TrajectoryPair {
+    Segment *segment;
+    int length;
+  };
+
+  Logger *logger;
+  std::map<std::string, TrajectoryPair> paths{};
+  double maxVel{0};
+  double maxAccel{0};
+  double maxJerk{0};
+  std::shared_ptr<AsyncVelocityController<double, double>> output;
+  TimeUtil timeUtil;
+
+  std::string currentPath{""};
+  bool isRunning{false};
+  bool disabled{false};
+  std::atomic_bool dtorCalled{false};
+  CrossplatformThread *task{nullptr};
+
+  static void trampoline(void *context);
+  void loop();
+
+  /**
+   * Follow the supplied path. Must follow the disabled lifecycle.
+   */
+  virtual void executeSinglePath(const TrajectoryPair &path, std::unique_ptr<AbstractRate> rate);
+};
+} // namespace okapi
+
+#endif

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -25,7 +25,7 @@ namespace okapi {
 class AsyncLinearMotionProfileController : public AsyncPositionController<std::string, QLength> {
   public:
   /**
-   * An Async Controller which generates and follows 2D motion profiles.
+   * An Async Controller which generates and follows 1D motion profiles.
    *
    * @param imaxVel The maximum possible velocity.
    * @param imaxAccel The maximum possible acceleration.
@@ -90,6 +90,15 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * it has finished following a path. If no path is being followed, it is settled.
    */
   void waitUntilSettled() override;
+
+  /**
+   * Generates a new path from the position (typically the current position) to the target and
+   * blocks until the controller has settled. Does not save the path which was generated.
+   *
+   * @param iposition The starting position.
+   * @param itarget The target position.
+   */
+  void moveTo(QLength iposition, QLength itarget);
 
   /**
    * Returns the last error of the controller. This implementation always returns zero since the

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -34,9 +34,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   /**
    * An Async Controller which generates and follows 2D motion profiles.
    *
-   * @param imaxVel The maximum possible velocity.
-   * @param imaxAccel The maximum possible acceleration.
-   * @param imaxJerk The maximum possible jerk.
+   * @param imaxVel The maximum possible velocity in m/s.
+   * @param imaxAccel The maximum possible acceleration in m/s/s.
+   * @param imaxJerk The maximum possible jerk in m/s/s/s.
    * @param imodel The chassis model to control.
    * @param iwidth The chassis wheelbase width.
    */
@@ -85,6 +85,12 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * @param ipathId A unique identifier for the path, previously passed to generatePath().
    */
   void setTarget(std::string ipathId) override;
+
+  /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. This just calls setTarget().
+   */
+  void controllerSet(std::string ivalue) override;
 
   /**
    * Gets the last set target, or the default target if none was set.

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -18,7 +18,8 @@ namespace okapi {
  * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are whatever
  * units the motor is in.
  */
-class AsyncPosIntegratedController : public AsyncPositionController<double, double> {
+class AsyncPosIntegratedController : public AsyncPositionController<double, double>,
+                                     public ControllerOutput<double> {
   public:
   AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 
@@ -81,6 +82,14 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    * implementation-dependent.
    */
   void waitUntilSettled() override;
+
+  /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. The range of input values is expected to be [-1, 1].
+   *
+   * @param ivalue the controller's output in the range [-1, 1]
+   */
+  void controllerSet(double ivalue) override;
 
   protected:
   Logger *logger;

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -18,8 +18,7 @@ namespace okapi {
  * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are whatever
  * units the motor is in.
  */
-class AsyncPosIntegratedController : public AsyncPositionController<double, double>,
-                                     public ControllerOutput<double> {
+class AsyncPosIntegratedController : public AsyncPositionController<double, double> {
   public:
   AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -19,8 +19,7 @@ namespace okapi {
  * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are whatever
  * units the motor is in.
  */
-class AsyncVelIntegratedController : public AsyncVelocityController<double, double>,
-                                     public ControllerOutput<double> {
+class AsyncVelIntegratedController : public AsyncVelocityController<double, double> {
   public:
   AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -84,6 +84,12 @@ class AsyncVelIntegratedController : public AsyncVelocityController<double, doub
    */
   void waitUntilSettled() override;
 
+  /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. The range of input values is expected to be [-1, 1].
+   *
+   * @param ivalue the controller's output in the range [-1, 1]
+   */
   void controllerSet(double ivalue) override;
 
   protected:

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -19,7 +19,8 @@ namespace okapi {
  * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are whatever
  * units the motor is in.
  */
-class AsyncVelIntegratedController : public AsyncVelocityController<double, double> {
+class AsyncVelIntegratedController : public AsyncVelocityController<double, double>,
+                                     public ControllerOutput<double> {
   public:
   AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
 
@@ -82,6 +83,8 @@ class AsyncVelIntegratedController : public AsyncVelocityController<double, doub
    * implementation-dependent.
    */
   void waitUntilSettled() override;
+
+  void controllerSet(double ivalue) override;
 
   protected:
   Logger *logger;

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -74,6 +74,16 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller.
+   *
+   * @param ivalue the controller's output
+   */
+  void controllerSet(Input ivalue) override {
+    controller->controllerSet(ivalue);
+  }
+
+  /**
    * Gets the last set target, or the default target if none was set.
    *
    * @return the last target
@@ -197,10 +207,6 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
     }
 
     logger->info("AsyncWrapper: Done waiting to settle");
-  }
-
-  void controllerSet(Input ivalue) override {
-    controller->controllerSet(ivalue);
   }
 
   /**

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -10,7 +10,6 @@
 
 #include "okapi/api/control/async/asyncController.hpp"
 #include "okapi/api/control/controllerInput.hpp"
-#include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/control/iterative/iterativeController.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
 #include "okapi/api/coreProsAPI.hpp"
@@ -84,7 +83,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Returns the last calculated output of the controller. Default is 0.
+   * Returns the last calculated output of the controller.
    */
   Output getOutput() const {
     return controller->getOutput();
@@ -110,7 +109,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Set time between loops. Default does nothing.
+   * Set time between loops.
    *
    * @param isampleTime time between loops
    */
@@ -119,13 +118,31 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Set controller output bounds. Default does nothing.
+   * Set controller output bounds.
    *
    * @param imax max output
    * @param imin min output
    */
   void setOutputLimits(Output imax, Output imin) {
     controller->setOutputLimits(imax, imin);
+  }
+
+  /**
+   * Get the upper output bound.
+   *
+   * @return  the upper output bound
+   */
+  Output getMaxOutput() {
+    return controller->getMaxOutput();
+  }
+
+  /**
+   * Get the lower output bound.
+   *
+   * @return the lower output bound
+   */
+  Output getMinOutput() {
+    return controller->getMinOutput();
   }
 
   /**
@@ -180,6 +197,10 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
     }
 
     logger->info("AsyncWrapper: Done waiting to settle");
+  }
+
+  void controllerSet(Input ivalue) override {
+    controller->controllerSet(ivalue);
   }
 
   /**

--- a/include/okapi/api/control/closedLoopController.hpp
+++ b/include/okapi/api/control/closedLoopController.hpp
@@ -8,6 +8,7 @@
 #ifndef _OKAPI_CLOSEDLOOPCONTROLLER_HPP_
 #define _OKAPI_CLOSEDLOOPCONTROLLER_HPP_
 
+#include "okapi/api/control/controllerOutput.hpp"
 #include "okapi/api/units/QTime.hpp"
 
 namespace okapi {
@@ -17,7 +18,8 @@ namespace okapi {
  * @tparam Input The target/input type.
  * @tparam Output The error/output type.
  */
-template <typename Input, typename Output> class ClosedLoopController {
+template <typename Input, typename Output>
+class ClosedLoopController : public ControllerOutput<Input> {
   public:
   virtual ~ClosedLoopController() = default;
 

--- a/include/okapi/api/control/iterative/iterativeController.hpp
+++ b/include/okapi/api/control/iterative/iterativeController.hpp
@@ -14,6 +14,9 @@
 namespace okapi {
 /**
  * Closed-loop controller that steps iteratively using the step method below.
+ *
+ * ControllerOutput::controllerSet() should set the controller's target to the input scaled by the
+ * output bounds.
  */
 template <typename Input, typename Output>
 class IterativeController : public ClosedLoopController<Input, Output> {
@@ -38,6 +41,20 @@ class IterativeController : public ClosedLoopController<Input, Output> {
    * @param imin min output
    */
   virtual void setOutputLimits(Output imax, Output imin) = 0;
+
+  /**
+   * Get the upper output bound.
+   *
+   * @return  the upper output bound
+   */
+  virtual Output getMaxOutput() = 0;
+
+  /**
+   * Get the lower output bound.
+   *
+   * @return the lower output bound
+   */
+  virtual Output getMinOutput() = 0;
 
   /**
    * Set time between loops.

--- a/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
+++ b/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
@@ -37,6 +37,14 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
   void setTarget(double itarget) override;
 
   /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. The range of input values is expected to be [-1, 1].
+   *
+   * @param ivalue the controller's output in the range [-1, 1]
+   */
+  void controllerSet(double ivalue) override;
+
+  /**
    * Gets the last set target, or the default target if none was set.
    *
    * @return the last target
@@ -47,6 +55,20 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
    * Returns the last calculated output of the controller.
    */
   double getOutput() const override;
+
+  /**
+   * Get the upper output bound.
+   *
+   * @return  the upper output bound
+   */
+  double getMaxOutput() override;
+
+  /**
+   * Get the lower output bound.
+   *
+   * @return the lower output bound
+   */
+  double getMinOutput() override;
 
   /**
    * Returns the last error of the controller.

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -76,6 +76,14 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   void setTarget(double itarget) override;
 
   /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. The range of input values is expected to be [-1, 1].
+   *
+   * @param ivalue the controller's output in the range [-1, 1]
+   */
+  void controllerSet(double ivalue) override;
+
+  /**
    * Gets the last set target, or the default target if none was set.
    *
    * @return the last target
@@ -87,6 +95,20 @@ class IterativePosPIDController : public IterativePositionController<double, dou
    * unless the bounds have been changed with setOutputLimits().
    */
   double getOutput() const override;
+
+  /**
+   * Get the upper output bound.
+   *
+   * @return  the upper output bound
+   */
+  double getMaxOutput() override;
+
+  /**
+   * Get the lower output bound.
+   *
+   * @return the lower output bound
+   */
+  double getMinOutput() override;
 
   /**
    * Returns the last error of the controller.

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -54,6 +54,14 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   void setTarget(double itarget) override;
 
   /**
+   * Writes the value of the controller output. This method might be automatically called in another
+   * thread by the controller. The range of input values is expected to be [-1, 1].
+   *
+   * @param ivalue the controller's output in the range [-1, 1]
+   */
+  void controllerSet(double ivalue) override;
+
+  /**
    * Gets the last set target, or the default target if none was set.
    *
    * @return the last target
@@ -64,6 +72,20 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
    * Returns the last calculated output of the controller.
    */
   double getOutput() const override;
+
+  /**
+   * Get the upper output bound.
+   *
+   * @return  the upper output bound
+   */
+  double getMaxOutput() override;
+
+  /**
+   * Get the lower output bound.
+   *
+   * @return the lower output bound
+   */
+  double getMinOutput() override;
 
   /**
    * Returns the last error of the controller.

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -385,6 +385,17 @@ class AbstractMotor : public ControllerOutput<double> {
   virtual std::int32_t setBrakeMode(brakeMode imode) = 0;
 
   /**
+   * Gets the brake mode that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of brakeMode, according to what was set for the motor, or brakeMode::invalid if the
+   * operation failed, setting errno.
+   */
+  virtual brakeMode getBrakeMode() const = 0;
+
+  /**
    * Sets the current limit for the motor in mA.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -394,6 +405,18 @@ class AbstractMotor : public ControllerOutput<double> {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setCurrentLimit(std::int32_t ilimit) const = 0;
+
+  /**
+   * Gets the current limit for the motor in mA.
+   *
+   * The default value is 2500 mA.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return The motor's current limit in mA or PROS_ERR if the operation failed, setting errno.
+   */
+  virtual std::int32_t getCurrentLimit() const = 0;
 
   /**
    * Sets one of encoderUnits for the motor encoder.
@@ -407,6 +430,17 @@ class AbstractMotor : public ControllerOutput<double> {
   virtual std::int32_t setEncoderUnits(encoderUnits iunits) = 0;
 
   /**
+   * Gets the encoder units that were set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of encoderUnits according to what is set for the motor or encoderUnits::invalid if
+   * the operation failed.
+   */
+  virtual encoderUnits getEncoderUnits() const = 0;
+
+  /**
    * Sets one of gearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -416,6 +450,17 @@ class AbstractMotor : public ControllerOutput<double> {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setGearing(gearset igearset) = 0;
+
+  /**
+   * Gets the gearset that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of gearset according to what is set for the motor, or gearset::invalid if the
+   * operation failed.
+   */
+  virtual gearset getGearing() const = 0;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/okapi/impl/control/async/asyncControllerFactory.hpp
+++ b/include/okapi/impl/control/async/asyncControllerFactory.hpp
@@ -9,6 +9,7 @@
 #define _OKAPI_ASYNCCONTROLLERFACTORY_HPP_
 
 #include "okapi/api/chassis/controller/chassisController.hpp"
+#include "okapi/api/control/async/asyncLinearMotionProfileController.hpp"
 #include "okapi/api/control/async/asyncMotionProfileController.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 #include "okapi/api/control/async/asyncPosPidController.hpp"
@@ -319,9 +320,9 @@ class AsyncControllerFactory {
   /**
    * A controller which generates and follows 2D motion profiles.
    *
-   * @param imaxVel The maximum possible velocity.
-   * @param imaxAccel The maximum possible acceleration.
-   * @param imaxJerk The maximum possible jerk.
+   * @param imaxVel The maximum possible velocity in m/s.
+   * @param imaxAccel The maximum possible acceleration in m/s/s.
+   * @param imaxJerk The maximum possible jerk in m/s/s/s.
    * @param ichassis The chassis to control.
    */
   static AsyncMotionProfileController motionProfile(double imaxVel,
@@ -332,9 +333,9 @@ class AsyncControllerFactory {
   /**
    * A controller which generates and follows 2D motion profiles.
    *
-   * @param imaxVel The maximum possible velocity.
-   * @param imaxAccel The maximum possible acceleration.
-   * @param imaxJerk The maximum possible jerk.
+   * @param imaxVel The maximum possible velocity in m/s.
+   * @param imaxAccel The maximum possible acceleration in m/s/s.
+   * @param imaxJerk The maximum possible jerk in m/s/s/s.
    * @param imodel The chassis model to control.
    * @param iwidth The chassis wheelbase width.
    */
@@ -343,6 +344,20 @@ class AsyncControllerFactory {
                                                     double imaxJerk,
                                                     std::shared_ptr<ChassisModel> imodel,
                                                     QLength iwidth);
+
+  /**
+   * A controller which generates and follows 1D motion profiles.
+   *
+   * @param imaxVel The maximum possible velocity in m/s.
+   * @param imaxAccel The maximum possible acceleration in m/s/s.
+   * @param imaxJerk The maximum possible jerk in m/s/s/s.
+   * @param ioutput The output to write velocity targets to.
+   */
+  static AsyncLinearMotionProfileController
+  linearMotionProfile(double imaxVel,
+                      double imaxAccel,
+                      double imaxJerk,
+                      std::shared_ptr<ControllerOutput<double>> ioutput);
 };
 } // namespace okapi
 

--- a/include/okapi/impl/device/motor/motor.hpp
+++ b/include/okapi/impl/device/motor/motor.hpp
@@ -358,6 +358,17 @@ class Motor : public AbstractMotor, public pros::Motor {
   virtual std::int32_t setBrakeMode(AbstractMotor::brakeMode imode) override;
 
   /**
+   * Gets the brake mode that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of brakeMode, according to what was set for the motor, or brakeMode::invalid if the
+   * operation failed, setting errno.
+   */
+  virtual brakeMode getBrakeMode() const override;
+
+  /**
    * Sets the current limit for the motor in mA.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -367,6 +378,18 @@ class Motor : public AbstractMotor, public pros::Motor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setCurrentLimit(std::int32_t ilimit) const override;
+
+  /**
+   * Gets the current limit for the motor in mA.
+   *
+   * The default value is 2500 mA.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return The motor's current limit in mA or PROS_ERR if the operation failed, setting errno.
+   */
+  virtual std::int32_t getCurrentLimit() const override;
 
   /**
    * Sets one of AbstractMotor::encoderUnits for the motor encoder.
@@ -380,6 +403,17 @@ class Motor : public AbstractMotor, public pros::Motor {
   virtual std::int32_t setEncoderUnits(AbstractMotor::encoderUnits iunits) override;
 
   /**
+   * Gets the encoder units that were set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of encoderUnits according to what is set for the motor or encoderUnits::invalid if
+   * the operation failed.
+   */
+  virtual encoderUnits getEncoderUnits() const override;
+
+  /**
    * Sets one of AbstractMotor::gearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -389,6 +423,17 @@ class Motor : public AbstractMotor, public pros::Motor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setGearing(AbstractMotor::gearset igearset) override;
+
+  /**
+   * Gets the gearset that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of gearset according to what is set for the motor, or gearset::invalid if the
+   * operation failed.
+   */
+  virtual gearset getGearing() const override;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/okapi/impl/device/motor/motorGroup.hpp
+++ b/include/okapi/impl/device/motor/motorGroup.hpp
@@ -355,6 +355,17 @@ class MotorGroup : public AbstractMotor {
   virtual std::int32_t setBrakeMode(AbstractMotor::brakeMode imode) override;
 
   /**
+   * Gets the brake mode that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of brakeMode, according to what was set for the motor, or brakeMode::invalid if the
+   * operation failed, setting errno.
+   */
+  virtual brakeMode getBrakeMode() const override;
+
+  /**
    * Sets the current limit for the motor in mA.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -364,6 +375,18 @@ class MotorGroup : public AbstractMotor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setCurrentLimit(std::int32_t ilimit) const override;
+
+  /**
+   * Gets the current limit for the motor in mA.
+   *
+   * The default value is 2500 mA.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return The motor's current limit in mA or PROS_ERR if the operation failed, setting errno.
+   */
+  virtual std::int32_t getCurrentLimit() const override;
 
   /**
    * Sets one of AbstractMotor::encoderUnits for the motor encoder.
@@ -377,6 +400,17 @@ class MotorGroup : public AbstractMotor {
   virtual std::int32_t setEncoderUnits(AbstractMotor::encoderUnits iunits) override;
 
   /**
+   * Gets the encoder units that were set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of encoderUnits according to what is set for the motor or encoderUnits::invalid if
+   * the operation failed.
+   */
+  virtual encoderUnits getEncoderUnits() const override;
+
+  /**
    * Sets one of AbstractMotor::gearset for the motor.
    *
    * This function uses the following values of errno when an error state is reached:
@@ -386,6 +420,17 @@ class MotorGroup : public AbstractMotor {
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   virtual std::int32_t setGearing(AbstractMotor::gearset igearset) override;
+
+  /**
+   * Gets the gearset that was set for the motor.
+   *
+   * This function uses the following values of errno when an error state is reached:
+   * EACCES - Another resource is currently trying to access the port.
+   *
+   * @return One of gearset according to what is set for the motor, or gearset::invalid if the
+   * operation failed.
+   */
+  virtual gearset getGearing() const override;
 
   /**
    * Sets the reverse flag for the motor.

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -10,6 +10,7 @@
 
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
+#include "okapi/api/control/async/asyncVelIntegratedController.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/control/util/flywheelSimulator.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
@@ -235,15 +236,28 @@ class SimulatedSystem : public ControllerInput<double>, public ControllerOutput<
   std::thread thread;
 };
 
-class MockAsyncController : public AsyncPosIntegratedController {
+class MockAsyncPosIntegratedController : public AsyncPosIntegratedController {
   public:
-  MockAsyncController();
+  MockAsyncPosIntegratedController();
 
-  explicit MockAsyncController(const TimeUtil &itimeUtil);
+  explicit MockAsyncPosIntegratedController(const TimeUtil &itimeUtil);
 
   bool isSettled() override;
 
   bool isSettledOverride{true};
+};
+
+class MockAsyncVelIntegratedController : public AsyncVelIntegratedController {
+  public:
+  MockAsyncVelIntegratedController();
+
+  void setTarget(double itarget) override;
+
+  bool isSettled() override;
+
+  bool isSettledOverride{true};
+  double lastTarget{0};
+  double maxTarget{0};
 };
 
 class MockIterativeController : public IterativePosPIDController {

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -330,8 +330,7 @@ void assertControllerFollowsTargetLifecycle(ClosedLoopController<double, double>
 void assertIterativeControllerScalesControllerSetTargets(
   IterativeController<double, double> &controller);
 
-void assertAsyncWrapperScalesControllerSetTargets(
-  AsyncWrapper<double, double> &controller);
+void assertAsyncWrapperScalesControllerSetTargets(AsyncWrapper<double, double> &controller);
 
 } // namespace okapi
 

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -11,6 +11,7 @@
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
 #include "okapi/api/control/async/asyncVelIntegratedController.hpp"
+#include "okapi/api/control/async/asyncWrapper.hpp"
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
 #include "okapi/api/control/util/flywheelSimulator.hpp"
 #include "okapi/api/control/util/settledUtil.hpp"
@@ -325,6 +326,12 @@ void assertIterativeControllerFollowsDisableLifecycle(
   IterativeController<double, double> &controller);
 
 void assertControllerFollowsTargetLifecycle(ClosedLoopController<double, double> &controller);
+
+void assertIterativeControllerScalesControllerSetTargets(
+  IterativeController<double, double> &controller);
+
+void assertAsyncWrapperScalesControllerSetTargets(
+  AsyncWrapper<double, double> &controller);
 
 } // namespace okapi
 

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -129,6 +129,14 @@ class MockMotor : public AbstractMotor {
                         double ithreshold,
                         double iloopSpeed) const override;
 
+  AbstractMotor::brakeMode getBrakeMode() const override;
+
+  int32_t getCurrentLimit() const override;
+
+  AbstractMotor::encoderUnits getEncoderUnits() const override;
+
+  AbstractMotor::gearset getGearing() const override;
+
   std::shared_ptr<MockContinuousRotarySensor> encoder;
   mutable std::int16_t lastVelocity{0};
   mutable std::int16_t maxVelocity{0};
@@ -255,9 +263,15 @@ class MockAsyncVelIntegratedController : public AsyncVelIntegratedController {
 
   bool isSettled() override;
 
+  void controllerSet(double ivalue) override;
+
   bool isSettledOverride{true};
+
   double lastTarget{0};
   double maxTarget{0};
+
+  double lastControllerOutputSet{0};
+  double maxControllerOutputSet{0};
 };
 
 class MockIterativeController : public IterativePosPIDController {

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -198,6 +198,14 @@ void AsyncLinearMotionProfileController::waitUntilSettled() {
   logger->info("AsyncLinearMotionProfileController: Done waiting to settle");
 }
 
+void AsyncLinearMotionProfileController::moveTo(QLength iposition, QLength itarget) {
+  std::string name = reinterpret_cast<const char *>(this); // hmmmm...
+  generatePath({iposition, itarget}, name);
+  setTarget(name);
+  waitUntilSettled();
+  removePath(name);
+}
+
 QLength AsyncLinearMotionProfileController::getError() const {
   throw std::runtime_error("not implemented");
 }

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -14,7 +14,7 @@ AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
   const double imaxVel,
   const double imaxAccel,
   const double imaxJerk,
-  std::shared_ptr<AsyncVelocityController<double, double>> ioutput)
+  std::shared_ptr<ControllerOutput<double>> ioutput)
   : logger(Logger::instance()),
     maxVel(imaxVel),
     maxAccel(imaxAccel),
@@ -161,7 +161,7 @@ void AsyncLinearMotionProfileController::loop() {
                       std::to_string(path->second.length));
 
         executeSinglePath(path->second, timeUtil.getRate());
-        output->setTarget(0);
+        output->controllerSet(0);
 
         logger->info("AsyncLinearMotionProfileController: Done moving");
       }
@@ -176,7 +176,7 @@ void AsyncLinearMotionProfileController::loop() {
 void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair &path,
                                                            std::unique_ptr<AbstractRate> rate) {
   for (int i = 0; i < path.length && !isDisabled(); ++i) {
-    output->setTarget(path.segment[i].velocity / maxVel);
+    output->controllerSet(path.segment[i].velocity / maxVel);
     rate->delayUntil(1_ms);
   }
 }

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -135,9 +135,13 @@ std::vector<std::string> AsyncLinearMotionProfileController::getPaths() {
   return keys;
 }
 
-void AsyncLinearMotionProfileController::setTarget(std::string ipathId) {
+void AsyncLinearMotionProfileController::setTarget(const std::string ipathId) {
   currentPath = ipathId;
   isRunning = true;
+}
+
+void AsyncLinearMotionProfileController::controllerSet(const std::string ivalue) {
+  setTarget(ivalue);
 }
 
 std::string AsyncLinearMotionProfileController::getTarget() {

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -1,0 +1,229 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/control/async/asyncLinearMotionProfileController.hpp"
+#include <numeric>
+
+namespace okapi {
+AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
+  const TimeUtil &itimeUtil,
+  const double imaxVel,
+  const double imaxAccel,
+  const double imaxJerk,
+  std::shared_ptr<AsyncVelocityController<double, double>> ioutput)
+  : logger(Logger::instance()),
+    maxVel(imaxVel),
+    maxAccel(imaxAccel),
+    maxJerk(imaxJerk),
+    output(ioutput),
+    timeUtil(itimeUtil) {
+}
+
+AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
+  AsyncLinearMotionProfileController &&other) noexcept
+  : logger(other.logger),
+    paths(std::move(other.paths)),
+    maxVel(other.maxVel),
+    maxAccel(other.maxAccel),
+    maxJerk(other.maxJerk),
+    output(std::move(other.output)),
+    timeUtil(std::move(other.timeUtil)),
+    currentPath(std::move(other.currentPath)),
+    isRunning(other.isRunning),
+    disabled(other.disabled),
+    dtorCalled(other.dtorCalled.load(std::memory_order::memory_order_relaxed)),
+    task(other.task) {
+}
+
+AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
+  dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+
+  for (auto path : paths) {
+    free(path.second.segment);
+  }
+
+  delete task;
+}
+
+void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLength> iwaypoints,
+                                                      const std::string &ipathId) {
+  if (iwaypoints.size() == 0) {
+    // No point in generating a path
+    logger->warn(
+      "AsyncLinearMotionProfileController: Not generating a path because no waypoints were given.");
+    return;
+  }
+
+  std::vector<Waypoint> points;
+  points.reserve(iwaypoints.size());
+  for (auto &point : iwaypoints) {
+    points.push_back(Waypoint{point.convert(meter), 0, 0});
+  }
+
+  TrajectoryCandidate candidate;
+  logger->info("AsyncLinearMotionProfileController: Preparing trajectory");
+  pathfinder_prepare(points.data(),
+                     static_cast<int>(points.size()),
+                     FIT_HERMITE_CUBIC,
+                     PATHFINDER_SAMPLES_FAST,
+                     0.001,
+                     maxVel,
+                     maxAccel,
+                     maxJerk,
+                     &candidate);
+
+  const int length = candidate.length;
+
+  if (length < 0) {
+    auto pointToString = [](Waypoint point) {
+      return "Point{x = " + std::to_string(point.x) + ", y = " + std::to_string(point.y) +
+             ", theta = " + std::to_string(point.angle) + "}";
+    };
+
+    std::string message =
+      "AsyncLinearMotionProfileController: Path is impossible with waypoints: " +
+      std::accumulate(std::next(points.begin()),
+                      points.end(),
+                      pointToString(points.at(0)),
+                      [&](std::string a, Waypoint b) { return a + ", " + pointToString(b); });
+
+    logger->error(message);
+
+    if (candidate.laptr) {
+      free(candidate.laptr);
+    }
+
+    if (candidate.saptr) {
+      free(candidate.saptr);
+    }
+
+    throw std::runtime_error(message);
+  }
+
+  auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
+
+  logger->info("AsyncLinearMotionProfileController: Generating path");
+  pathfinder_generate(&candidate, trajectory);
+
+  // Free the old path before overwriting it
+  removePath(ipathId);
+
+  paths.emplace(ipathId, TrajectoryPair{trajectory, length});
+  logger->info("AsyncLinearMotionProfileController: Completely done generating path");
+  logger->info("AsyncLinearMotionProfileController: " + std::to_string(length));
+}
+
+void AsyncLinearMotionProfileController::removePath(const std::string &ipathId) {
+  auto oldPath = paths.find(ipathId);
+  if (oldPath != paths.end()) {
+    free(oldPath->second.segment);
+    paths.erase(ipathId);
+  }
+}
+
+std::vector<std::string> AsyncLinearMotionProfileController::getPaths() {
+  std::vector<std::string> keys;
+
+  for (const auto &path : paths) {
+    keys.push_back(path.first);
+  }
+
+  return keys;
+}
+
+void AsyncLinearMotionProfileController::setTarget(std::string ipathId) {
+  currentPath = ipathId;
+  isRunning = true;
+}
+
+std::string AsyncLinearMotionProfileController::getTarget() {
+  return currentPath;
+}
+
+void AsyncLinearMotionProfileController::loop() {
+  auto rate = timeUtil.getRate();
+
+  while (!dtorCalled.load(std::memory_order::memory_order_relaxed)) {
+    if (isRunning && !isDisabled()) {
+      logger->info("AsyncLinearMotionProfileController: Running with path: " + currentPath);
+      auto path = paths.find(currentPath);
+
+      if (path == paths.end()) {
+        logger->warn(
+          "AsyncLinearMotionProfileController: Target was set to non-existent path with name: " +
+          currentPath);
+      } else {
+        logger->debug("AsyncLinearMotionProfileController: Path length is " +
+                      std::to_string(path->second.length));
+
+        executeSinglePath(path->second, timeUtil.getRate());
+        output->setTarget(0);
+
+        logger->info("AsyncLinearMotionProfileController: Done moving");
+      }
+
+      isRunning = false;
+    }
+
+    rate->delayUntil(10_ms);
+  }
+}
+
+void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair &path,
+                                                           std::unique_ptr<AbstractRate> rate) {
+  for (int i = 0; i < path.length && !isDisabled(); ++i) {
+    output->setTarget(path.segment[i].velocity / maxVel);
+    rate->delayUntil(1_ms);
+  }
+}
+
+void AsyncLinearMotionProfileController::trampoline(void *context) {
+  if (context) {
+    static_cast<AsyncLinearMotionProfileController *>(context)->loop();
+  }
+}
+
+void AsyncLinearMotionProfileController::waitUntilSettled() {
+  logger->info("AsyncLinearMotionProfileController: Waiting to settle");
+
+  auto rate = timeUtil.getRate();
+  while (!isSettled()) {
+    rate->delayUntil(10_ms);
+  }
+
+  logger->info("AsyncLinearMotionProfileController: Done waiting to settle");
+}
+
+QLength AsyncLinearMotionProfileController::getError() const {
+  throw std::runtime_error("not implemented");
+}
+
+bool AsyncLinearMotionProfileController::isSettled() {
+  return isDisabled() || !isRunning;
+}
+
+void AsyncLinearMotionProfileController::reset() {
+}
+
+void AsyncLinearMotionProfileController::flipDisable() {
+  disabled = !disabled;
+}
+
+void AsyncLinearMotionProfileController::flipDisable(bool iisDisabled) {
+  disabled = iisDisabled;
+}
+
+bool AsyncLinearMotionProfileController::isDisabled() const {
+  return disabled;
+}
+
+void AsyncLinearMotionProfileController::startThread() {
+  if (!task) {
+    task = new CrossplatformThread(trampoline, this);
+  }
+}
+} // namespace okapi

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -153,6 +153,10 @@ void AsyncMotionProfileController::setTarget(std::string ipathId) {
   isRunning = true;
 }
 
+void AsyncMotionProfileController::controllerSet(std::string ivalue) {
+  setTarget(ivalue);
+}
+
 std::string AsyncMotionProfileController::getTarget() {
   return currentPath;
 }

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -81,4 +81,14 @@ void AsyncPosIntegratedController::waitUntilSettled() {
 
   logger->info("AsyncPosIntegratedController: Done waiting to settle");
 }
+
+void AsyncPosIntegratedController::controllerSet(double ivalue) {
+  hasFirstTarget = true;
+
+  if (!controllerIsDisabled) {
+    motor->controllerSet(ivalue);
+  }
+
+  lastTarget = ivalue * toUnderlyingType(motor->getGearing());
+}
 } // namespace okapi

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -76,4 +76,14 @@ void AsyncVelIntegratedController::waitUntilSettled() {
   }
   logger->info("AsyncVelIntegratedController: Done waiting to settle");
 }
+
+void AsyncVelIntegratedController::controllerSet(double ivalue) {
+  hasFirstTarget = true;
+
+  if (!controllerIsDisabled) {
+    motor->controllerSet(ivalue);
+  }
+
+  lastTarget = ivalue;
+}
 } // namespace okapi

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -84,6 +84,8 @@ void AsyncVelIntegratedController::controllerSet(double ivalue) {
     motor->controllerSet(ivalue);
   }
 
-  lastTarget = ivalue;
+  // Need to scale the controller output from [-1, 1] to the range of the motor based on its
+  // internal gearset
+  lastTarget = ivalue * toUnderlyingType(motor->getGearing());
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativeMotorVelocityController.cpp
+++ b/src/api/control/iterative/iterativeMotorVelocityController.cpp
@@ -23,12 +23,24 @@ void IterativeMotorVelocityController::setTarget(const double itarget) {
   controller->setTarget(itarget);
 }
 
+void IterativeMotorVelocityController::controllerSet(double ivalue) {
+  controller->controllerSet(ivalue);
+}
+
 double IterativeMotorVelocityController::getTarget() {
   return controller->getTarget();
 }
 
 double IterativeMotorVelocityController::getOutput() const {
   return controller->getOutput();
+}
+
+double IterativeMotorVelocityController::getMaxOutput() {
+  return controller->getMaxOutput();
+}
+
+double IterativeMotorVelocityController::getMinOutput() {
+  return controller->getMinOutput();
 }
 
 double IterativeMotorVelocityController::getError() const {

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -8,6 +8,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/control/iterative/iterativePosPidController.hpp"
+#include "okapi/api/util/mathUtil.hpp"
 #include <algorithm>
 #include <cmath>
 
@@ -45,12 +46,24 @@ void IterativePosPIDController::setTarget(const double itarget) {
   target = itarget;
 }
 
+void IterativePosPIDController::controllerSet(const double ivalue) {
+  target = remapRange(ivalue, -1, 1, outputMin, outputMax);
+}
+
 double IterativePosPIDController::getTarget() {
   return target;
 }
 
 double IterativePosPIDController::getOutput() const {
   return isDisabled() ? 0 : output;
+}
+
+double IterativePosPIDController::getMaxOutput() {
+  return outputMax;
+}
+
+double IterativePosPIDController::getMinOutput() {
+  return outputMin;
 }
 
 double IterativePosPIDController::getError() const {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -97,12 +97,24 @@ void IterativeVelPIDController::setTarget(const double itarget) {
   target = itarget;
 }
 
+void IterativeVelPIDController::controllerSet(const double ivalue) {
+  target = remapRange(ivalue, -1, 1, outputMin, outputMax);
+}
+
 double IterativeVelPIDController::getTarget() {
   return target;
 }
 
 double IterativeVelPIDController::getOutput() const {
   return isDisabled() ? 0 : output;
+}
+
+double IterativeVelPIDController::getMaxOutput() {
+  return outputMax;
+}
+
+double IterativeVelPIDController::getMinOutput() {
+  return outputMin;
 }
 
 double IterativeVelPIDController::getError() const {

--- a/src/autonomous.cpp
+++ b/src/autonomous.cpp
@@ -11,4 +11,5 @@
  * will be stopped. Re-enabling the robot will restart the task, not re-start it
  * from where it left off.
  */
-void autonomous() {}
+void autonomous() {
+}

--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -146,8 +146,25 @@ std::int32_t Motor::setBrakeMode(const AbstractMotor::brakeMode imode) {
   }
 }
 
+AbstractMotor::brakeMode Motor::getBrakeMode() const {
+  switch (get_brake_mode()) {
+  case E_MOTOR_BRAKE_COAST:
+    return AbstractMotor::brakeMode::coast;
+  case E_MOTOR_BRAKE_BRAKE:
+    return AbstractMotor::brakeMode::brake;
+  case E_MOTOR_BRAKE_HOLD:
+    return AbstractMotor::brakeMode::hold;
+  case E_MOTOR_BRAKE_INVALID:
+    return AbstractMotor::brakeMode::invalid;
+  }
+}
+
 std::int32_t Motor::setCurrentLimit(const std::int32_t ilimit) const {
   return set_current_limit(ilimit);
+}
+
+std::int32_t Motor::getCurrentLimit() const {
+  return get_current_limit();
 }
 
 std::int32_t Motor::setEncoderUnits(const AbstractMotor::encoderUnits iunits) {
@@ -163,6 +180,19 @@ std::int32_t Motor::setEncoderUnits(const AbstractMotor::encoderUnits iunits) {
   }
 }
 
+AbstractMotor::encoderUnits Motor::getEncoderUnits() const {
+  switch (get_encoder_units()) {
+  case E_MOTOR_ENCODER_DEGREES:
+    return AbstractMotor::encoderUnits::degrees;
+  case E_MOTOR_ENCODER_ROTATIONS:
+    return AbstractMotor::encoderUnits::rotations;
+  case E_MOTOR_ENCODER_COUNTS:
+    return AbstractMotor::encoderUnits::counts;
+  case E_MOTOR_ENCODER_INVALID:
+    return AbstractMotor::encoderUnits::invalid;
+  }
+}
+
 std::int32_t Motor::setGearing(const AbstractMotor::gearset igearset) {
   switch (igearset) {
   case AbstractMotor::gearset::blue:
@@ -173,6 +203,19 @@ std::int32_t Motor::setGearing(const AbstractMotor::gearset igearset) {
     return set_gearing(pros::E_MOTOR_GEARSET_36);
   case AbstractMotor::gearset::invalid:
     return set_gearing(pros::E_MOTOR_GEARSET_INVALID);
+  }
+}
+
+AbstractMotor::gearset Motor::getGearing() const {
+  switch (get_gearing()) {
+  E_MOTOR_GEARSET_36:
+    return AbstractMotor::gearset::red;
+  E_MOTOR_GEARSET_18:
+    return AbstractMotor::gearset::green;
+  E_MOTOR_GEARSET_06:
+    return AbstractMotor::gearset::blue;
+  E_MOTOR_GEARSET_INVALID:
+    return AbstractMotor::gearset::invalid;
   }
 }
 

--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -148,13 +148,13 @@ std::int32_t Motor::setBrakeMode(const AbstractMotor::brakeMode imode) {
 
 AbstractMotor::brakeMode Motor::getBrakeMode() const {
   switch (get_brake_mode()) {
-  case E_MOTOR_BRAKE_COAST:
+  case pros::E_MOTOR_BRAKE_COAST:
     return AbstractMotor::brakeMode::coast;
-  case E_MOTOR_BRAKE_BRAKE:
+  case pros::E_MOTOR_BRAKE_BRAKE:
     return AbstractMotor::brakeMode::brake;
-  case E_MOTOR_BRAKE_HOLD:
+  case pros::E_MOTOR_BRAKE_HOLD:
     return AbstractMotor::brakeMode::hold;
-  case E_MOTOR_BRAKE_INVALID:
+  case pros::E_MOTOR_BRAKE_INVALID:
     return AbstractMotor::brakeMode::invalid;
   }
 }
@@ -182,13 +182,13 @@ std::int32_t Motor::setEncoderUnits(const AbstractMotor::encoderUnits iunits) {
 
 AbstractMotor::encoderUnits Motor::getEncoderUnits() const {
   switch (get_encoder_units()) {
-  case E_MOTOR_ENCODER_DEGREES:
+  case pros::E_MOTOR_ENCODER_DEGREES:
     return AbstractMotor::encoderUnits::degrees;
-  case E_MOTOR_ENCODER_ROTATIONS:
+  case pros::E_MOTOR_ENCODER_ROTATIONS:
     return AbstractMotor::encoderUnits::rotations;
-  case E_MOTOR_ENCODER_COUNTS:
+  case pros::E_MOTOR_ENCODER_COUNTS:
     return AbstractMotor::encoderUnits::counts;
-  case E_MOTOR_ENCODER_INVALID:
+  case pros::E_MOTOR_ENCODER_INVALID:
     return AbstractMotor::encoderUnits::invalid;
   }
 }
@@ -208,13 +208,13 @@ std::int32_t Motor::setGearing(const AbstractMotor::gearset igearset) {
 
 AbstractMotor::gearset Motor::getGearing() const {
   switch (get_gearing()) {
-  E_MOTOR_GEARSET_36:
+  case pros::E_MOTOR_GEARSET_36:
     return AbstractMotor::gearset::red;
-  E_MOTOR_GEARSET_18:
+  case pros::E_MOTOR_GEARSET_18:
     return AbstractMotor::gearset::green;
-  E_MOTOR_GEARSET_06:
+  case pros::E_MOTOR_GEARSET_06:
     return AbstractMotor::gearset::blue;
-  E_MOTOR_GEARSET_INVALID:
+  case pros::E_MOTOR_GEARSET_INVALID:
     return AbstractMotor::gearset::invalid;
   }
 }

--- a/src/impl/device/motor/motorGroup.cpp
+++ b/src/impl/device/motor/motorGroup.cpp
@@ -160,6 +160,10 @@ std::int32_t MotorGroup::setBrakeMode(const AbstractMotor::brakeMode imode) {
   return out;
 }
 
+AbstractMotor::brakeMode MotorGroup::getBrakeMode() const {
+  return motors[0].getBrakeMode();
+}
+
 std::int32_t MotorGroup::setCurrentLimit(const std::int32_t ilimit) const {
   auto out = 1;
   for (auto &&elem : motors) {
@@ -169,6 +173,10 @@ std::int32_t MotorGroup::setCurrentLimit(const std::int32_t ilimit) const {
     }
   }
   return out;
+}
+
+std::int32_t MotorGroup::getCurrentLimit() const {
+  return motors[0].getCurrentLimit();
 }
 
 std::int32_t MotorGroup::setEncoderUnits(const AbstractMotor::encoderUnits iunits) {
@@ -182,6 +190,10 @@ std::int32_t MotorGroup::setEncoderUnits(const AbstractMotor::encoderUnits iunit
   return out;
 }
 
+AbstractMotor::encoderUnits MotorGroup::getEncoderUnits() const {
+  return motors[0].getEncoderUnits();
+}
+
 std::int32_t MotorGroup::setGearing(const AbstractMotor::gearset igearset) {
   auto out = 1;
   for (auto &&elem : motors) {
@@ -191,6 +203,10 @@ std::int32_t MotorGroup::setGearing(const AbstractMotor::gearset igearset) {
     }
   }
   return out;
+}
+
+AbstractMotor::gearset MotorGroup::getGearing() const {
+  return motors[0].getGearing();
 }
 
 std::int32_t MotorGroup::setReversed(const bool ireverse) const {

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -1,15 +1,5 @@
 #include "main.h"
 
-void on_center_button() {
-  static bool pressed = false;
-  pressed = !pressed;
-  if (pressed) {
-    pros::lcd::set_text(2, "I was pressed!");
-  } else {
-    pros::lcd::clear_line(2);
-  }
-}
-
 /**
  * Runs initialization code. This occurs as soon as the program is started.
  *
@@ -17,10 +7,6 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
-  pros::lcd::initialize();
-  pros::lcd::set_text(1, "Hello PROS User!");
-
-  pros::lcd::register_btn1_cb(on_center_button);
 }
 
 /**

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -1,13 +1,13 @@
 #include "main.h"
 
 void on_center_button() {
-	static bool pressed = false;
-	pressed = !pressed;
-	if (pressed) {
-		pros::lcd::set_text(2, "I was pressed!");
-	} else {
-		pros::lcd::clear_line(2);
-	}
+  static bool pressed = false;
+  pressed = !pressed;
+  if (pressed) {
+    pros::lcd::set_text(2, "I was pressed!");
+  } else {
+    pros::lcd::clear_line(2);
+  }
 }
 
 /**
@@ -17,10 +17,10 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
-	pros::lcd::initialize();
-	pros::lcd::set_text(1, "Hello PROS User!");
+  pros::lcd::initialize();
+  pros::lcd::set_text(1, "Hello PROS User!");
 
-	pros::lcd::register_btn1_cb(on_center_button);
+  pros::lcd::register_btn1_cb(on_center_button);
 }
 
 /**
@@ -28,7 +28,8 @@ void initialize() {
  * the VEX Competition Switch, following either autonomous or opcontrol. When
  * the robot is enabled, this task will exit.
  */
-void disabled() {}
+void disabled() {
+}
 
 /**
  * Runs after initialize(), and before autonomous when connected to the Field
@@ -39,4 +40,5 @@ void disabled() {}
  * This task will exit when the robot is enabled and autonomous or opcontrol
  * starts.
  */
-void competition_initialize() {}
+void competition_initialize() {
+}

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -26,7 +26,7 @@ void opcontrol() {
   mpCnt.startThread();
 
   Logger::initialize(TimeUtilFactory::create().getTimer(), "/ser/sout", Logger::LogLevel::debug);
-  mpCnt.generatePath({0_in, 12_in}, "A");
+  mpCnt.generatePath({0, 12}, "A");
   mpCnt.setTarget("A");
   mpCnt.waitUntilSettled();
 }

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -16,18 +16,20 @@ using namespace pros::literals;
  * task, not resume it from where it left off.
  */
 void opcontrol() {
-	pros::Controller master(pros::E_CONTROLLER_MASTER);
-	auto left_mtr = 1_mtr;
-	pros::Motor right_mtr(2);
-	while (true) {
-		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
-		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
-		                 (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
-		int left = master.get_analog(ANALOG_LEFT_Y);
-		int right = master.get_analog(ANALOG_RIGHT_Y);
+  pros::Controller master(pros::E_CONTROLLER_MASTER);
+  auto left_mtr = 1_mtr;
+  pros::Motor right_mtr(2);
+  while (true) {
+    pros::lcd::print(0,
+                     "%d %d %d",
+                     (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
+                     (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
+                     (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
+    int left = master.get_analog(ANALOG_LEFT_Y);
+    int right = master.get_analog(ANALOG_RIGHT_Y);
 
-		left_mtr = left;
-		right_mtr = right;
-		pros::delay(20);
-	}
+    left_mtr = left;
+    right_mtr = right;
+    pros::delay(20);
+  }
 }

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -1,7 +1,5 @@
 #include "main.h"
 
-using namespace pros::literals;
-
 /**
  * Runs the operator control code. This function will be started in its own task
  * with the default priority and stack size whenever the robot is enabled via
@@ -16,20 +14,19 @@ using namespace pros::literals;
  * task, not resume it from where it left off.
  */
 void opcontrol() {
-  pros::Controller master(pros::E_CONTROLLER_MASTER);
-  auto left_mtr = 1_mtr;
-  pros::Motor right_mtr(2);
-  while (true) {
-    pros::lcd::print(0,
-                     "%d %d %d",
-                     (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
-                     (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
-                     (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
-    int left = master.get_analog(ANALOG_LEFT_Y);
-    int right = master.get_analog(ANALOG_RIGHT_Y);
+  using namespace okapi;
 
-    left_mtr = left;
-    right_mtr = right;
-    pros::delay(20);
-  }
+  pros::delay(100);
+
+  auto velCnt =
+    std::make_shared<AsyncVelIntegratedController>(AsyncControllerFactory::velIntegrated(1));
+
+  auto mpCnt =
+    AsyncLinearMotionProfileController(TimeUtilFactory::create(), 1.0, 2.0, 10.0, velCnt);
+  mpCnt.startThread();
+
+  Logger::initialize(TimeUtilFactory::create().getTimer(), "/ser/sout", Logger::LogLevel::debug);
+  mpCnt.generatePath({0_in, 12_in}, "A");
+  mpCnt.setTarget("A");
+  mpCnt.waitUntilSettled();
 }

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -39,8 +39,8 @@ TEST_F(AsyncLinearMotionProfileControllerTest, WaitUntilSettledWorksWhenDisabled
 
 TEST_F(AsyncLinearMotionProfileControllerTest, MoveToTest) {
   controller->moveTo(0_ft, 3_ft);
-  EXPECT_EQ(output->lastTarget, 0);
-  EXPECT_GT(output->maxTarget, 0);
+  EXPECT_EQ(output->lastControllerOutputSet, 0);
+  EXPECT_GT(output->maxControllerOutputSet, 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
@@ -55,16 +55,16 @@ TEST_F(AsyncLinearMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
 
   controller->waitUntilSettled();
 
-  EXPECT_EQ(output->lastTarget, 0);
-  EXPECT_GT(output->maxTarget, 0);
+  EXPECT_EQ(output->lastControllerOutputSet, 0);
+  EXPECT_GT(output->maxControllerOutputSet, 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, WrongPathNameDoesNotMoveAnything) {
   controller->setTarget("A");
   controller->waitUntilSettled();
 
-  EXPECT_EQ(output->lastTarget, 0);
-  EXPECT_EQ(output->maxTarget, 0);
+  EXPECT_EQ(output->lastControllerOutputSet, 0);
+  EXPECT_EQ(output->maxControllerOutputSet, 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, TwoPathsOverwriteEachOther) {
@@ -76,8 +76,8 @@ TEST_F(AsyncLinearMotionProfileControllerTest, TwoPathsOverwriteEachOther) {
 
   controller->setTarget("A");
   controller->waitUntilSettled();
-  EXPECT_EQ(output->lastTarget, 0);
-  EXPECT_GT(output->maxTarget, 0);
+  EXPECT_EQ(output->lastControllerOutputSet, 0);
+  EXPECT_GT(output->maxControllerOutputSet, 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, ZeroWaypointsDoesNothing) {

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -1,0 +1,99 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/control/async/asyncLinearMotionProfileController.hpp"
+#include "test/tests/api/implMocks.hpp"
+#include <gtest/gtest.h>
+
+using namespace okapi;
+
+class AsyncLinearMotionProfileControllerTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    output = new MockAsyncVelIntegratedController();
+
+    controller = new AsyncLinearMotionProfileController(
+      createTimeUtil(), 1.0, 2.0, 10.0, std::shared_ptr<MockAsyncVelIntegratedController>(output));
+    controller->startThread();
+  }
+
+  void TearDown() override {
+    delete controller;
+  }
+
+  MockAsyncVelIntegratedController *output;
+  AsyncLinearMotionProfileController *controller;
+};
+
+TEST_F(AsyncLinearMotionProfileControllerTest, SettledWhenDisabled) {
+  assertControllerIsSettledWhenDisabled(*controller, std::string("A"));
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, WaitUntilSettledWorksWhenDisabled) {
+  assertWaitUntilSettledWorksWhenDisabled(*controller);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
+  controller->generatePath({0_m, 3_ft}, "A");
+
+  EXPECT_EQ(controller->getPaths().front(), "A");
+  EXPECT_EQ(controller->getPaths().size(), 1);
+
+  controller->setTarget("A");
+
+  EXPECT_EQ(controller->getTarget(), "A");
+
+  controller->waitUntilSettled();
+
+  EXPECT_EQ(output->lastTarget, 0);
+  EXPECT_GT(output->maxTarget, 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, WrongPathNameDoesNotMoveAnything) {
+  controller->setTarget("A");
+  controller->waitUntilSettled();
+
+  EXPECT_EQ(output->lastTarget, 0);
+  EXPECT_EQ(output->maxTarget, 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, TwoPathsOverwriteEachOther) {
+  controller->generatePath({0_m, 3_ft}, "A");
+  controller->generatePath({0_m, 4_ft}, "A");
+
+  EXPECT_EQ(controller->getPaths().front(), "A");
+  EXPECT_EQ(controller->getPaths().size(), 1);
+
+  controller->setTarget("A");
+  controller->waitUntilSettled();
+  EXPECT_EQ(output->lastTarget, 0);
+  EXPECT_GT(output->maxTarget, 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, ZeroWaypointsDoesNothing) {
+  controller->generatePath({}, "A");
+  EXPECT_EQ(controller->getPaths().size(), 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, RemoveAPath) {
+  controller->generatePath({0_m, 3_ft}, "A");
+
+  EXPECT_EQ(controller->getPaths().front(), "A");
+  EXPECT_EQ(controller->getPaths().size(), 1);
+
+  controller->removePath("A");
+
+  EXPECT_EQ(controller->getPaths().size(), 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, RemoveAPathWhichDoesNotExist) {
+  EXPECT_EQ(controller->getPaths().size(), 0);
+
+  controller->removePath("A");
+
+  EXPECT_EQ(controller->getPaths().size(), 0);
+}

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -108,3 +108,20 @@ TEST_F(AsyncLinearMotionProfileControllerTest, ControllerSetChangesTarget) {
   controller->controllerSet("A");
   EXPECT_EQ(controller->getTarget(), "A");
 }
+
+TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithNoTarget) {
+  EXPECT_EQ(controller->getError().convert(meter), 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithNonexistentTarget) {
+  controller->setTarget("A");
+  EXPECT_EQ(controller->getError().convert(meter), 0);
+}
+
+TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithCorrectTarget) {
+  controller->generatePath({0_m, 3_ft}, "A");
+  controller->setTarget("A");
+
+  // Pathfinder generates an approximate path so this could be slightly off
+  EXPECT_NEAR(controller->getError().convert(foot), 3, 0.1);
+}

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -103,3 +103,8 @@ TEST_F(AsyncLinearMotionProfileControllerTest, RemoveAPathWhichDoesNotExist) {
 
   EXPECT_EQ(controller->getPaths().size(), 0);
 }
+
+TEST_F(AsyncLinearMotionProfileControllerTest, ControllerSetChangesTarget) {
+  controller->controllerSet("A");
+  EXPECT_EQ(controller->getTarget(), "A");
+}

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -38,13 +38,13 @@ TEST_F(AsyncLinearMotionProfileControllerTest, WaitUntilSettledWorksWhenDisabled
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, MoveToTest) {
-  controller->moveTo(0_ft, 3_ft);
+  controller->moveTo(0, 3);
   EXPECT_EQ(output->lastControllerOutputSet, 0);
   EXPECT_GT(output->maxControllerOutputSet, 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
-  controller->generatePath({0_m, 3_ft}, "A");
+  controller->generatePath({0, 3}, "A");
 
   EXPECT_EQ(controller->getPaths().front(), "A");
   EXPECT_EQ(controller->getPaths().size(), 1);
@@ -68,8 +68,8 @@ TEST_F(AsyncLinearMotionProfileControllerTest, WrongPathNameDoesNotMoveAnything)
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, TwoPathsOverwriteEachOther) {
-  controller->generatePath({0_m, 3_ft}, "A");
-  controller->generatePath({0_m, 4_ft}, "A");
+  controller->generatePath({0, 3}, "A");
+  controller->generatePath({0, 4}, "A");
 
   EXPECT_EQ(controller->getPaths().front(), "A");
   EXPECT_EQ(controller->getPaths().size(), 1);
@@ -86,7 +86,7 @@ TEST_F(AsyncLinearMotionProfileControllerTest, ZeroWaypointsDoesNothing) {
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, RemoveAPath) {
-  controller->generatePath({0_m, 3_ft}, "A");
+  controller->generatePath({0, 3}, "A");
 
   EXPECT_EQ(controller->getPaths().front(), "A");
   EXPECT_EQ(controller->getPaths().size(), 1);
@@ -110,18 +110,18 @@ TEST_F(AsyncLinearMotionProfileControllerTest, ControllerSetChangesTarget) {
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithNoTarget) {
-  EXPECT_EQ(controller->getError().convert(meter), 0);
+  EXPECT_EQ(controller->getError(), 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithNonexistentTarget) {
   controller->setTarget("A");
-  EXPECT_EQ(controller->getError().convert(meter), 0);
+  EXPECT_EQ(controller->getError(), 0);
 }
 
 TEST_F(AsyncLinearMotionProfileControllerTest, GetErrorWithCorrectTarget) {
-  controller->generatePath({0_m, 3_ft}, "A");
+  controller->generatePath({0, 3}, "A");
   controller->setTarget("A");
 
   // Pathfinder generates an approximate path so this could be slightly off
-  EXPECT_NEAR(controller->getError().convert(foot), 3, 0.1);
+  EXPECT_NEAR(controller->getError(), 3, 0.1);
 }

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -37,6 +37,12 @@ TEST_F(AsyncLinearMotionProfileControllerTest, WaitUntilSettledWorksWhenDisabled
   assertWaitUntilSettledWorksWhenDisabled(*controller);
 }
 
+TEST_F(AsyncLinearMotionProfileControllerTest, MoveToTest) {
+  controller->moveTo(0_ft, 3_ft);
+  EXPECT_EQ(output->lastTarget, 0);
+  EXPECT_GT(output->maxTarget, 0);
+}
+
 TEST_F(AsyncLinearMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
   controller->generatePath({0_m, 3_ft}, "A");
 

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -116,3 +116,8 @@ TEST_F(AsyncMotionProfileControllerTest, RemoveAPathWhichDoesNotExist) {
 
   EXPECT_EQ(controller->getPaths().size(), 0);
 }
+
+TEST_F(AsyncMotionProfileControllerTest, ControllerSetChangesTarget) {
+  controller->controllerSet("A");
+  EXPECT_EQ(controller->getTarget(), "A");
+}

--- a/test/asyncPosIntegratedControllerTests.cpp
+++ b/test/asyncPosIntegratedControllerTests.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/control/async/asyncPosIntegratedController.hpp"
+#include "okapi/api/util/mathUtil.hpp"
 #include "test/tests/api/implMocks.hpp"
 #include <gtest/gtest.h>
 
@@ -47,4 +48,9 @@ TEST_F(AsyncPosIntegratedControllerTest, FollowsDisableLifecycle) {
 
 TEST_F(AsyncPosIntegratedControllerTest, FollowsTargetLifecycle) {
   assertControllerFollowsTargetLifecycle(*controller);
+}
+
+TEST_F(AsyncPosIntegratedControllerTest, ControllerSetScalesTarget) {
+  controller->controllerSet(1);
+  EXPECT_EQ(controller->getTarget(), toUnderlyingType(motor->getGearing()));
 }

--- a/test/asyncVelIntegratedControllerTests.cpp
+++ b/test/asyncVelIntegratedControllerTests.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/control/async/asyncVelIntegratedController.hpp"
+#include "okapi/api/util/mathUtil.hpp"
 #include "test/tests/api/implMocks.hpp"
 #include <gtest/gtest.h>
 #include <limits>
@@ -48,4 +49,9 @@ TEST_F(AsyncVelIntegratedControllerTest, FollowsDisableLifecycle) {
 
 TEST_F(AsyncVelIntegratedControllerTest, FollowsTargetLifecycle) {
   assertControllerFollowsTargetLifecycle(*controller);
+}
+
+TEST_F(AsyncVelIntegratedControllerTest, ControllerSetScalesTarget) {
+  controller->controllerSet(1);
+  EXPECT_EQ(controller->getTarget(), toUnderlyingType(motor->getGearing()));
 }

--- a/test/asyncWrapperTests.cpp
+++ b/test/asyncWrapperTests.cpp
@@ -90,3 +90,11 @@ TEST_F(AsyncWrapperTest, FollowsTargetLifecyclePosPID) {
 TEST_F(AsyncWrapperTest, FollowsTargetLifecycleVelPID) {
   assertControllerFollowsTargetLifecycle(*velPIDController);
 }
+
+TEST_F(AsyncWrapperTest, ScalesControllerSetTargetPosPID) {
+  assertAsyncWrapperScalesControllerSetTargets(*posPIDController);
+}
+
+TEST_F(AsyncWrapperTest, ScalesControllerSetTargetVelPID) {
+  assertAsyncWrapperScalesControllerSetTargets(*velPIDController);
+}

--- a/test/chassisControllerIntegratedTests.cpp
+++ b/test/chassisControllerIntegratedTests.cpp
@@ -19,8 +19,8 @@ class ChassisControllerIntegratedTest : public ::testing::Test {
     leftMotor = new MockMotor();
     rightMotor = new MockMotor();
 
-    leftController = new MockAsyncController();
-    rightController = new MockAsyncController();
+    leftController = new MockAsyncPosIntegratedController();
+    rightController = new MockAsyncPosIntegratedController();
 
     model = new SkidSteerModel(std::unique_ptr<AbstractMotor>(leftMotor),
                                std::unique_ptr<AbstractMotor>(rightMotor));
@@ -43,8 +43,8 @@ class ChassisControllerIntegratedTest : public ::testing::Test {
   ChassisController *controller;
   MockMotor *leftMotor;
   MockMotor *rightMotor;
-  MockAsyncController *leftController;
-  MockAsyncController *rightController;
+  MockAsyncPosIntegratedController *leftController;
+  MockAsyncPosIntegratedController *rightController;
   SkidSteerModel *model;
 };
 

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -351,16 +351,34 @@ void SimulatedSystem::join() {
   thread.join();
 }
 
-MockAsyncController::MockAsyncController()
+MockAsyncPosIntegratedController::MockAsyncPosIntegratedController()
   : AsyncPosIntegratedController(std::make_shared<MockMotor>(), createTimeUtil()) {
 }
 
-MockAsyncController::MockAsyncController(const TimeUtil &itimeUtil)
+MockAsyncPosIntegratedController::MockAsyncPosIntegratedController(const TimeUtil &itimeUtil)
   : AsyncPosIntegratedController(std::make_shared<MockMotor>(), itimeUtil) {
 }
 
-bool MockAsyncController::isSettled() {
+bool MockAsyncPosIntegratedController::isSettled() {
   return isSettledOverride || AsyncPosIntegratedController::isSettled();
+}
+
+MockAsyncVelIntegratedController::MockAsyncVelIntegratedController()
+  : AsyncVelIntegratedController(std::make_shared<MockMotor>(), createTimeUtil()) {
+}
+
+bool MockAsyncVelIntegratedController::isSettled() {
+  return isSettledOverride || AsyncVelIntegratedController::isSettled();
+}
+
+void MockAsyncVelIntegratedController::setTarget(double itarget) {
+  lastTarget = itarget;
+
+  if (itarget > maxTarget) {
+    maxTarget = itarget;
+  }
+
+  AsyncVelIntegratedController::setTarget(itarget);
 }
 
 MockIterativeController::MockIterativeController()

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -387,7 +387,7 @@ bool MockAsyncVelIntegratedController::isSettled() {
   return isSettledOverride || AsyncVelIntegratedController::isSettled();
 }
 
-void MockAsyncVelIntegratedController::setTarget(double itarget) {
+void MockAsyncVelIntegratedController::setTarget(const double itarget) {
   lastTarget = itarget;
 
   if (itarget > maxTarget) {
@@ -397,7 +397,7 @@ void MockAsyncVelIntegratedController::setTarget(double itarget) {
   AsyncVelIntegratedController::setTarget(itarget);
 }
 
-void MockAsyncVelIntegratedController::controllerSet(double ivalue) {
+void MockAsyncVelIntegratedController::controllerSet(const double ivalue) {
   lastControllerOutputSet = ivalue;
 
   if (ivalue > maxControllerOutputSet) {
@@ -514,5 +514,20 @@ void assertControllerFollowsTargetLifecycle(ClosedLoopController<double, double>
   EXPECT_DOUBLE_EQ(controller.getError(), 100);
   controller.setTarget(0);
   EXPECT_DOUBLE_EQ(controller.getError(), 0);
+}
+
+void assertIterativeControllerScalesControllerSetTargets(
+  IterativeController<double, double> &controller) {
+  EXPECT_DOUBLE_EQ(controller.getTarget(), 0);
+  controller.setOutputLimits(-100, 100);
+  controller.controllerSet(0.5);
+  EXPECT_DOUBLE_EQ(controller.getTarget(), 50);
+}
+
+void assertAsyncWrapperScalesControllerSetTargets(AsyncWrapper<double, double> &controller) {
+  EXPECT_DOUBLE_EQ(controller.getTarget(), 0);
+  controller.setOutputLimits(-100, 100);
+  controller.controllerSet(0.5);
+  EXPECT_DOUBLE_EQ(controller.getTarget(), 50);
 }
 } // namespace okapi

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -197,6 +197,22 @@ int32_t MockMotor::setVelPIDFull(double ikF,
   return 0;
 }
 
+AbstractMotor::brakeMode MockMotor::getBrakeMode() const {
+  return brakeMode::coast;
+}
+
+int32_t MockMotor::getCurrentLimit() const {
+  return 2500;
+}
+
+AbstractMotor::encoderUnits MockMotor::getEncoderUnits() const {
+  return encoderUnits::degrees;
+}
+
+AbstractMotor::gearset MockMotor::getGearing() const {
+  return gearset::red;
+}
+
 MockTimer::MockTimer() : AbstractTimer(millis()) {
 }
 
@@ -379,6 +395,16 @@ void MockAsyncVelIntegratedController::setTarget(double itarget) {
   }
 
   AsyncVelIntegratedController::setTarget(itarget);
+}
+
+void MockAsyncVelIntegratedController::controllerSet(double ivalue) {
+  lastControllerOutputSet = ivalue;
+
+  if (ivalue > maxControllerOutputSet) {
+    maxControllerOutputSet = ivalue;
+  }
+
+  AsyncVelIntegratedController::controllerSet(ivalue);
 }
 
 MockIterativeController::MockIterativeController()

--- a/test/iterativeMotorVelocityControllerTest.cpp
+++ b/test/iterativeMotorVelocityControllerTest.cpp
@@ -66,6 +66,10 @@ TEST_F(IterativeMotorVelocityControllerTest, TargetLifecycle) {
   assertControllerFollowsTargetLifecycle(*controller);
 }
 
+TEST_F(IterativeMotorVelocityControllerTest, ScalesControllerSetTarget) {
+  assertIterativeControllerScalesControllerSetTargets(*controller);
+}
+
 TEST_F(IterativeMotorVelocityControllerTest, StaticFrictionGainUsesTargetSign) {
   velController->setGains(0, 0, 0, 0.1);
 

--- a/test/iterativeMotorVelocityControllerTest.cpp
+++ b/test/iterativeMotorVelocityControllerTest.cpp
@@ -92,16 +92,20 @@ TEST_F(IterativeMotorVelocityControllerTest, SetOutputLimitsTest) {
   controller->setOutputLimits(0.5, -0.5);
   EXPECT_DOUBLE_EQ(velController->outputMax, 0.5);
   EXPECT_DOUBLE_EQ(velController->getMaxOutput(), 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMin, -0.5);
   EXPECT_DOUBLE_EQ(velController->getMinOutput(), -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, SetOutputLimitsReversedTest) {
   controller->setOutputLimits(-0.5, 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMax, 0.5);
   EXPECT_DOUBLE_EQ(velController->getMaxOutput(), 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMin, -0.5);
   EXPECT_DOUBLE_EQ(velController->getMinOutput(), -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, NoOutputWhenDisabled) {

--- a/test/iterativeMotorVelocityControllerTest.cpp
+++ b/test/iterativeMotorVelocityControllerTest.cpp
@@ -91,13 +91,17 @@ TEST_F(IterativeMotorVelocityControllerTest, StaticFrictionGainUsesTargetSign) {
 TEST_F(IterativeMotorVelocityControllerTest, SetOutputLimitsTest) {
   controller->setOutputLimits(0.5, -0.5);
   EXPECT_DOUBLE_EQ(velController->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(velController->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(velController->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, SetOutputLimitsReversedTest) {
   controller->setOutputLimits(-0.5, 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(velController->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(velController->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(velController->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, NoOutputWhenDisabled) {

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -63,6 +63,10 @@ TEST_F(IterativePosPIDControllerTest, TargetLifecycle) {
   assertControllerFollowsTargetLifecycle(*controller);
 }
 
+TEST_F(IterativePosPIDControllerTest, ScalesControllerSetTarget) {
+  assertIterativeControllerScalesControllerSetTargets(*controller);
+}
+
 TEST_F(IterativePosPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getError(), 0);
   controller->flipDisable(true);

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -99,13 +99,17 @@ TEST_F(IterativePosPIDControllerTest, SetIntegralLimitsReversedTest) {
 TEST_F(IterativePosPIDControllerTest, SetOutputLimitsTest) {
   controller->setOutputLimits(0.5, -0.5);
   EXPECT_DOUBLE_EQ(controller->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativePosPIDControllerTest, SetOutputLimitsReversedTest) {
   controller->setOutputLimits(-0.5, 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativePosPIDControllerTest, NoOutputWhenDisabled) {

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -54,6 +54,10 @@ TEST_F(IterativeVelPIDControllerTest, TargetLifecycle) {
   assertControllerFollowsTargetLifecycle(*controller);
 }
 
+TEST_F(IterativeVelPIDControllerTest, ScalesControllerSetTarget) {
+  assertIterativeControllerScalesControllerSetTargets(*controller);
+}
+
 TEST_F(IterativeVelPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getError(), 0);
   controller->flipDisable(true);

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -94,13 +94,17 @@ TEST_F(IterativeVelPIDControllerTest, StaticFrictionGainUsesTargetSign) {
 TEST_F(IterativeVelPIDControllerTest, SetOutputLimitsTest) {
   controller->setOutputLimits(0.5, -0.5);
   EXPECT_DOUBLE_EQ(controller->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeVelPIDControllerTest, SetOutputLimitsReversedTest) {
   controller->setOutputLimits(-0.5, 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMax, 0.5);
+  EXPECT_DOUBLE_EQ(controller->getMaxOutput(), 0.5);
   EXPECT_DOUBLE_EQ(controller->outputMin, -0.5);
+  EXPECT_DOUBLE_EQ(controller->getMinOutput(), -0.5);
 }
 
 TEST_F(IterativeVelPIDControllerTest, NoOutputWhenDisabled) {


### PR DESCRIPTION
### Description of the Change

Pathfinder's "unmodified" profiles are 1D trapezoidal profiles. We should expose this to the user for 1DOF systems such as lifts. This PR adds that, adds a few missing telemetry methods to `AbstractMotor` that the new 1D motion profile class needed (albeit indirectly) and makes some async controllers implement `ControllerOutput`.

Still need to do:
- [x] Investigate (and update) other Async Controllers that could implement `ControllerOutput`.
- [x] Add the new class to the `AsyncControllerFactory`.

### Benefits

1D motion profiling of course :)

### Possible Drawbacks

I'm not thrilled with the lack of code reuse, but I can't think of a good way to split this in a concise way that will make sense to people looking to extend the features.

### Verification Process

Tested by hand. Still need to do:
- [x] Test the most recent changes again.

### Applicable Issues

Closes #198.
