### PR TITLE
Throw exception from MotorGroup ctor if no motors are given

### DIFF
--- a/include/okapi/impl/device/motor/motorGroup.hpp
+++ b/include/okapi/impl/device/motor/motorGroup.hpp
@@ -16,6 +16,13 @@
 namespace okapi {
 class MotorGroup : public AbstractMotor {
   public:
+  /**
+   * A group of V5 motors which act as one motor (i.e. they are mechanically linked). A MotorGroup
+   * requires at least one motor. If no motors are supplied, a std::invalid_argument exception is
+   * thrown.
+   *
+   * @param imotors the motors in this group
+   */
   MotorGroup(const std::initializer_list<Motor> &imotors);
 
   /******************************************************************************/

--- a/src/impl/device/motor/motorGroup.cpp
+++ b/src/impl/device/motor/motorGroup.cpp
@@ -6,9 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/device/motor/motorGroup.hpp"
+#include "okapi/api/util/logging.hpp"
 
 namespace okapi {
 MotorGroup::MotorGroup(const std::initializer_list<Motor> &imotors) : motors(imotors) {
+  if (motors.empty()) {
+    Logger::instance()->error(
+      "MotorGroup: A MotorGroup must be created with at least one motor. No motors were given.");
+    throw std::invalid_argument(
+      "MotorGroup: A MotorGroup must be created with at least one motor. No motors were given.");
+  }
 }
 
 std::int32_t MotorGroup::moveAbsolute(const double iposition, const std::int32_t ivelocity) const {


### PR DESCRIPTION
### Description of the Change

`MotorGroup` should throw a `std::invalid_argument` if it isn't given any motors. The class does not perform any bounds checking for speed purposes, so having no motors would invoke undefined behavior.

### Verification Process

This change was not verified; however, I did verify a small test class with the exact same constructor code.

### Applicable Issues

Closes #205.
