### PR TITLE
Issue #234: Pass shared_ptr by const ref

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -26,7 +26,7 @@ class ChassisController : public ChassisModel {
    *
    * @param imodel underlying ChassisModel
    */
-  explicit ChassisController(std::shared_ptr<ChassisModel> imodel,
+  explicit ChassisController(const std::shared_ptr<ChassisModel> &imodel,
                              double imaxVelocity,
                              double imaxVoltage = 12000);
 

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -28,7 +28,7 @@ class ChassisControllerIntegrated : public virtual ChassisController {
    */
   ChassisControllerIntegrated(
     const TimeUtil &itimeUtil,
-    std::shared_ptr<ChassisModel> imodel,
+    const std::shared_ptr<ChassisModel> &imodel,
     std::unique_ptr<AsyncPosIntegratedController> ileftController,
     std::unique_ptr<AsyncPosIntegratedController> irightController,
     AbstractMotor::GearsetRatioPair igearset = AbstractMotor::gearset::red,

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -30,7 +30,7 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param iscales see ChassisScales docs
    */
   ChassisControllerPID(const TimeUtil &itimeUtil,
-                       std::shared_ptr<ChassisModel> imodel,
+                       const std::shared_ptr<ChassisModel> &imodel,
                        std::unique_ptr<IterativePosPIDController> idistanceController,
                        std::unique_ptr<IterativePosPIDController> iangleController,
                        std::unique_ptr<IterativePosPIDController> iturnController,

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -25,8 +25,8 @@ class SkidSteerModel : public ChassisModel {
    * @param ileftSideMotor left side motor
    * @param irightSideMotor right side motor
    */
-  SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                 std::shared_ptr<AbstractMotor> irightSideMotor,
+  SkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+                 const std::shared_ptr<AbstractMotor> &irightSideMotor,
                  double imaxVelocity,
                  double imaxVoltage = 12000);
 
@@ -39,10 +39,10 @@ class SkidSteerModel : public ChassisModel {
    * @param ileftEnc  left side encoder
    * @param irightEnc right side encoder
    */
-  SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                 std::shared_ptr<AbstractMotor> irightSideMotor,
-                 std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-                 std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  SkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+                 const std::shared_ptr<AbstractMotor> &irightSideMotor,
+                 const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+                 const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
                  double imaxVelocity,
                  double imaxVoltage = 12000);
 

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -23,11 +23,11 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
    * @param imiddleEnc middle encoder (mounted perpendicular to the left and right side encoders)
    * @param irightEnc right side encoder
    */
-  ThreeEncoderSkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                             std::shared_ptr<AbstractMotor> irightSideMotor,
-                             std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-                             std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
-                             std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  ThreeEncoderSkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+                             const std::shared_ptr<AbstractMotor> &irightSideMotor,
+                             const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+                             const std::shared_ptr<ContinuousRotarySensor> &imiddleEnc,
+                             const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
                              double imaxVelocity,
                              double imaxVoltage = 12000);
 

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -27,10 +27,10 @@ class XDriveModel : public ChassisModel {
    * @param ibottomRightMotor bottom right motor
    * @param ibottomLeftMotor bottom left motor
    */
-  XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
-              std::shared_ptr<AbstractMotor> itopRightMotor,
-              std::shared_ptr<AbstractMotor> ibottomRightMotor,
-              std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+  XDriveModel(const std::shared_ptr<AbstractMotor> &itopLeftMotor,
+              const std::shared_ptr<AbstractMotor> &itopRightMotor,
+              const std::shared_ptr<AbstractMotor> &ibottomRightMotor,
+              const std::shared_ptr<AbstractMotor> &ibottomLeftMotor,
               double imaxVelocity,
               double imaxVoltage = 12000);
 
@@ -45,12 +45,12 @@ class XDriveModel : public ChassisModel {
    * @param ileftEnc Left side encoder
    * @param irightEnc Right side encoder
    */
-  XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
-              std::shared_ptr<AbstractMotor> itopRightMotor,
-              std::shared_ptr<AbstractMotor> ibottomRightMotor,
-              std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-              std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-              std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  XDriveModel(const std::shared_ptr<AbstractMotor> &itopLeftMotor,
+              const std::shared_ptr<AbstractMotor> &itopRightMotor,
+              const std::shared_ptr<AbstractMotor> &ibottomRightMotor,
+              const std::shared_ptr<AbstractMotor> &ibottomLeftMotor,
+              const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+              const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
               double imaxVelocity,
               double imaxVoltage = 12000);
 

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -36,7 +36,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
                                      double imaxVel,
                                      double imaxAccel,
                                      double imaxJerk,
-                                     std::shared_ptr<ControllerOutput<double>> ioutput);
+                                     const std::shared_ptr<ControllerOutput<double>> &ioutput);
 
   AsyncLinearMotionProfileController(AsyncLinearMotionProfileController &&other) noexcept;
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -47,7 +47,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
                                double imaxVel,
                                double imaxAccel,
                                double imaxJerk,
-                               std::shared_ptr<ChassisModel> imodel,
+                               const std::shared_ptr<ChassisModel> &imodel,
                                const ChassisScales &iscales,
                                AbstractMotor::GearsetRatioPair ipair);
 

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -27,7 +27,7 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    *
    * @param imotor the motor to control
    */
-  AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
+  AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor, const TimeUtil &itimeUtil);
 
   /**
    * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are
@@ -36,7 +36,7 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    * @param imotor the motor to control
    * @param imaxVelocity the maximum velocity during a profiled movement in RPM [0-600].
    */
-  AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+  AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
                                std::int32_t imaxVelocity,
                                const TimeUtil &itimeUtil);
 

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -27,7 +27,8 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    *
    * @param imotor the motor to control
    */
-  AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor, const TimeUtil &itimeUtil);
+  AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
+                               const TimeUtil &itimeUtil);
 
   /**
    * Closed-loop controller that uses the V5 motor's onboard control to move. Input units are

--- a/include/okapi/api/control/async/asyncPosPidController.hpp
+++ b/include/okapi/api/control/async/asyncPosPidController.hpp
@@ -21,8 +21,8 @@ class AsyncPosPIDController : public AsyncWrapper<double, double>,
                               public AsyncPositionController<double, double> {
   public:
   AsyncPosPIDController(
-    std::shared_ptr<ControllerInput<double>> iinput,
-    std::shared_ptr<ControllerOutput<double>> ioutput,
+    const std::shared_ptr<ControllerInput<double>> &iinput,
+    const std::shared_ptr<ControllerOutput<double>> &ioutput,
     const TimeUtil &itimeUtil,
     double ikP,
     double ikI,

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -21,7 +21,8 @@ namespace okapi {
  */
 class AsyncVelIntegratedController : public AsyncVelocityController<double, double> {
   public:
-  AsyncVelIntegratedController(const std::shared_ptr<AbstractMotor> &imotor, const TimeUtil &itimeUtil);
+  AsyncVelIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
+                               const TimeUtil &itimeUtil);
 
   /**
    * Sets the target for the controller.

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -21,7 +21,7 @@ namespace okapi {
  */
 class AsyncVelIntegratedController : public AsyncVelocityController<double, double> {
   public:
-  AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor, const TimeUtil &itimeUtil);
+  AsyncVelIntegratedController(const std::shared_ptr<AbstractMotor> &imotor, const TimeUtil &itimeUtil);
 
   /**
    * Sets the target for the controller.

--- a/include/okapi/api/control/async/asyncVelPidController.hpp
+++ b/include/okapi/api/control/async/asyncVelPidController.hpp
@@ -21,8 +21,8 @@ class AsyncVelPIDController : public AsyncWrapper<double, double>,
                               public AsyncVelocityController<double, double> {
   public:
   AsyncVelPIDController(
-    std::shared_ptr<ControllerInput<double>> iinput,
-    std::shared_ptr<ControllerOutput<double>> ioutput,
+    const std::shared_ptr<ControllerInput<double>> &iinput,
+    const std::shared_ptr<ControllerOutput<double>> &ioutput,
     const TimeUtil &itimeUtil,
     double ikP,
     double ikD,

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -35,8 +35,8 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * @param isettledUtil used in waitUntilSettled
    * @param iscale the scale applied to the controller output
    */
-  AsyncWrapper(std::shared_ptr<ControllerInput<Input>> iinput,
-               std::shared_ptr<ControllerOutput<Output>> ioutput,
+  AsyncWrapper(const std::shared_ptr<ControllerInput<Input>> &iinput,
+               const std::shared_ptr<ControllerOutput<Output>> &ioutput,
                std::unique_ptr<IterativeController<Input, Output>> icontroller,
                const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier)
     : logger(Logger::instance()),

--- a/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
+++ b/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
@@ -20,8 +20,8 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
    * Velocity controller that automatically writes to the motor.
    */
   IterativeMotorVelocityController(
-    std::shared_ptr<AbstractMotor> imotor,
-    std::shared_ptr<IterativeVelocityController<double, double>> icontroller);
+    const std::shared_ptr<AbstractMotor> &imotor,
+    const std::shared_ptr<IterativeVelocityController<double, double>> &icontroller);
 
   /**
    * Do one iteration of the controller.

--- a/include/okapi/api/control/util/pidTuner.hpp
+++ b/include/okapi/api/control/util/pidTuner.hpp
@@ -25,8 +25,8 @@ class PIDTuner {
     double kP, kI, kD;
   };
 
-  PIDTuner(std::shared_ptr<ControllerInput<double>> iinput,
-           std::shared_ptr<ControllerOutput<double>> ioutput,
+  PIDTuner(const std::shared_ptr<ControllerInput<double>> &iinput,
+           const std::shared_ptr<ControllerOutput<double>> &ioutput,
            const TimeUtil &itimeUtil,
            QTime itimeout,
            std::int32_t igoal,

--- a/include/okapi/api/filter/composableFilter.hpp
+++ b/include/okapi/api/filter/composableFilter.hpp
@@ -53,7 +53,7 @@ class ComposableFilter : public Filter {
    *
    * @param ifilter the filter to add
    */
-  virtual void addFilter(std::shared_ptr<Filter> ifilter);
+  virtual void addFilter(const std::shared_ptr<Filter> &ifilter);
 
   protected:
   std::vector<std::shared_ptr<Filter>> filters;

--- a/include/okapi/api/filter/velMath.hpp
+++ b/include/okapi/api/filter/velMath.hpp
@@ -20,7 +20,9 @@ namespace okapi {
 class VelMathArgs {
   public:
   explicit VelMathArgs(double iticksPerRev, QTime isampleTime = 0_ms);
-  VelMathArgs(double iticksPerRev, const std::shared_ptr<Filter> &ifilter, QTime isampleTime = 0_ms);
+  VelMathArgs(double iticksPerRev,
+              const std::shared_ptr<Filter> &ifilter,
+              QTime isampleTime = 0_ms);
 
   virtual ~VelMathArgs();
 

--- a/include/okapi/api/filter/velMath.hpp
+++ b/include/okapi/api/filter/velMath.hpp
@@ -20,7 +20,7 @@ namespace okapi {
 class VelMathArgs {
   public:
   explicit VelMathArgs(double iticksPerRev, QTime isampleTime = 0_ms);
-  VelMathArgs(double iticksPerRev, std::shared_ptr<Filter> ifilter, QTime isampleTime = 0_ms);
+  VelMathArgs(double iticksPerRev, const std::shared_ptr<Filter> &ifilter, QTime isampleTime = 0_ms);
 
   virtual ~VelMathArgs();
 
@@ -40,7 +40,7 @@ class VelMath {
    * @param isampleTime the minimum time between velocity measurements
    */
   VelMath(double iticksPerRev,
-          std::shared_ptr<Filter> ifilter,
+          const std::shared_ptr<Filter> &ifilter,
           QTime isampleTime,
           std::unique_ptr<AbstractTimer> iloopDtTimer);
 

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -9,7 +9,7 @@
 #include <cmath>
 
 namespace okapi {
-ChassisController::ChassisController(std::shared_ptr<ChassisModel> imodel,
+ChassisController::ChassisController(const std::shared_ptr<ChassisModel> &imodel,
                                      const double imaxVelocity,
                                      const double imaxVoltage)
   : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage), model(imodel) {

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -11,7 +11,7 @@
 namespace okapi {
 ChassisControllerIntegrated::ChassisControllerIntegrated(
   const TimeUtil &itimeUtil,
-  std::shared_ptr<ChassisModel> imodel,
+  const std::shared_ptr<ChassisModel> &imodel,
   std::unique_ptr<AsyncPosIntegratedController> ileftController,
   std::unique_ptr<AsyncPosIntegratedController> irightController,
   AbstractMotor::GearsetRatioPair igearset,

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -12,7 +12,7 @@
 namespace okapi {
 ChassisControllerPID::ChassisControllerPID(
   const TimeUtil &itimeUtil,
-  std::shared_ptr<ChassisModel> imodel,
+  const std::shared_ptr<ChassisModel> &imodel,
   std::unique_ptr<IterativePosPIDController> idistanceController,
   std::unique_ptr<IterativePosPIDController> iangleController,
   std::unique_ptr<IterativePosPIDController> iturnController,

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -10,10 +10,10 @@
 #include <utility>
 
 namespace okapi {
-SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                               std::shared_ptr<AbstractMotor> irightSideMotor,
-                               std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-                               std::shared_ptr<ContinuousRotarySensor> irightEnc,
+SkidSteerModel::SkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+                               const std::shared_ptr<AbstractMotor> &irightSideMotor,
+                               const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+                               const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
                                const double imaxVelocity,
                                const double imaxVoltage)
   : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
@@ -23,8 +23,8 @@ SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
     rightSensor(irightEnc) {
 }
 
-SkidSteerModel::SkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
-                               std::shared_ptr<AbstractMotor> irightSideMotor,
+SkidSteerModel::SkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+                               const std::shared_ptr<AbstractMotor> &irightSideMotor,
                                const double imaxVelocity,
                                const double imaxVoltage)
   : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -9,11 +9,11 @@
 
 namespace okapi {
 ThreeEncoderSkidSteerModel::ThreeEncoderSkidSteerModel(
-  std::shared_ptr<AbstractMotor> ileftSideMotor,
-  std::shared_ptr<AbstractMotor> irightSideMotor,
-  std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-  std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
-  std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  const std::shared_ptr<AbstractMotor> &ileftSideMotor,
+  const std::shared_ptr<AbstractMotor> &irightSideMotor,
+  const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+  const std::shared_ptr<ContinuousRotarySensor> &imiddleEnc,
+  const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
   const double imaxVelocity,
   const double imaxVoltage)
   : SkidSteerModel(ileftSideMotor, irightSideMotor, ileftEnc, irightEnc, imaxVelocity, imaxVoltage),

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -9,12 +9,12 @@
 #include <utility>
 
 namespace okapi {
-XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
-                         std::shared_ptr<AbstractMotor> itopRightMotor,
-                         std::shared_ptr<AbstractMotor> ibottomRightMotor,
-                         std::shared_ptr<AbstractMotor> ibottomLeftMotor,
-                         std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-                         std::shared_ptr<ContinuousRotarySensor> irightEnc,
+XDriveModel::XDriveModel(const std::shared_ptr<AbstractMotor> &itopLeftMotor,
+                         const std::shared_ptr<AbstractMotor> &itopRightMotor,
+                         const std::shared_ptr<AbstractMotor> &ibottomRightMotor,
+                         const std::shared_ptr<AbstractMotor> &ibottomLeftMotor,
+                         const std::shared_ptr<ContinuousRotarySensor> &ileftEnc,
+                         const std::shared_ptr<ContinuousRotarySensor> &irightEnc,
                          const double imaxVelocity,
                          const double imaxVoltage)
   : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),
@@ -26,10 +26,10 @@ XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
     rightSensor(irightEnc) {
 }
 
-XDriveModel::XDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
-                         std::shared_ptr<AbstractMotor> itopRightMotor,
-                         std::shared_ptr<AbstractMotor> ibottomRightMotor,
-                         std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+XDriveModel::XDriveModel(const std::shared_ptr<AbstractMotor> &itopLeftMotor,
+                         const std::shared_ptr<AbstractMotor> &itopRightMotor,
+                         const std::shared_ptr<AbstractMotor> &ibottomRightMotor,
+                         const std::shared_ptr<AbstractMotor> &ibottomLeftMotor,
                          const double imaxVelocity,
                          const double imaxVoltage)
   : ChassisModel::ChassisModel(imaxVelocity, imaxVoltage),

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -14,7 +14,7 @@ AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
   const double imaxVel,
   const double imaxAccel,
   const double imaxJerk,
-  std::shared_ptr<ControllerOutput<double>> ioutput)
+  const std::shared_ptr<ControllerOutput<double>> &ioutput)
   : logger(Logger::instance()),
     maxVel(imaxVel),
     maxAccel(imaxAccel),

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -10,13 +10,14 @@
 #include <numeric>
 
 namespace okapi {
-AsyncMotionProfileController::AsyncMotionProfileController(const TimeUtil &itimeUtil,
-                                                           const double imaxVel,
-                                                           const double imaxAccel,
-                                                           const double imaxJerk,
-                                                           const std::shared_ptr<ChassisModel> &imodel,
-                                                           const ChassisScales &iscales,
-                                                           AbstractMotor::GearsetRatioPair ipair)
+AsyncMotionProfileController::AsyncMotionProfileController(
+  const TimeUtil &itimeUtil,
+  const double imaxVel,
+  const double imaxAccel,
+  const double imaxJerk,
+  const std::shared_ptr<ChassisModel> &imodel,
+  const ChassisScales &iscales,
+  AbstractMotor::GearsetRatioPair ipair)
   : logger(Logger::instance()),
     maxVel(imaxVel),
     maxAccel(imaxAccel),

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -14,7 +14,7 @@ AsyncMotionProfileController::AsyncMotionProfileController(const TimeUtil &itime
                                                            const double imaxVel,
                                                            const double imaxAccel,
                                                            const double imaxJerk,
-                                                           std::shared_ptr<ChassisModel> imodel,
+                                                           const std::shared_ptr<ChassisModel> &imodel,
                                                            const ChassisScales &iscales,
                                                            AbstractMotor::GearsetRatioPair ipair)
   : logger(Logger::instance()),

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -9,12 +9,12 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+AsyncPosIntegratedController::AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
                                                            const TimeUtil &itimeUtil)
   : AsyncPosIntegratedController(imotor, toUnderlyingType(imotor->getGearing()), itimeUtil) {
 }
 
-AsyncPosIntegratedController::AsyncPosIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+AsyncPosIntegratedController::AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
                                                            const std::int32_t imaxVelocity,
                                                            const TimeUtil &itimeUtil)
   : logger(Logger::instance()),

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -9,14 +9,16 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncPosIntegratedController::AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
-                                                           const TimeUtil &itimeUtil)
+AsyncPosIntegratedController::AsyncPosIntegratedController(
+  const std::shared_ptr<AbstractMotor> &imotor,
+  const TimeUtil &itimeUtil)
   : AsyncPosIntegratedController(imotor, toUnderlyingType(imotor->getGearing()), itimeUtil) {
 }
 
-AsyncPosIntegratedController::AsyncPosIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
-                                                           const std::int32_t imaxVelocity,
-                                                           const TimeUtil &itimeUtil)
+AsyncPosIntegratedController::AsyncPosIntegratedController(
+  const std::shared_ptr<AbstractMotor> &imotor,
+  const std::int32_t imaxVelocity,
+  const TimeUtil &itimeUtil)
   : logger(Logger::instance()),
     motor(imotor),
     maxVelocity(imaxVelocity),

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -8,14 +8,15 @@
 #include "okapi/api/control/async/asyncPosPidController.hpp"
 
 namespace okapi {
-AsyncPosPIDController::AsyncPosPIDController(const std::shared_ptr<ControllerInput<double>> &iinput,
-                                             const std::shared_ptr<ControllerOutput<double>> &ioutput,
-                                             const TimeUtil &itimeUtil,
-                                             const double ikP,
-                                             const double ikI,
-                                             const double ikD,
-                                             const double ikBias,
-                                             std::unique_ptr<Filter> iderivativeFilter)
+AsyncPosPIDController::AsyncPosPIDController(
+  const std::shared_ptr<ControllerInput<double>> &iinput,
+  const std::shared_ptr<ControllerOutput<double>> &ioutput,
+  const TimeUtil &itimeUtil,
+  const double ikP,
+  const double ikI,
+  const double ikD,
+  const double ikBias,
+  std::unique_ptr<Filter> iderivativeFilter)
   : AsyncWrapper<double, double>(
       iinput,
       ioutput,

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -8,8 +8,8 @@
 #include "okapi/api/control/async/asyncPosPidController.hpp"
 
 namespace okapi {
-AsyncPosPIDController::AsyncPosPIDController(std::shared_ptr<ControllerInput<double>> iinput,
-                                             std::shared_ptr<ControllerOutput<double>> ioutput,
+AsyncPosPIDController::AsyncPosPIDController(const std::shared_ptr<ControllerInput<double>> &iinput,
+                                             const std::shared_ptr<ControllerOutput<double>> &ioutput,
                                              const TimeUtil &itimeUtil,
                                              const double ikP,
                                              const double ikI,

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -9,7 +9,7 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncVelIntegratedController::AsyncVelIntegratedController(std::shared_ptr<AbstractMotor> imotor,
+AsyncVelIntegratedController::AsyncVelIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
                                                            const TimeUtil &itimeUtil)
   : motor(imotor), settledUtil(itimeUtil.getSettledUtil()), rate(itimeUtil.getRate()) {
 }

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -9,8 +9,9 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncVelIntegratedController::AsyncVelIntegratedController(const std::shared_ptr<AbstractMotor> &imotor,
-                                                           const TimeUtil &itimeUtil)
+AsyncVelIntegratedController::AsyncVelIntegratedController(
+  const std::shared_ptr<AbstractMotor> &imotor,
+  const TimeUtil &itimeUtil)
   : motor(imotor), settledUtil(itimeUtil.getSettledUtil()), rate(itimeUtil.getRate()) {
 }
 

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -9,8 +9,8 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncVelPIDController::AsyncVelPIDController(std::shared_ptr<ControllerInput<double>> iinput,
-                                             std::shared_ptr<ControllerOutput<double>> ioutput,
+AsyncVelPIDController::AsyncVelPIDController(const std::shared_ptr<ControllerInput<double>> &iinput,
+                                             const std::shared_ptr<ControllerOutput<double>> &ioutput,
                                              const TimeUtil &itimeUtil,
                                              const double ikP,
                                              const double ikD,

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -9,15 +9,16 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-AsyncVelPIDController::AsyncVelPIDController(const std::shared_ptr<ControllerInput<double>> &iinput,
-                                             const std::shared_ptr<ControllerOutput<double>> &ioutput,
-                                             const TimeUtil &itimeUtil,
-                                             const double ikP,
-                                             const double ikD,
-                                             const double ikF,
-                                             const double ikSF,
-                                             std::unique_ptr<VelMath> ivelMath,
-                                             std::unique_ptr<Filter> iderivativeFilter)
+AsyncVelPIDController::AsyncVelPIDController(
+  const std::shared_ptr<ControllerInput<double>> &iinput,
+  const std::shared_ptr<ControllerOutput<double>> &ioutput,
+  const TimeUtil &itimeUtil,
+  const double ikP,
+  const double ikD,
+  const double ikF,
+  const double ikSF,
+  std::unique_ptr<VelMath> ivelMath,
+  std::unique_ptr<Filter> iderivativeFilter)
   : AsyncWrapper<double, double>(
       iinput,
       ioutput,

--- a/src/api/control/iterative/iterativeMotorVelocityController.cpp
+++ b/src/api/control/iterative/iterativeMotorVelocityController.cpp
@@ -9,8 +9,8 @@
 
 namespace okapi {
 IterativeMotorVelocityController::IterativeMotorVelocityController(
-  std::shared_ptr<AbstractMotor> imotor,
-  std::shared_ptr<IterativeVelocityController<double, double>> icontroller)
+  const std::shared_ptr<AbstractMotor> &imotor,
+  const std::shared_ptr<IterativeVelocityController<double, double>> &icontroller)
   : motor(imotor), controller(icontroller) {
 }
 

--- a/src/api/control/util/pidTuner.cpp
+++ b/src/api/control/util/pidTuner.cpp
@@ -13,8 +13,8 @@
 #include <random>
 
 namespace okapi {
-PIDTuner::PIDTuner(std::shared_ptr<ControllerInput<double>> iinput,
-                   std::shared_ptr<ControllerOutput<double>> ioutput,
+PIDTuner::PIDTuner(const std::shared_ptr<ControllerInput<double>> &iinput,
+                   const std::shared_ptr<ControllerOutput<double>> &ioutput,
                    const TimeUtil &itimeUtil,
                    QTime itimeout,
                    std::int32_t igoal,

--- a/src/api/filter/composableFilter.cpp
+++ b/src/api/filter/composableFilter.cpp
@@ -38,7 +38,7 @@ double ComposableFilter::getOutput() const {
   return output;
 }
 
-void ComposableFilter::addFilter(std::shared_ptr<Filter> ifilter) {
+void ComposableFilter::addFilter(const std::shared_ptr<Filter> &ifilter) {
   filters.push_back(ifilter);
 }
 } // namespace okapi

--- a/src/api/filter/velMath.cpp
+++ b/src/api/filter/velMath.cpp
@@ -17,7 +17,7 @@ VelMathArgs::VelMathArgs(const double iticksPerRev, const QTime isampleTime)
 }
 
 VelMathArgs::VelMathArgs(const double iticksPerRev,
-                         std::shared_ptr<Filter> ifilter,
+                         const std::shared_ptr<Filter> &ifilter,
                          const QTime isampleTime)
   : ticksPerRev(iticksPerRev), filter(ifilter), sampleTime(isampleTime) {
 }
@@ -29,7 +29,7 @@ VelMath::VelMath(const VelMathArgs &iparams, std::unique_ptr<AbstractTimer> iloo
 }
 
 VelMath::VelMath(const double iticksPerRev,
-                 std::shared_ptr<Filter> ifilter,
+                 const std::shared_ptr<Filter> &ifilter,
                  QTime isampleTime,
                  std::unique_ptr<AbstractTimer> iloopDtTimer)
   : logger(Logger::instance()),


### PR DESCRIPTION
### Description of the Change

Used const refs to pass shared_ptr to functions

### Benefits

Avoid unnecessary reference count increment/decrement

### Possible Drawbacks

Didn't change factory classes

### Verification Process

- [x] Compiles
- [x] run cppcheck
- [x] run clang-format

### Applicable Issues

Closes #234 
