### PR TITLE
Refactor flipDisable to always log

### DIFF
--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -170,6 +170,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * cause the controller to move to its last set target, unless it was reset in that time.
    */
   void flipDisable() override {
+    logger->info("AsyncWrapper: flipDisable " + std::to_string(!controller->isDisabled()));
     controller->flipDisable();
     resumeMovement();
   }

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -212,33 +212,33 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   protected:
   Logger *logger;
   double kP, kI, kD, kBias;
-  QTime sampleTime = 10_ms;
-  double target = 0;
-  double lastReading = 0;
-  double error = 0;
-  double lastError = 0;
+  QTime sampleTime{10_ms};
+  double target{0};
+  double lastReading{0};
+  double error{0};
+  double lastError{0};
   std::unique_ptr<Filter> derivativeFilter;
 
   // Integral bounds
-  double integral = 0;
-  double integralMax = 1;
-  double integralMin = -1;
+  double integral{0};
+  double integralMax{1};
+  double integralMin{-1};
 
   // Error will only be added to the integral term within these bounds on either side of the target
-  double errorSumMin = 0;
-  double errorSumMax = std::numeric_limits<double>::max();
+  double errorSumMin{0};
+  double errorSumMax{std::numeric_limits<double>::max()};
 
-  double derivative = 0;
+  double derivative{0};
 
   // Output bounds
-  double output = 0;
-  double outputMax = 1;
-  double outputMin = -1;
+  double output{0};
+  double outputMax{1};
+  double outputMin{-1};
 
   // Reset the integrated when the controller crosses 0 or not
-  bool shouldResetOnCross = true;
+  bool shouldResetOnCross{true};
 
-  bool isOn = true;
+  bool controllerIsDisabled{false};
 
   std::unique_ptr<AbstractTimer> loopDtTimer;
   std::unique_ptr<SettledUtil> settledUtil;

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -184,15 +184,15 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   protected:
   Logger *logger;
   double kP, kD, kF, kSF;
-  QTime sampleTime = 10_ms;
-  double error = 0;
-  double derivative = 0;
-  double target = 0;
-  double outputSum = 0;
-  double output = 0;
-  double outputMax = 1;
-  double outputMin = -1;
-  bool isOn = true;
+  QTime sampleTime{10_ms};
+  double error{0};
+  double derivative{0};
+  double target{0};
+  double outputSum{0};
+  double output{0};
+  double outputMax{1};
+  double outputMin{-1};
+  bool controllerIsDisabled{false};
 
   std::unique_ptr<VelMath> velMath;
   std::unique_ptr<Filter> derivativeFilter;

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -232,7 +232,7 @@ void AsyncLinearMotionProfileController::reset() {
 }
 
 void AsyncLinearMotionProfileController::flipDisable() {
-  disabled = !disabled;
+  flipDisable(!disabled);
 }
 
 void AsyncLinearMotionProfileController::flipDisable(bool iisDisabled) {

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -243,7 +243,7 @@ void AsyncMotionProfileController::reset() {
 }
 
 void AsyncMotionProfileController::flipDisable() {
-  disabled = !disabled;
+  flipDisable(!disabled);
 }
 
 void AsyncMotionProfileController::flipDisable(bool iisDisabled) {

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -55,8 +55,7 @@ void AsyncPosIntegratedController::reset() {
 }
 
 void AsyncPosIntegratedController::flipDisable() {
-  controllerIsDisabled = !controllerIsDisabled;
-  resumeMovement();
+  flipDisable(!controllerIsDisabled);
 }
 
 void AsyncPosIntegratedController::flipDisable(const bool iisDisabled) {

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -45,8 +45,7 @@ void AsyncVelIntegratedController::reset() {
 }
 
 void AsyncVelIntegratedController::flipDisable() {
-  controllerIsDisabled = !controllerIsDisabled;
-  resumeMovement();
+  flipDisable(!controllerIsDisabled);
 }
 
 void AsyncVelIntegratedController::flipDisable(const bool iisDisabled) {

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -119,7 +119,9 @@ void IterativePosPIDController::setErrorSumLimits(const double imax, const doubl
 double IterativePosPIDController::step(const double inewReading) {
   lastReading = inewReading;
 
-  if (isOn) {
+  if (controllerIsDisabled) {
+    return 0;
+  } else {
     loopDtTimer->placeHardMark();
 
     if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
@@ -146,8 +148,6 @@ double IterativePosPIDController::step(const double inewReading) {
 
       settledUtil->isSettled(error);
     }
-  } else {
-    return 0;
   }
 
   return output;
@@ -179,16 +179,16 @@ void IterativePosPIDController::setIntegratorReset(bool iresetOnZero) {
 }
 
 void IterativePosPIDController::flipDisable() {
-  isOn = !isOn;
+  flipDisable(!controllerIsDisabled);
 }
 
 void IterativePosPIDController::flipDisable(const bool iisDisabled) {
   logger->info("IterativePosPIDController: flipDisable " + std::to_string(iisDisabled));
-  isOn = !iisDisabled;
+  controllerIsDisabled = iisDisabled;
 }
 
 bool IterativePosPIDController::isDisabled() const {
-  return !isOn;
+  return controllerIsDisabled;
 }
 
 QTime IterativePosPIDController::getSampleTime() const {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -67,7 +67,7 @@ double IterativeVelPIDController::step(const double inewReading) {
     stepVel(inewReading);
   }
 
-  if (isOn) {
+  if (!controllerIsDisabled) {
     loopDtTimer->placeHardMark();
 
     if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
@@ -134,16 +134,16 @@ void IterativeVelPIDController::reset() {
 }
 
 void IterativeVelPIDController::flipDisable() {
-  isOn = !isOn;
+  flipDisable(!controllerIsDisabled);
 }
 
 void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
   logger->info("IterativeVelPIDController: flipDisable " + std::to_string(iisDisabled));
-  isOn = !iisDisabled;
+  controllerIsDisabled = iisDisabled;
 }
 
 bool IterativeVelPIDController::isDisabled() const {
-  return !isOn;
+  return controllerIsDisabled;
 }
 
 void IterativeVelPIDController::setTicksPerRev(const double tpr) {


### PR DESCRIPTION
### Description of the Change

`flipDisable()` should always produce a log statement like how `flipDisable(bool)` functions. We can use this issue to also refactor `isOn` to `controllerIsDisabled` for `IterativePosPIDController` and `IterativeVelPIDController` since the old logic is now confusing.

### Benefits

Clearer log files and clearer logic.

### Possible Drawbacks

Originally I had the no-arg version of `flipDisable()` not log because it is more likely to be called by users and I want to keep OkapiLib's logs separated. We really should just log both calls even if it makes the log file a bit messier.

### Verification Process

Tests still pass :)

### Applicable Issues

Closes #227.
