### PR TITLE
Make each ButtonBase method track its state separately

### DIFF
--- a/include/okapi/api/device/button/buttonBase.hpp
+++ b/include/okapi/api/device/button/buttonBase.hpp
@@ -6,7 +6,7 @@
 namespace okapi {
 class ButtonBase : public AbstractButton {
   public:
-  explicit ButtonBase(bool iinverted = false);
+  explicit ButtonBase();
 
   /**
    * Return whether the button is currently pressed.
@@ -14,28 +14,31 @@ class ButtonBase : public AbstractButton {
   bool isPressed() override;
 
   /**
-   * Return whether the state of the button changed since the last time this method was
-   * called.
+   * Return whether the state of the button changed since the last time this method was called.
    **/
   bool changed() override;
 
   /**
-   * Return whether the state of the button changed to being pressed since the last time this method
-   * was called.
+   * Return whether the state of the button changed to pressed since the last time this method was
+   *called.
    **/
   bool changedToPressed() override;
 
   /**
-   * Return whether the state of the button to being not pressed changed since the last time this
-   * method was called.
+   * Return whether the state of the button to not pressed since the last time this method was
+   *called.
    **/
   bool changedToReleased() override;
 
   protected:
-  const bool inverted;
-  bool wasPressedLast = false;
+  bool wasPressedLast_c{false};
+  bool wasPressedLast_ctp{false};
+  bool wasPressedLast_ctr{false};
 
   virtual bool currentlyPressed() = 0;
+
+  private:
+  bool changedImpl(bool &prevState);
 };
 } // namespace okapi
 

--- a/include/okapi/api/device/button/buttonBase.hpp
+++ b/include/okapi/api/device/button/buttonBase.hpp
@@ -6,7 +6,7 @@
 namespace okapi {
 class ButtonBase : public AbstractButton {
   public:
-  explicit ButtonBase();
+  explicit ButtonBase(bool iinverted = false);
 
   /**
    * Return whether the button is currently pressed.
@@ -31,6 +31,7 @@ class ButtonBase : public AbstractButton {
   bool changedToReleased() override;
 
   protected:
+  bool inverted{false};
   bool wasPressedLast_c{false};
   bool wasPressedLast_ctp{false};
   bool wasPressedLast_ctr{false};

--- a/src/api/device/button/buttonBase.cpp
+++ b/src/api/device/button/buttonBase.cpp
@@ -1,26 +1,28 @@
 #include "okapi/api/device/button/buttonBase.hpp"
 
 namespace okapi {
-ButtonBase::ButtonBase(const bool iinverted) : inverted(iinverted) {
-}
+ButtonBase::ButtonBase() = default;
 
 bool ButtonBase::isPressed() {
-  wasPressedLast = currentlyPressed();
-  return wasPressedLast;
+  return currentlyPressed();
 }
 
 bool ButtonBase::changed() {
-  const bool pressed = currentlyPressed();
-  const bool out = pressed ^ wasPressedLast;
-  wasPressedLast = pressed;
-  return out;
+  return changedImpl(wasPressedLast_c);
 }
 
 bool ButtonBase::changedToPressed() {
-  return changed() && wasPressedLast;
+  return changedImpl(wasPressedLast_ctp) && wasPressedLast_ctp;
 }
 
 bool ButtonBase::changedToReleased() {
-  return changed() && !wasPressedLast;
+  return changedImpl(wasPressedLast_ctr) && !wasPressedLast_ctr;
+}
+
+bool ButtonBase::changedImpl(bool &prevState) {
+  const bool pressed = currentlyPressed();
+  const bool out = pressed ^ prevState;
+  prevState = pressed;
+  return out;
 }
 } // namespace okapi

--- a/src/api/device/button/buttonBase.cpp
+++ b/src/api/device/button/buttonBase.cpp
@@ -1,7 +1,8 @@
 #include "okapi/api/device/button/buttonBase.hpp"
 
 namespace okapi {
-ButtonBase::ButtonBase() = default;
+ButtonBase::ButtonBase(const bool iinverted) : inverted(iinverted) {
+}
 
 bool ButtonBase::isPressed() {
   return currentlyPressed();

--- a/test/buttonTests.cpp
+++ b/test/buttonTests.cpp
@@ -20,7 +20,7 @@ class MockButton : public ButtonBase {
   }
 
   bool currentlyPressed() override {
-    return returnVals.at(index++);
+    return returnVals.at(index);
   }
 
   std::vector<bool> returnVals{};
@@ -31,7 +31,9 @@ TEST(ButtonBaseTest, IsPressedShouldMirrorCurrentlyPressed) {
   MockButton btn({false, true, false});
 
   EXPECT_FALSE(btn.isPressed());
+  btn.index++;
   EXPECT_TRUE(btn.isPressed());
+  btn.index++;
   EXPECT_FALSE(btn.isPressed());
 }
 
@@ -42,24 +44,63 @@ class ButtonBaseChangeTest : public ::testing::Test {
 
 TEST_F(ButtonBaseChangeTest, ChangeShouldDetectBothEdges) {
   EXPECT_FALSE(btn.changed());
+  btn.index++;
   EXPECT_TRUE(btn.changed());
+  btn.index++;
   EXPECT_FALSE(btn.changed());
+  btn.index++;
   EXPECT_TRUE(btn.changed());
+  btn.index++;
   EXPECT_FALSE(btn.changed());
 }
 
 TEST_F(ButtonBaseChangeTest, ChangedToPressedShouldDetectRisingEdges) {
   EXPECT_FALSE(btn.changedToPressed());
+  btn.index++;
   EXPECT_TRUE(btn.changedToPressed());
+  btn.index++;
   EXPECT_FALSE(btn.changedToPressed());
+  btn.index++;
   EXPECT_FALSE(btn.changedToPressed());
+  btn.index++;
   EXPECT_FALSE(btn.changedToPressed());
 }
 
 TEST_F(ButtonBaseChangeTest, ChangedToReleasedShouldDetectFallingEdges) {
   EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
   EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
   EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
   EXPECT_TRUE(btn.changedToReleased());
+  btn.index++;
+  EXPECT_FALSE(btn.changedToReleased());
+}
+
+TEST_F(ButtonBaseChangeTest, CallAllMethodsTogether) {
+  EXPECT_FALSE(btn.isPressed());
+  EXPECT_FALSE(btn.changed());
+  EXPECT_FALSE(btn.changedToPressed());
+  EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
+  EXPECT_TRUE(btn.isPressed());
+  EXPECT_TRUE(btn.changed());
+  EXPECT_TRUE(btn.changedToPressed());
+  EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
+  EXPECT_TRUE(btn.isPressed());
+  EXPECT_FALSE(btn.changed());
+  EXPECT_FALSE(btn.changedToPressed());
+  EXPECT_FALSE(btn.changedToReleased());
+  btn.index++;
+  EXPECT_FALSE(btn.isPressed());
+  EXPECT_TRUE(btn.changed());
+  EXPECT_FALSE(btn.changedToPressed());
+  EXPECT_TRUE(btn.changedToReleased());
+  btn.index++;
+  EXPECT_FALSE(btn.isPressed());
+  EXPECT_FALSE(btn.changed());
+  EXPECT_FALSE(btn.changedToPressed());
   EXPECT_FALSE(btn.changedToReleased());
 }


### PR DESCRIPTION
### Description of the Change

This PR makes each method of `ButtonBase` track its state (`wasPressedLast`) separately so they can be checked in the same loop iteration. The following code passes with a press order `false, true, true, false, false`:
```
TEST_F(ButtonBaseChangeTest, CallAllMethodsTogether) {
  EXPECT_FALSE(btn.isPressed());
  EXPECT_FALSE(btn.changed());
  EXPECT_FALSE(btn.changedToPressed());
  EXPECT_FALSE(btn.changedToReleased());
  btn.index++;
  EXPECT_TRUE(btn.isPressed());
  EXPECT_TRUE(btn.changed());
  EXPECT_TRUE(btn.changedToPressed());
  EXPECT_FALSE(btn.changedToReleased());
  btn.index++;
  EXPECT_TRUE(btn.isPressed());
  EXPECT_FALSE(btn.changed());
  EXPECT_FALSE(btn.changedToPressed());
  EXPECT_FALSE(btn.changedToReleased());
  btn.index++;
  EXPECT_FALSE(btn.isPressed());
  EXPECT_TRUE(btn.changed());
  EXPECT_FALSE(btn.changedToPressed());
  EXPECT_TRUE(btn.changedToReleased());
  btn.index++;
  EXPECT_FALSE(btn.isPressed());
  EXPECT_FALSE(btn.changed());
  EXPECT_FALSE(btn.changedToPressed());
  EXPECT_FALSE(btn.changedToReleased());
}
```

### Benefits

This implementation is more intuitive and is closer to what the docs say.

### Possible Drawbacks

None.

### Verification Process

New tests were added.

### Applicable Issues

Closes #235.
