### PR TITLE
Add a way to mirror ChassisController turns

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -89,6 +89,13 @@ class ChassisController : public ChassisModel {
   virtual void turnAngleAsync(double idegTarget) = 0;
 
   /**
+   * Sets whether turns should be mirrored.
+   *
+   * @param ishouldMirror whether turns should be mirrored
+   */
+  virtual void setTurnsMirrored(bool ishouldMirror);
+
+  /**
    * Delays until the currently executing movement completes.
    */
   virtual void waitUntilSettled() = 0;
@@ -282,6 +289,7 @@ class ChassisController : public ChassisModel {
 
   protected:
   std::shared_ptr<ChassisModel> model;
+  bool normalTurns{true};
 };
 } // namespace okapi
 

--- a/include/okapi/api/util/mathUtil.hpp
+++ b/include/okapi/api/util/mathUtil.hpp
@@ -104,6 +104,13 @@ constexpr double remapRange(const double value,
 template <typename E> constexpr auto toUnderlyingType(E e) noexcept {
   return static_cast<std::underlying_type_t<E>>(e);
 }
+
+/**
+ * Converts a bool to a sign. True corresponds to 1 and false corresponds to -1.
+ */
+constexpr auto boolToSign(bool b) noexcept {
+  return b ? 1 : -1;
+}
 } // namespace okapi
 
 #endif

--- a/include/okapi/api/util/mathUtil.hpp
+++ b/include/okapi/api/util/mathUtil.hpp
@@ -101,14 +101,14 @@ constexpr double remapRange(const double value,
 /**
  * Converts an enum to its value type.
  */
-template <typename E> constexpr auto toUnderlyingType(E e) noexcept {
+template <typename E> constexpr auto toUnderlyingType(const E e) noexcept {
   return static_cast<std::underlying_type_t<E>>(e);
 }
 
 /**
  * Converts a bool to a sign. True corresponds to 1 and false corresponds to -1.
  */
-constexpr auto boolToSign(bool b) noexcept {
+constexpr auto boolToSign(const bool b) noexcept {
   return b ? 1 : -1;
 }
 } // namespace okapi

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -17,6 +17,10 @@ ChassisController::ChassisController(const std::shared_ptr<ChassisModel> &imodel
 
 ChassisController::~ChassisController() = default;
 
+void ChassisController::setTurnsMirrored(const bool ishouldMirror) {
+  normalTurns = !ishouldMirror;
+}
+
 void ChassisController::forward(const double ispeed) const {
   model->forward(ispeed);
 }

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -88,7 +88,8 @@ void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
   leftController->flipDisable(false);
   rightController->flipDisable(false);
 
-  const double newTarget = idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio;
+  const double newTarget =
+    idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
 
   logger->info("ChassisControllerIntegrated: turning " + std::to_string(newTarget) +
                " motor degrees");

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -153,7 +153,8 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   anglePid->flipDisable(true);
   mode = angle;
 
-  const double newTarget = idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio;
+  const double newTarget =
+    idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
 
   logger->info("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
 

--- a/src/opcontrol.cpp
+++ b/src/opcontrol.cpp
@@ -14,8 +14,12 @@
  * task, not resume it from where it left off.
  */
 using namespace okapi;
-auto drive = ChassisControllerFactory::create(
-  -18, 19, {}, {}, AbstractMotor::gearset::green, {4.125_in, 10.5_in});
+auto drive = ChassisControllerFactory::create(-18,
+                                              19,
+                                              {},
+                                              {},
+                                              AbstractMotor::gearset::green,
+                                              {4.125_in, 10.5_in});
 void opcontrol() {
 
   Logger::initialize(TimeUtilFactory::create().getTimer(), "/ser/sout", Logger::LogLevel::debug);

--- a/test/chassisControllerIntegratedTests.cpp
+++ b/test/chassisControllerIntegratedTests.cpp
@@ -173,6 +173,14 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncUnitsTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
+TEST_F(ChassisControllerIntegratedTest, MirrorTurnTest) {
+  controller->setTurnsMirrored(true);
+  controller->turnAngle(45_deg);
+
+  EXPECT_DOUBLE_EQ(leftController->getTarget(), -90);
+  EXPECT_DOUBLE_EQ(rightController->getTarget(), 90);
+}
+
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
   controller->moveDistanceAsync(100);
 

--- a/test/chassisControllerPidTest.cpp
+++ b/test/chassisControllerPidTest.cpp
@@ -186,6 +186,15 @@ TEST_F(ChassisControllerPIDTest, TurnAngleAsyncUnitsTest) {
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
+TEST_F(ChassisControllerPIDTest, MirrorTurnTest) {
+  controller->setTurnsMirrored(true);
+  controller->turnAngle(45_deg);
+
+  EXPECT_DOUBLE_EQ(distanceController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
+  EXPECT_DOUBLE_EQ(turnController->getTarget(), -90);
+}
+
 TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
   controller->moveDistanceAsync(100);
 


### PR DESCRIPTION
### Description of the Change

This PR adds the method `setTurnsMirrored()` so users can mirror their turns without creating a sign they manage themselves.

### Benefits

Cleaner user code.

### Possible Drawbacks

None.

### Verification Process

New tests were added.

### Applicable Issues

Closes #222.
