### PR TITLE
Make Controller::operator[] return the same ControllerButton instance

### DIFF
--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -11,6 +11,7 @@
 #include "api.h"
 #include "okapi/impl/device/button/controllerButton.hpp"
 #include "okapi/impl/device/controllerUtil.hpp"
+#include <array>
 
 namespace okapi {
 class Controller {
@@ -108,8 +109,9 @@ class Controller {
   virtual std::int32_t getBatteryLevel();
 
   protected:
-  const ControllerId m_id;
+  ControllerId m_id;
   pros::Controller controller;
+  static std::array<ControllerButton *, 12> buttonArray;
 };
 } // namespace okapi
 

--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -61,7 +61,7 @@ class Controller {
    * @param ibtn the button
    * @return a ControllerButton on this controller
    */
-  virtual ControllerButton operator[](ControllerDigital ibtn);
+  virtual ControllerButton &operator[](ControllerDigital ibtn);
 
   /**
    * Sets text to the controller LCD screen.

--- a/src/impl/device/controller.cpp
+++ b/src/impl/device/controller.cpp
@@ -10,6 +10,8 @@
 #include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
+std::array<ControllerButton *, 12> Controller::buttonArray;
+
 Controller::Controller(const ControllerId iid)
   : m_id(iid), controller(ControllerUtil::idToProsEnum(iid)) {
   std::fill(buttonArray.begin(), buttonArray.end(), nullptr);
@@ -40,7 +42,7 @@ bool Controller::getDigital(const ControllerDigital ibutton) {
   return controller.get_digital(ControllerUtil::digitalToProsEnum(ibutton)) == 1;
 }
 
-ControllerButton Controller::operator[](const ControllerDigital ibtn) {
+ControllerButton &Controller::operator[](const ControllerDigital ibtn) {
   const auto index = toUnderlyingType(ibtn) - toUnderlyingType(ControllerDigital::L1);
 
   if (buttonArray[index] == nullptr) {

--- a/src/impl/device/controller.cpp
+++ b/src/impl/device/controller.cpp
@@ -6,11 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/device/controller.hpp"
+#include "okapi/api/util/mathUtil.hpp"
 #include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
 Controller::Controller(const ControllerId iid)
   : m_id(iid), controller(ControllerUtil::idToProsEnum(iid)) {
+  std::fill(buttonArray.begin(), buttonArray.end(), nullptr);
 }
 
 Controller::~Controller() = default;
@@ -26,6 +28,7 @@ std::int32_t Controller::getConnectionState() {
 
 float Controller::getAnalog(const ControllerAnalog ichannel) {
   const auto val = controller.get_analog(ControllerUtil::analogToProsEnum(ichannel));
+
   if (val == PROS_ERR) {
     return 0;
   }
@@ -38,7 +41,13 @@ bool Controller::getDigital(const ControllerDigital ibutton) {
 }
 
 ControllerButton Controller::operator[](const ControllerDigital ibtn) {
-  return ControllerButton(m_id, ibtn);
+  const auto index = toUnderlyingType(ibtn) - toUnderlyingType(ControllerDigital::L1);
+
+  if (buttonArray[index] == nullptr) {
+    buttonArray[index] = new ControllerButton(m_id, ibtn);
+  }
+
+  return *buttonArray[index];
 }
 
 std::int32_t Controller::setText(std::uint8_t iline, std::uint8_t icol, std::string itext) {


### PR DESCRIPTION
### Description of the Change

People tend to query a button once, so the natural API usage is something like `master[ControllerButton::X].changedToPressed()`. If you only query the button once, saving it to a variable is more verbose than inlining the button. Right now that isn't possible because `Controller::operator[]` return a new `ControllerButton` instance. If instead, we return the same instance, then both API usages are supported.

### Benefits

Described above :)

### Possible Drawbacks

Slightly more memory usage (12 static pointers) but it's not really a problem.

### Verification Process

This was tested by hand with
```cpp
  Controller master;
  std::cout << &master[ControllerDigital::X] << ", " << &master[ControllerDigital::X] << std::endl;
  std::cout << &master[ControllerDigital::A] << ", " << &master[ControllerDigital::A] << std::endl;
  std::cout << &master[ControllerDigital::L1] << ", " << &master[ControllerDigital::L1] << std::endl;
  pros::delay(100);
```
which prints
```
0x39fe220, 0x39fe220
0x39fe638, 0x39fe638
0x39fe648, 0x39fe648
```

### Applicable Issues

Closes #246.
