### PR TITLE
Fix motion profile controllers sometimes segfaulting

### DIFF
--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -106,6 +106,22 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<doub
 
   auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
 
+  if (trajectory == nullptr) {
+    std::string message = "AsyncLinearMotionProfileController: Could not allocate trajectory. The "
+                          "path is probably impossible.";
+    logger->error(message);
+
+    if (candidate.laptr) {
+      free(candidate.laptr);
+    }
+
+    if (candidate.saptr) {
+      free(candidate.saptr);
+    }
+
+    throw std::runtime_error(message);
+  }
+
   logger->info("AsyncLinearMotionProfileController: Generating path");
   pathfinder_generate(&candidate, trajectory);
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -116,11 +116,47 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
 
   auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
 
+  if (trajectory == nullptr) {
+    std::string message = "AsyncMotionProfileController: Could not allocate trajectory. The path "
+                          "is probably impossible.";
+    logger->error(message);
+
+    if (candidate.laptr) {
+      free(candidate.laptr);
+    }
+
+    if (candidate.saptr) {
+      free(candidate.saptr);
+    }
+
+    throw std::runtime_error(message);
+  }
+
   logger->info("AsyncMotionProfileController: Generating path");
   pathfinder_generate(&candidate, trajectory);
 
   auto *leftTrajectory = (Segment *)malloc(sizeof(Segment) * length);
   auto *rightTrajectory = (Segment *)malloc(sizeof(Segment) * length);
+
+  if (leftTrajectory == nullptr || rightTrajectory == nullptr) {
+    std::string message = "AsyncMotionProfileController: Could not allocate left and/or right "
+                          "trajectories. The path is probably impossible.";
+    logger->error(message);
+
+    if (leftTrajectory) {
+      free(leftTrajectory);
+    }
+
+    if (rightTrajectory) {
+      free(rightTrajectory);
+    }
+
+    if (trajectory) {
+      free(trajectory);
+    }
+
+    throw std::runtime_error(message);
+  }
 
   logger->info("AsyncMotionProfileController: Modifying for tank drive");
   pathfinder_modify_tank(


### PR DESCRIPTION
### Description of the Change

This PR fixes `AsyncMotionProfileController` and `AsyncLinearMotionProfileController` segfaulting if the path requested was impossible, but not "impossible enough" to get caught by the existing error check. The fix is to check every result from a malloc and throw if it is null. We probably requested too much memory because the path is very large (but not large enough to get caught by the existing error check).

### Benefits

Bug fix :)

### Possible Drawbacks

None.

### Verification Process

This is hard to test without the uC. I have done testing by hand with various paths.

### Applicable Issues

Closes #240.
