### PR TITLE
Fix ChassisModel low maximum velocity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(OkapiLibV5
         src/api/chassis/controller/chassisController.cpp
         src/api/chassis/controller/chassisControllerIntegrated.cpp
         src/api/chassis/controller/chassisControllerPid.cpp
+        src/api/chassis/model/chassisModel.cpp
         src/api/chassis/model/skidSteerModel.cpp
         src/api/chassis/model/readOnlyChassisModel.cpp
         src/api/chassis/model/threeEncoderSkidSteerModel.cpp

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -24,6 +24,7 @@ namespace okapi {
 class ChassisModel : public ReadOnlyChassisModel {
   public:
   ChassisModel() = default;
+  ChassisModel(double imaxVelocity, double imaxVoltage);
   ChassisModel(const ChassisModel &) = delete;
   ChassisModel &operator=(const ChassisModel &) = delete;
 
@@ -176,6 +177,24 @@ class ChassisModel : public ReadOnlyChassisModel {
                              double ilimit,
                              double ithreshold,
                              double iloopSpeed) const = 0;
+
+  /**
+   * Sets a new maximum velocity.
+   *
+   * @param imaxVelocity the new maximum velocity
+   */
+  virtual void setMaxVelocity(double imaxVelocity);
+
+  /**
+   * Sets a new maximum voltage.
+   *
+   * @param imaxVoltage the new maximum voltage
+   */
+  virtual void setMaxVoltage(double imaxVoltage);
+
+  protected:
+  double maxVelocity{600};
+  double maxVoltage{12000};
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -27,7 +27,7 @@ class SkidSteerModel : public ChassisModel {
    */
   SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                  std::shared_ptr<AbstractMotor> irightSideMotor,
-                 double imaxVelocity = 127,
+                 double imaxVelocity = 600,
                  double imaxVoltage = 12000);
 
   /**
@@ -43,7 +43,7 @@ class SkidSteerModel : public ChassisModel {
                  std::shared_ptr<AbstractMotor> irightSideMotor,
                  std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                  std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                 double imaxVelocity = 127,
+                 double imaxVelocity = 600,
                  double imaxVoltage = 12000);
 
   /**
@@ -226,8 +226,8 @@ class SkidSteerModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> rightSideMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  const double maxVelocity;
-  const double maxVoltage;
+  double maxVelocity;
+  double maxVoltage;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -226,8 +226,6 @@ class SkidSteerModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> rightSideMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  double maxVelocity;
-  double maxVoltage;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -28,7 +28,7 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
                              std::shared_ptr<ContinuousRotarySensor> ileftEnc,
                              std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
                              std::shared_ptr<ContinuousRotarySensor> irightEnc,
-                             double imaxVelocity = 127,
+                             double imaxVelocity = 600,
                              double imaxVoltage = 12000);
 
   /**

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -31,7 +31,7 @@ class XDriveModel : public ChassisModel {
               std::shared_ptr<AbstractMotor> itopRightMotor,
               std::shared_ptr<AbstractMotor> ibottomRightMotor,
               std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-              double imaxVelocity = 127,
+              double imaxVelocity = 600,
               double imaxVoltage = 12000);
 
   /**
@@ -51,7 +51,7 @@ class XDriveModel : public ChassisModel {
               std::shared_ptr<AbstractMotor> ibottomLeftMotor,
               std::shared_ptr<ContinuousRotarySensor> ileftEnc,
               std::shared_ptr<ContinuousRotarySensor> irightEnc,
-              double imaxVelocity = 127,
+              double imaxVelocity = 600,
               double imaxVoltage = 12000);
 
   /**
@@ -261,8 +261,8 @@ class XDriveModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> bottomLeftMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  const double maxVelocity;
-  const double maxVoltage;
+  double maxVelocity;
+  double maxVoltage;
 };
 } // namespace okapi
 

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -261,8 +261,6 @@ class XDriveModel : public ChassisModel {
   std::shared_ptr<AbstractMotor> bottomLeftMotor;
   std::shared_ptr<ContinuousRotarySensor> leftSensor;
   std::shared_ptr<ContinuousRotarySensor> rightSensor;
-  double maxVelocity;
-  double maxVoltage;
 };
 } // namespace okapi
 

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -9,7 +9,8 @@
 #include <cmath>
 
 namespace okapi {
-ChassisController::ChassisController(std::shared_ptr<ChassisModel> imodel) : model(imodel) {
+ChassisController::ChassisController(std::shared_ptr<ChassisModel> imodel)
+  : ChassisModel::ChassisModel(), model(imodel) {
 }
 
 ChassisController::~ChassisController() = default;

--- a/src/api/chassis/model/chassisModel.cpp
+++ b/src/api/chassis/model/chassisModel.cpp
@@ -1,0 +1,22 @@
+/**
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/chassis/model/chassisModel.hpp"
+
+namespace okapi {
+ChassisModel::ChassisModel(const double imaxVelocity, const double imaxVoltage)
+  : maxVelocity(imaxVelocity), maxVoltage(imaxVoltage) {
+}
+
+void ChassisModel::setMaxVelocity(const double imaxVelocity) {
+  maxVelocity = imaxVelocity;
+}
+
+void ChassisModel::setMaxVoltage(const double imaxVoltage) {
+  maxVoltage = imaxVoltage;
+}
+} // namespace okapi

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -16,24 +16,22 @@ SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                std::shared_ptr<ContinuousRotarySensor> irightEnc,
                                const double imaxVelocity,
                                const double imaxVoltage)
-  : leftSideMotor(ileftSideMotor),
+  : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
+    leftSideMotor(ileftSideMotor),
     rightSideMotor(irightSideMotor),
     leftSensor(ileftEnc),
-    rightSensor(irightEnc),
-    maxVelocity(imaxVelocity),
-    maxVoltage(imaxVoltage) {
+    rightSensor(irightEnc) {
 }
 
 SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                                std::shared_ptr<AbstractMotor> irightSideMotor,
                                const double imaxVelocity,
                                const double imaxVoltage)
-  : leftSideMotor(ileftSideMotor),
+  : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
+    leftSideMotor(ileftSideMotor),
     rightSideMotor(irightSideMotor),
     leftSensor(ileftSideMotor->getEncoder()),
-    rightSensor(irightSideMotor->getEncoder()),
-    maxVelocity(imaxVelocity),
-    maxVoltage(imaxVoltage) {
+    rightSensor(irightSideMotor->getEncoder()) {
 }
 
 void SkidSteerModel::forward(const double ispeed) const {

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -17,14 +17,13 @@ XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
                          std::shared_ptr<ContinuousRotarySensor> irightEnc,
                          const double imaxVelocity,
                          const double imaxVoltage)
-  : topLeftMotor(itopLeftMotor),
+  : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
+    topLeftMotor(itopLeftMotor),
     topRightMotor(itopRightMotor),
     bottomRightMotor(ibottomRightMotor),
     bottomLeftMotor(ibottomLeftMotor),
     leftSensor(ileftEnc),
-    rightSensor(irightEnc),
-    maxVelocity(imaxVelocity),
-    maxVoltage(imaxVoltage) {
+    rightSensor(irightEnc) {
 }
 
 XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
@@ -33,14 +32,13 @@ XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
                          std::shared_ptr<AbstractMotor> ibottomLeftMotor,
                          const double imaxVelocity,
                          const double imaxVoltage)
-  : topLeftMotor(itopLeftMotor),
+  : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
+    topLeftMotor(itopLeftMotor),
     topRightMotor(itopRightMotor),
     bottomRightMotor(ibottomRightMotor),
     bottomLeftMotor(ibottomLeftMotor),
     leftSensor(itopLeftMotor->getEncoder()),
-    rightSensor(itopRightMotor->getEncoder()),
-    maxVelocity(imaxVelocity),
-    maxVoltage(imaxVoltage) {
+    rightSensor(itopRightMotor->getEncoder()) {
 }
 
 void XDriveModel::forward(const double ispeed) const {

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -151,6 +151,18 @@ TEST_F(SkidSteerModelTest, ArcadeThresholds) {
   assertAllMotorsLastVoltage(0);
 }
 
+TEST_F(SkidSteerModelTest, SetMaxVelocity) {
+  model.setMaxVelocity(2);
+  model.forward(0.5);
+  assertAllMotorsLastVelocity(1);
+}
+
+TEST_F(SkidSteerModelTest, SetMaxVoltage) {
+  model.setMaxVoltage(2);
+  model.tank(0.5, 0.5);
+  assertAllMotorsLastVoltage(1);
+}
+
 TEST_F(SkidSteerModelTest, SetGearsetTest) {
   model.setGearing(AbstractMotor::gearset::green);
   assertMotorsGearsetEquals(AbstractMotor::gearset::green, {*leftMotor, *rightMotor});

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -262,6 +262,18 @@ TEST_F(XDriveModelTest, XArcadeBoundsInputAllNoForward) {
   EXPECT_EQ(bottomLeftMotor->lastVoltage, 0);
 }
 
+TEST_F(XDriveModelTest, SetMaxVelocity) {
+  model.setMaxVelocity(2);
+  model.forward(0.5);
+  assertAllMotorsLastVelocity(1);
+}
+
+TEST_F(XDriveModelTest, SetMaxVoltage) {
+  model.setMaxVoltage(2);
+  model.tank(0.5, 0.5);
+  assertAllMotorsLastVoltage(1);
+}
+
 TEST_F(XDriveModelTest, SetGearsetTest) {
   model.setGearing(AbstractMotor::gearset::green);
   assertMotorsGearsetEquals(AbstractMotor::gearset::green,


### PR DESCRIPTION
### Description of the Change

This PR fixes all the `ChassisModel` implementations having a low default maximum velocity. It also moves the maximum velocity and voltage parameters to the `ChassisModel` class and exposes them through two virtual setters.

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

Some new tests were added for the new setters. I also verified by changing some existing tests by hand.

### Applicable Issues

Closes #217.
