### PR TITLE
Add a method to APIC to set the zero point

### DIFF
--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -116,6 +116,13 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    */
   virtual void setMaxVelocity(std::int32_t imaxVelocity);
 
+  /**
+   * Sets the "absolute" zero position of the motor to its current position.
+   *
+   * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
+   */
+  virtual std::int32_t tarePosition();
+
   protected:
   Logger *logger;
   std::shared_ptr<AbstractMotor> motor;

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -103,4 +103,8 @@ void AsyncPosIntegratedController::controllerSet(double ivalue) {
 void AsyncPosIntegratedController::setMaxVelocity(const std::int32_t imaxVelocity) {
   maxVelocity = imaxVelocity;
 }
+
+std::int32_t AsyncPosIntegratedController::tarePosition() {
+  return motor->tarePosition();
+}
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR adds a method `tarePosition()` which sets the "zero position" for the controller.

### Benefits

Exposes functionality to set the zero position.

### Possible Drawbacks

None.

### Verification Process

This change was not verified.

### Applicable Issues

Closes #258.
