### PR TITLE
Reword reset docs

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -131,10 +131,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   bool isSettled() override;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
-   *
-   * This implementation does nothing.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information. This implementation also stops movement.
    */
   void reset() override;
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -130,9 +130,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
 
   /**
    * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
-   *
-   * This implementation does nothing.
+   * before. This implementation also stops movement.
    */
   void reset() override;
 

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -69,8 +69,8 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
   bool isSettled() override;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override;
 

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -52,8 +52,8 @@ class AsyncVelIntegratedController : public AsyncVelocityController<double, doub
   bool isSettled() override;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override;
 

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -156,8 +156,8 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override {
     logger->info("AsyncWrapper: Reset");

--- a/include/okapi/api/control/closedLoopController.hpp
+++ b/include/okapi/api/control/closedLoopController.hpp
@@ -55,8 +55,8 @@ class ClosedLoopController : public ControllerOutput<Input> {
   virtual bool isSettled() = 0;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   virtual void reset() = 0;
 

--- a/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
+++ b/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
@@ -99,8 +99,8 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
   void setOutputLimits(double imax, double imin) override;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override;
 

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -169,8 +169,8 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   virtual void setErrorSumLimits(double imax, double imin);
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps gains and limits from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override;
 

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -118,8 +118,8 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   void setOutputLimits(double imax, double imin) override;
 
   /**
-   * Resets the controller so it can start from 0 again properly. Keeps configuration from
-   * before.
+   * Resets the controller's internal state so it is similar to when it was first initialized, while
+   * keeping any user-configured information.
    */
   void reset() override;
 


### PR DESCRIPTION
### Description of the Change

A few users have been misled by the current reset docs. This PR rewords the docs so that it clearly states that only the controller's internal state is reset.

### Benefits

Clearer wording and less confused users.

### Possible Drawbacks

None.

### Verification Process

This change was not verified.

### Applicable Issues

Closes #260.
