### PR TITLE
AsyncMotionProfileController does not account for external ratio

### DIFF
--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -34,7 +34,8 @@ struct Point {
 class AsyncMotionProfileController : public AsyncPositionController<std::string, Point> {
   public:
   /**
-   * An Async Controller which generates and follows 2D motion profiles.
+   * An Async Controller which generates and follows 2D motion profiles. Throws a
+   * std::invalid_argument exception if the gear ratio is zero.
    *
    * @param imaxVel The maximum possible velocity in m/s.
    * @param imaxAccel The maximum possible acceleration in m/s/s.

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -12,7 +12,9 @@
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/control/async/asyncPositionController.hpp"
 #include "okapi/api/units/QAngle.hpp"
+#include "okapi/api/units/QAngularSpeed.hpp"
 #include "okapi/api/units/QLength.hpp"
+#include "okapi/api/units/QSpeed.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <atomic>
@@ -190,6 +192,14 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * Follow the supplied path. Must follow the disabled lifecycle.
    */
   virtual void executeSinglePath(const TrajectoryPair &path, std::unique_ptr<AbstractRate> rate);
+
+  /**
+   * Converts linear chassis speed to rotational motor speed.
+   *
+   * @param linear chassis frame speed
+   * @return motor frame speed
+   */
+  QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 };
 } // namespace okapi
 

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -40,7 +40,19 @@ class AbstractMotor : public ControllerOutput<double> {
     invalid = INT32_MAX
   };
 
+  /**
+   * A simple structure representing the full ratio between motor and wheel.
+   */
   struct GearsetRatioPair {
+    /**
+     * A simple structure representing the full ratio between motor and wheel.
+     *
+     * The ratio is motor rotation : wheel rotation. So for example, if one motor rotation
+     * corresponds to two wheel rotations, the ratio is 1/2.
+     *
+     * @param igearset the motor's gearset
+     * @param iratio the ratio of motor rotation to wheel rotation
+     */
     GearsetRatioPair(const gearset igearset, const double iratio = 1)
       : internalGearset(igearset), ratio(iratio) {
     }

--- a/include/okapi/api/device/motor/abstractMotor.hpp
+++ b/include/okapi/api/device/motor/abstractMotor.hpp
@@ -48,7 +48,7 @@ class AbstractMotor : public ControllerOutput<double> {
      * A simple structure representing the full ratio between motor and wheel.
      *
      * The ratio is motor rotation : wheel rotation. So for example, if one motor rotation
-     * corresponds to two wheel rotations, the ratio is 1/2.
+     * corresponds to two wheel rotations, the ratio is 1.0/2.0.
      *
      * @param igearset the motor's gearset
      * @param iratio the ratio of motor rotation to wheel rotation

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -235,13 +235,16 @@ void AsyncMotionProfileController::loop() {
 
 void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
                                                      std::unique_ptr<AbstractRate> rate) {
+  // Converts linear chassis speed to rotational wheel speed
   const auto linearSpeedToRotationalSpeed = [&](QSpeed linearMps) -> QAngularSpeed {
     return linearMps * (360_deg / (scales.wheelDiameter * 1_pi));
   };
 
   for (int i = 0; i < path.length && !isDisabled(); ++i) {
-    const auto leftRPM = linearSpeedToRotationalSpeed(path.left[i].velocity * mps).convert(rpm);
-    const auto rightRPM = linearSpeedToRotationalSpeed(path.right[i].velocity * mps).convert(rpm);
+    const auto leftRPM =
+      linearSpeedToRotationalSpeed(path.left[i].velocity * mps).convert(rpm) * pair.ratio;
+    const auto rightRPM =
+      linearSpeedToRotationalSpeed(path.right[i].velocity * mps).convert(rpm) * pair.ratio;
 
     model->left(leftRPM / toUnderlyingType(pair.internalGearset));
     model->right(rightRPM / toUnderlyingType(pair.internalGearset));

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -14,6 +14,7 @@ using namespace okapi;
 class MockAsyncMotionProfileController : public AsyncMotionProfileController {
   public:
   using AsyncMotionProfileController::AsyncMotionProfileController;
+  using AsyncMotionProfileController::convertLinearToRotational;
 
   void executeSinglePath(const TrajectoryPair &path, std::unique_ptr<AbstractRate> rate) override {
     executeSinglePathCalled = true;
@@ -37,7 +38,7 @@ class AsyncMotionProfileControllerTest : public ::testing::Test {
                                                       10.0,
                                                       std::shared_ptr<SkidSteerModel>(model),
                                                       {4_in, 10.5_in},
-                                                      AbstractMotor::gearset::green);
+                                                      AbstractMotor::gearset::green * (1.0 / 2));
     controller->startThread();
   }
 
@@ -182,4 +183,9 @@ TEST_F(AsyncMotionProfileControllerTest, DisabledStopsMotors) {
   EXPECT_TRUE(controller->isSettled());
   EXPECT_EQ(leftMotor->lastVelocity, 0);
   EXPECT_EQ(rightMotor->lastVelocity, 0);
+}
+
+TEST_F(AsyncMotionProfileControllerTest, SpeedConversionTest) {
+  // 4 inch wheels, 2 wheel rotations per 1 motor rotation
+  EXPECT_NEAR(controller->convertLinearToRotational(1_mps).convert(rpm), 93.989, 0.001);
 }


### PR DESCRIPTION
### Description of the Change

`AsyncMotionProfileController` should factor in the external ratio from the `GearsetRatioPair`.

`leftRPM` and `rightRPM` in `AsyncMotionProfileController` are actually wheel RPM, not motor RPM. This PR uses the gear ratio to convert from wheel RPM to motor RPM. This PR also has `AsyncMotionProfileController` check if the gear ratio is got is zero, and throws a `std::invalid_argument` exception if that's the case.

### Benefits

More correct path following :)

### Possible Drawbacks

None.

### Verification Process

A test was added for the linear to rotational conversion.

### Applicable Issues

Closes #243.
