### PR TITLE
Take another pass at using std::atomic types

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -131,8 +131,8 @@ class ChassisControllerPID : public virtual ChassisController {
   std::unique_ptr<IterativePosPIDController> turnPid;
   ChassisScales scales;
   AbstractMotor::GearsetRatioPair gearsetRatioPair;
-  bool doneLooping{true};
-  bool newMovement{false};
+  std::atomic_bool doneLooping{true};
+  std::atomic_bool newMovement{false};
   std::atomic_bool dtorCalled{false};
 
   static void trampoline(void *context);

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -181,8 +181,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   TimeUtil timeUtil;
 
   std::string currentPath{""};
-  bool isRunning{false};
-  bool disabled{false};
+  std::atomic_bool isRunning{false};
+  std::atomic_bool disabled{false};
   std::atomic_bool dtorCalled{false};
   CrossplatformThread *task{nullptr};
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -178,8 +178,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   TimeUtil timeUtil;
 
   std::string currentPath{""};
-  bool isRunning{false};
-  bool disabled{false};
+  std::atomic_bool isRunning{false};
+  std::atomic_bool disabled{false};
   std::atomic_bool dtorCalled{false};
   CrossplatformThread *task{nullptr};
 

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -54,7 +54,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       controller(std::move(other.controller)),
       loopRate(std::move(other.loopRate)),
       settledRate(std::move(other.settledRate)),
-      dtorCalled(other.dtorCalled.load(std::memory_order_release)),
+      dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
       task(other.task) {
   }
 

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -54,12 +54,12 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       controller(std::move(other.controller)),
       loopRate(std::move(other.loopRate)),
       settledRate(std::move(other.settledRate)),
-      dtorCalled(other.dtorCalled.load(std::memory_order::memory_order_relaxed)),
+      dtorCalled(other.dtorCalled.load(std::memory_order_release)),
       task(other.task) {
   }
 
   ~AsyncWrapper() override {
-    dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+    dtorCalled.store(true, std::memory_order_release);
     delete task;
   }
 
@@ -239,7 +239,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   void loop() {
-    while (!dtorCalled.load(std::memory_order::memory_order_relaxed)) {
+    while (!dtorCalled.load(std::memory_order_acquire)) {
       if (!isDisabled()) {
         output->controllerSet(controller->step(input->controllerGet()));
       }

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -45,8 +45,8 @@ ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcep
     turnPid(std::move(other.turnPid)),
     scales(other.scales),
     gearsetRatioPair(other.gearsetRatioPair),
-    doneLooping(other.doneLooping),
-    newMovement(other.newMovement),
+    doneLooping(other.doneLooping.load(std::memory_order_acquire)),
+    newMovement(other.newMovement.load(std::memory_order_acquire)),
     dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
     mode(other.mode),
     task(other.task) {
@@ -69,10 +69,10 @@ void ChassisControllerPID::loop() {
      * doneLooping is set to false by moveDistanceAsync and turnAngleAsync and then set to true by
      * waitUntilSettled
      */
-    if (!doneLooping) {
-      if (mode != pastMode || newMovement) {
+    if (!doneLooping.load(std::memory_order_acquire)) {
+      if (mode != pastMode || newMovement.load(std::memory_order_acquire)) {
         encStartVals = model->getSensorVals();
-        newMovement = false;
+        newMovement.store(false, std::memory_order_release);
       }
 
       switch (mode) {
@@ -124,8 +124,8 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   distancePid->setTarget(newTarget);
   anglePid->setTarget(0);
 
-  doneLooping = false;
-  newMovement = true;
+  doneLooping.store(false, std::memory_order_release);
+  newMovement.store(true, std::memory_order_release);
 }
 
 void ChassisControllerPID::moveDistanceAsync(const double itarget) {
@@ -159,8 +159,8 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
 
   turnPid->setTarget(newTarget);
 
-  doneLooping = false;
-  newMovement = true;
+  doneLooping.store(false, std::memory_order_release);
+  newMovement.store(true, std::memory_order_release);
 }
 
 void ChassisControllerPID::turnAngleAsync(const double idegTarget) {
@@ -200,7 +200,7 @@ void ChassisControllerPID::waitUntilSettled() {
 
   stopAfterSettled();
   mode = none;
-  doneLooping = true;
+  doneLooping.store(true, std::memory_order_release);
   logger->info("ChassisControllerPID: Done waiting to settle");
 }
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -47,14 +47,14 @@ ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcep
     gearsetRatioPair(other.gearsetRatioPair),
     doneLooping(other.doneLooping),
     newMovement(other.newMovement),
-    dtorCalled(other.dtorCalled.load(std::memory_order::memory_order_relaxed)),
+    dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
     mode(other.mode),
     task(other.task) {
   other.task = nullptr;
 }
 
 ChassisControllerPID::~ChassisControllerPID() {
-  dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+  dtorCalled.store(true, std::memory_order_release);
   delete task;
 }
 
@@ -64,7 +64,7 @@ void ChassisControllerPID::loop() {
   double distanceElapsed = 0, angleChange = 0;
   modeType pastMode = none;
 
-  while (!dtorCalled.load(std::memory_order::memory_order_relaxed)) {
+  while (!dtorCalled.load(std::memory_order_acquire)) {
     /**
      * doneLooping is set to false by moveDistanceAsync and turnAngleAsync and then set to true by
      * waitUntilSettled

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -43,12 +43,12 @@ AsyncMotionProfileController::AsyncMotionProfileController(
     currentPath(std::move(other.currentPath)),
     isRunning(other.isRunning),
     disabled(other.disabled),
-    dtorCalled(other.dtorCalled.load(std::memory_order::memory_order_relaxed)),
+    dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
     task(other.task) {
 }
 
 AsyncMotionProfileController::~AsyncMotionProfileController() {
-  dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+  dtorCalled.store(true, std::memory_order_release);
 
   for (auto &path : paths) {
     free(path.second.left);
@@ -171,7 +171,7 @@ std::string AsyncMotionProfileController::getTarget() {
 void AsyncMotionProfileController::loop() {
   auto rate = timeUtil.getRate();
 
-  while (!dtorCalled.load(std::memory_order::memory_order_relaxed)) {
+  while (!dtorCalled.load(std::memory_order_acquire)) {
     if (isRunning && !isDisabled()) {
       logger->info("AsyncMotionProfileController: Running with path: " + currentPath);
       auto path = paths.find(currentPath);

--- a/test/asyncPosIntegratedControllerTests.cpp
+++ b/test/asyncPosIntegratedControllerTests.cpp
@@ -55,25 +55,22 @@ TEST_F(AsyncPosIntegratedControllerTest, ControllerSetScalesTarget) {
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForRedGearset) {
-  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::red);
-  AsyncPosIntegratedController controller(motor, createTimeUtil());
-  controller.setTarget(5);
+  AsyncPosIntegratedController newController(motor, createTimeUtil());
+  newController.setTarget(5);
   EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::red));
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForBlueGearset) {
-  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::blue);
-  AsyncPosIntegratedController controller(motor, createTimeUtil());
-  controller.setTarget(5);
+  AsyncPosIntegratedController newController(motor, createTimeUtil());
+  newController.setTarget(5);
   EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::blue));
 }
 
 TEST_F(AsyncPosIntegratedControllerTest, ProfiledMovementUsesMaxVelocityForGreenGearset) {
-  auto motor = std::make_shared<MockMotor>();
   motor->setGearing(AbstractMotor::gearset::green);
-  AsyncPosIntegratedController controller(motor, createTimeUtil());
-  controller.setTarget(5);
+  AsyncPosIntegratedController newController(motor, createTimeUtil());
+  newController.setTarget(5);
   EXPECT_EQ(motor->lastProfiledMaxVelocity, toUnderlyingType(AbstractMotor::gearset::green));
 }

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -324,7 +324,7 @@ SimulatedSystem::SimulatedSystem(FlywheelSimulator &isimulator) : simulator(isim
 }
 
 SimulatedSystem::~SimulatedSystem() {
-  dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+  dtorCalled.store(true, std::memory_order_release);
 }
 
 double SimulatedSystem::controllerGet() {
@@ -336,7 +336,7 @@ void SimulatedSystem::controllerSet(double ivalue) {
 }
 
 void SimulatedSystem::step() {
-  while (!dtorCalled.load(std::memory_order::memory_order_relaxed)) {
+  while (!dtorCalled.load(std::memory_order_acquire)) {
     simulator.step();
     rate.delayUntil(10_ms);
   }
@@ -353,7 +353,7 @@ void SimulatedSystem::startThread() {
 }
 
 void SimulatedSystem::join() {
-  dtorCalled.store(true, std::memory_order::memory_order_relaxed);
+  dtorCalled.store(true, std::memory_order_release);
   thread.join();
 }
 


### PR DESCRIPTION
### Description of the Change

This PR uses `std::atomic` types in the remaining places where member variables are used for inter-thread communication.

### Benefits

Better code correctness and less likelihood of a rogue optimization breaking something.

### Possible Drawbacks

None.

### Verification Process

The tests still pass and I ran a few things by hand.

### Applicable Issues

Closes #233.
