### PR TITLE
Add a method to APIC to interrupt a movement

### DIFF
--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -116,6 +116,11 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
    */
   virtual void setMaxVelocity(std::int32_t imaxVelocity);
 
+  /**
+   * Stops the motor mid-movement. Does not change the last set target.
+   */
+  virtual void stop();
+
   protected:
   Logger *logger;
   std::shared_ptr<AbstractMotor> motor;

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -72,7 +72,7 @@ bool AsyncPosIntegratedController::isDisabled() const {
 
 void AsyncPosIntegratedController::resumeMovement() {
   if (isDisabled()) {
-    motor->moveVelocity(0);
+    stop();
   } else {
     if (hasFirstTarget) {
       setTarget(lastTarget);
@@ -102,5 +102,9 @@ void AsyncPosIntegratedController::controllerSet(double ivalue) {
 
 void AsyncPosIntegratedController::setMaxVelocity(const std::int32_t imaxVelocity) {
   maxVelocity = imaxVelocity;
+}
+
+void AsyncPosIntegratedController::stop() {
+  motor->moveVelocity(0);
 }
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR adds a method `stop()` to interrupt a motor mid-movement and stop it. Disabling the controller will accomplish this, but then you'll need to manage the disabled lifecycle when making any movements.

### Benefits

A nicer API to stop the controller.

### Possible Drawbacks

Stopping the controller and then disabling/enabling it will cause it to move back to its last set target. This is the intended behavior, but some users might get caught off-guard by it.

### Verification Process

This change was not verified.

### Applicable Issues

Closes #259.
