### PR TITLE
Add AMPC moveTo

### DIFF
--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -109,6 +109,14 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   void waitUntilSettled() override;
 
   /**
+   * Generates a new path from the position (typically the current position) to the target and
+   * blocks until the controller has settled. Does not save the path which was generated.
+   *
+   * @param iwaypoints The waypoints to hit on the path.
+   */
+  void moveTo(std::initializer_list<Point> iwaypoints);
+
+  /**
    * Returns the last error of the controller. This implementation always returns zero since the
    * robot is assumed to perfectly follow the path. Subclasses can override this to be more
    * accurate using odometry information.

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -273,6 +273,14 @@ void AsyncMotionProfileController::waitUntilSettled() {
   logger->info("AsyncMotionProfileController: Done waiting to settle");
 }
 
+void AsyncMotionProfileController::moveTo(std::initializer_list<Point> iwaypoints) {
+  std::string name = reinterpret_cast<const char *>(this); // hmmmm...
+  generatePath(iwaypoints, name);
+  setTarget(name);
+  waitUntilSettled();
+  removePath(name);
+}
+
 Point AsyncMotionProfileController::getError() const {
   return Point{0_m, 0_m, 0_deg};
 }

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -76,6 +76,15 @@ TEST_F(AsyncMotionProfileControllerTest, MotorsAreStoppedAfterSettling) {
   EXPECT_GT(leftMotor->maxVelocity, 0);
   EXPECT_GT(rightMotor->maxVelocity, 0);
 }
+
+TEST_F(AsyncMotionProfileControllerTest, FollowPathWithMoveTo) {
+  controller->moveTo({Point{0_m, 0_m, 0_deg}, Point{3_ft, 0_m, 0_deg}});
+
+  assertMotorsHaveBeenStopped(leftMotor.get(), rightMotor.get());
+  EXPECT_GT(leftMotor->maxVelocity, 0);
+  EXPECT_GT(rightMotor->maxVelocity, 0);
+}
+
 TEST_F(AsyncMotionProfileControllerTest, WrongPathNameDoesNotMoveAnything) {
   controller->setTarget("A");
   controller->waitUntilSettled();


### PR DESCRIPTION
### Description of the Change

This PR adds `moveTo()` to AMPC.

### Benefits

Simpler API if you just want to make a simple movement.

### Possible Drawbacks

None.

### Verification Process

A test was added.

### Applicable Issues

Closes #269.
