### PR TITLE
Override setMaxVelocity in ChassisControllerIntegrated

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -251,14 +251,14 @@ class ChassisController : public ChassisModel {
                      double iloopSpeed) const override;
 
   /**
-   * Sets a new maximum velocity.
+   * Sets a new maximum velocity in RPM [0-600].
    *
    * @param imaxVelocity the new maximum velocity
    */
   void setMaxVelocity(double imaxVelocity) override;
 
   /**
-   * Sets a new maximum voltage.
+   * Sets a new maximum voltage in mV [0-12000].
    *
    * @param imaxVoltage the new maximum voltage
    */

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -101,7 +101,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
   void stop() override;
 
   /**
-   * Sets a new maximum velocity.
+   * Sets a new maximum velocity in RPM [0-600].
    *
    * @param imaxVelocity the new maximum velocity
    */

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -101,6 +101,13 @@ class ChassisControllerIntegrated : public virtual ChassisController {
   void stop() override;
 
   /**
+   * Sets a new maximum velocity.
+   *
+   * @param imaxVelocity the new maximum velocity
+   */
+  void setMaxVelocity(double imaxVelocity) override;
+
+  /**
    * Get the ChassisScales.
    */
   ChassisScales getChassisScales() const override;

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -178,14 +178,14 @@ class ChassisModel : public ReadOnlyChassisModel {
                              double iloopSpeed) const = 0;
 
   /**
-   * Sets a new maximum velocity.
+   * Sets a new maximum velocity in RPM [0-600].
    *
    * @param imaxVelocity the new maximum velocity
    */
   virtual void setMaxVelocity(double imaxVelocity);
 
   /**
-   * Sets a new maximum voltage.
+   * Sets a new maximum voltage in mV [0-12000].
    *
    * @param imaxVoltage the new maximum voltage
    */

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -34,7 +34,7 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    * whatever units the motor is in.
    *
    * @param imotor the motor to control
-   * @param imaxVelocity the maximum velocity during a profiled movement
+   * @param imaxVelocity the maximum velocity during a profiled movement in RPM [0-600].
    */
   AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
                                std::int32_t imaxVelocity,
@@ -107,6 +107,13 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    * @param ivalue the controller's output in the range [-1, 1]
    */
   void controllerSet(double ivalue) override;
+
+  /**
+   * Sets a new maximum velocity in RPM [0-600].
+   *
+   * @param imaxVelocity the new maximum velocity
+   */
+  virtual void setMaxVelocity(std::int32_t imaxVelocity);
 
   protected:
   Logger *logger;

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -255,6 +255,7 @@ class MockAsyncPosIntegratedController : public AsyncPosIntegratedController {
   bool isSettled() override;
 
   bool isSettledOverride{true};
+  using AsyncPosIntegratedController::maxVelocity;
 };
 
 class MockAsyncVelIntegratedController : public AsyncVelIntegratedController {

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -144,9 +144,9 @@ class MockMotor : public AbstractMotor {
   mutable std::int16_t lastVoltage{0};
   mutable std::int16_t lastPosition{0};
   mutable std::int32_t lastProfiledMaxVelocity{0};
-  AbstractMotor::gearset gearset;
-  AbstractMotor::encoderUnits encoderUnits;
-  AbstractMotor::brakeMode brakeMode;
+  AbstractMotor::gearset gearset{AbstractMotor::gearset::green};
+  AbstractMotor::encoderUnits encoderUnits{AbstractMotor::encoderUnits::counts};
+  AbstractMotor::brakeMode brakeMode{AbstractMotor::brakeMode::coast};
 };
 
 /**

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -123,6 +123,12 @@ void ChassisControllerIntegrated::stop() {
   ChassisController::stop();
 }
 
+void ChassisControllerIntegrated::setMaxVelocity(const double imaxVelocity) {
+  leftController->setMaxVelocity(imaxVelocity);
+  rightController->setMaxVelocity(imaxVelocity);
+  ChassisController::setMaxVelocity(imaxVelocity);
+}
+
 ChassisScales ChassisControllerIntegrated::getChassisScales() const {
   return scales;
 }

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -235,7 +235,8 @@ void AsyncLinearMotionProfileController::flipDisable() {
   flipDisable(!disabled);
 }
 
-void AsyncLinearMotionProfileController::flipDisable(bool iisDisabled) {
+void AsyncLinearMotionProfileController::flipDisable(const bool iisDisabled) {
+  logger->info("AsyncMotionProfileController: flipDisable " + std::to_string(iisDisabled));
   disabled = iisDisabled;
 }
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -246,7 +246,8 @@ void AsyncMotionProfileController::flipDisable() {
   flipDisable(!disabled);
 }
 
-void AsyncMotionProfileController::flipDisable(bool iisDisabled) {
+void AsyncMotionProfileController::flipDisable(const bool iisDisabled) {
+  logger->info("AsyncMotionProfileController: flipDisable " + std::to_string(iisDisabled));
   disabled = iisDisabled;
 }
 

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -11,7 +11,7 @@
 namespace okapi {
 AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
                                                            const TimeUtil &itimeUtil)
-  : AsyncPosIntegratedController(imotor, 600, itimeUtil) {
+  : AsyncPosIntegratedController(imotor, toUnderlyingType(imotor->getGearing()), itimeUtil) {
 }
 
 AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
@@ -97,5 +97,9 @@ void AsyncPosIntegratedController::controllerSet(double ivalue) {
   }
 
   lastTarget = ivalue * toUnderlyingType(motor->getGearing());
+}
+
+void AsyncPosIntegratedController::setMaxVelocity(const std::int32_t imaxVelocity) {
+  maxVelocity = imaxVelocity;
 }
 } // namespace okapi

--- a/test/asyncPosIntegratedControllerTests.cpp
+++ b/test/asyncPosIntegratedControllerTests.cpp
@@ -56,19 +56,25 @@ TEST_F(AsyncPosIntegratedControllerTest, ControllerSetScalesTarget) {
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForRedGearset) {
+  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::red);
-  controller->setTarget(5);
-  EXPECT_GE(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::red));
+  AsyncPosIntegratedController controller(motor, createTimeUtil());
+  controller.setTarget(5);
+  EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::red));
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForBlueGearset) {
+  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::blue);
-  controller->setTarget(5);
-  EXPECT_GE(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::blue));
+  AsyncPosIntegratedController controller(motor, createTimeUtil());
+  controller.setTarget(5);
+  EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::blue));
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForGreenGearset) {
+  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::green);
-  controller->setTarget(5);
-  EXPECT_GE(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::green));
+  AsyncPosIntegratedController controller(motor, createTimeUtil());
+  controller.setTarget(5);
+  EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::green));
 }

--- a/test/asyncPosIntegratedControllerTests.cpp
+++ b/test/asyncPosIntegratedControllerTests.cpp
@@ -15,16 +15,15 @@ using namespace okapi;
 class AsyncPosIntegratedControllerTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    motor = new MockMotor();
-    controller =
-      new AsyncPosIntegratedController(std::shared_ptr<MockMotor>(motor), createTimeUtil());
+    motor = std::make_shared<MockMotor>();
+    controller = new AsyncPosIntegratedController(motor, createTimeUtil());
   }
 
   void TearDown() override {
     delete controller;
   }
 
-  MockMotor *motor;
+  std::shared_ptr<MockMotor> motor;
   AsyncPosIntegratedController *controller;
 };
 

--- a/test/asyncVelIntegratedControllerTests.cpp
+++ b/test/asyncVelIntegratedControllerTests.cpp
@@ -16,16 +16,15 @@ using namespace okapi;
 class AsyncVelIntegratedControllerTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    motor = new MockMotor();
-    controller =
-      new AsyncVelIntegratedController(std::shared_ptr<MockMotor>(motor), createTimeUtil());
+    motor = std::make_shared<MockMotor>();
+    controller = new AsyncVelIntegratedController(motor, createTimeUtil());
   }
 
   void TearDown() override {
     delete controller;
   }
 
-  MockMotor *motor;
+  std::shared_ptr<MockMotor> motor;
   AsyncVelIntegratedController *controller;
 };
 

--- a/test/chassisControllerIntegratedTests.cpp
+++ b/test/chassisControllerIntegratedTests.cpp
@@ -12,6 +12,12 @@
 
 using namespace okapi;
 
+class MockSkidSteerModel : public SkidSteerModel {
+  public:
+  using SkidSteerModel::maxVelocity;
+  using SkidSteerModel::SkidSteerModel;
+};
+
 class ChassisControllerIntegratedTest : public ::testing::Test {
   protected:
   void SetUp() override {
@@ -22,7 +28,7 @@ class ChassisControllerIntegratedTest : public ::testing::Test {
     leftController = new MockAsyncPosIntegratedController();
     rightController = new MockAsyncPosIntegratedController();
 
-    model = new SkidSteerModel(
+    model = new MockSkidSteerModel(
       std::unique_ptr<AbstractMotor>(leftMotor), std::unique_ptr<AbstractMotor>(rightMotor), 100);
 
     controller = new ChassisControllerIntegrated(
@@ -45,7 +51,7 @@ class ChassisControllerIntegratedTest : public ::testing::Test {
   MockMotor *rightMotor;
   MockAsyncPosIntegratedController *leftController;
   MockAsyncPosIntegratedController *rightController;
-  SkidSteerModel *model;
+  MockSkidSteerModel *model;
 };
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceRawUnitsTest) {
@@ -279,4 +285,11 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleAndStopTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
   EXPECT_TRUE(leftController->isDisabled());
   EXPECT_TRUE(rightController->isDisabled());
+}
+
+TEST_F(ChassisControllerIntegratedTest, SetMaxVelocityTest) {
+  controller->setMaxVelocity(42);
+  EXPECT_EQ(leftController->maxVelocity, 42);
+  EXPECT_EQ(rightController->maxVelocity, 42);
+  EXPECT_EQ(model->maxVelocity, 42);
 }

--- a/test/chassisControllerPidTest.cpp
+++ b/test/chassisControllerPidTest.cpp
@@ -12,6 +12,12 @@
 
 using namespace okapi;
 
+class MockSkidSteerModel : public SkidSteerModel {
+  public:
+  using SkidSteerModel::maxVelocity;
+  using SkidSteerModel::SkidSteerModel;
+};
+
 class ChassisControllerPIDTest : public ::testing::Test {
   protected:
   void SetUp() override {
@@ -23,7 +29,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
     angleController = new MockIterativeController(0.1);
     turnController = new MockIterativeController(0.1);
 
-    model = new SkidSteerModel(
+    model = new MockSkidSteerModel(
       std::unique_ptr<AbstractMotor>(leftMotor), std::unique_ptr<AbstractMotor>(rightMotor), 100);
 
     controller =
@@ -49,7 +55,7 @@ class ChassisControllerPIDTest : public ::testing::Test {
   MockIterativeController *distanceController;
   MockIterativeController *angleController;
   MockIterativeController *turnController;
-  SkidSteerModel *model;
+  MockSkidSteerModel *model;
 };
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceRawUnitsTest) {
@@ -303,4 +309,9 @@ TEST_F(ChassisControllerPIDTest, WaitUntilSettledInModeNone) {
   EXPECT_TRUE(turnController->isDisabled());
   EXPECT_TRUE(distanceController->isDisabled());
   EXPECT_TRUE(angleController->isDisabled());
+}
+
+TEST_F(ChassisControllerPIDTest, SetMaxVelocityTest) {
+  controller->setMaxVelocity(42);
+  EXPECT_EQ(model->maxVelocity, 42);
 }

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -188,7 +188,7 @@ MockMotor::setVelPIDFull(double, double, double, double, double, double, double,
 }
 
 AbstractMotor::brakeMode MockMotor::getBrakeMode() const {
-  return brakeMode::coast;
+  return brakeMode;
 }
 
 int32_t MockMotor::getCurrentLimit() const {
@@ -196,11 +196,11 @@ int32_t MockMotor::getCurrentLimit() const {
 }
 
 AbstractMotor::encoderUnits MockMotor::getEncoderUnits() const {
-  return encoderUnits::degrees;
+  return encoderUnits;
 }
 
 AbstractMotor::gearset MockMotor::getGearing() const {
-  return gearset::red;
+  return gearset;
 }
 
 MockTimer::MockTimer() : AbstractTimer(millis()) {


### PR DESCRIPTION
### Description of the Change

This PR has `ChassisControllerIntegrated` override `setMaxVelocity()` so it can also set the max velocity of its two `AsyncPosIntegratedController` instances. This PR also fixes `AsyncPosIntegratedController::AsyncPosIntegratedController()` so it obeys its ctor doc and infers max velocity from the supplied motor's gearset.

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

Some new tests were added.

### Applicable Issues

Closes #225.
