### PR TITLE
Add an IntegratedEncoder ctor that takes an Okapi motor

### DIFF
--- a/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
+++ b/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
@@ -26,7 +26,7 @@ class IntegratedEncoder : public ContinuousRotarySensor {
    *
    * @param imotor the motor to use the encoder from.
    */
-  IntegratedEncoder(const okapi::Motor &imotor);
+  explicit IntegratedEncoder(const okapi::Motor &imotor);
 
   /**
    * Get the current sensor value.

--- a/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
+++ b/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
@@ -9,6 +9,7 @@
 
 #include "api.h"
 #include "okapi/api/device/rotarysensor/continuousRotarySensor.hpp"
+#include "okapi/impl/device/motor/motor.hpp"
 
 namespace okapi {
 class IntegratedEncoder : public ContinuousRotarySensor {
@@ -16,9 +17,16 @@ class IntegratedEncoder : public ContinuousRotarySensor {
   /**
    * Integrated motor encoder. Uses the encoder inside the V5 motor.
    *
-   * @param imotor motor
+   * @param imotor the motor to use the encoder from.
    */
-  IntegratedEncoder(pros::Motor imotor);
+  IntegratedEncoder(const pros::Motor &imotor);
+
+  /**
+   * Integrated motor encoder. Uses the encoder inside the V5 motor.
+   *
+   * @param imotor the motor to use the encoder from.
+   */
+  IntegratedEncoder(const okapi::Motor &imotor);
 
   /**
    * Get the current sensor value.

--- a/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
+++ b/include/okapi/impl/device/rotarysensor/integratedEncoder.hpp
@@ -19,7 +19,7 @@ class IntegratedEncoder : public ContinuousRotarySensor {
    *
    * @param imotor the motor to use the encoder from.
    */
-  IntegratedEncoder(const pros::Motor &imotor);
+  explicit IntegratedEncoder(const pros::Motor &imotor);
 
   /**
    * Integrated motor encoder. Uses the encoder inside the V5 motor.

--- a/src/impl/device/rotarysensor/integratedEncoder.cpp
+++ b/src/impl/device/rotarysensor/integratedEncoder.cpp
@@ -8,7 +8,10 @@
 #include "okapi/impl/device/rotarysensor/integratedEncoder.hpp"
 
 namespace okapi {
-IntegratedEncoder::IntegratedEncoder(pros::Motor imotor) : motor(imotor) {
+IntegratedEncoder::IntegratedEncoder(const pros::Motor &imotor) : motor(imotor) {
+}
+
+IntegratedEncoder::IntegratedEncoder(const okapi::Motor &imotor) : motor(imotor) {
 }
 
 double IntegratedEncoder::get() const {


### PR DESCRIPTION
### Description of the Change

This PR adds a ctor to `IntegratedEncoder` that takes an `okapi::Motor`.

### Benefits

Users can now use implicit construction to make their encoder, such as `IntegratedEncoder(1)`.

### Possible Drawbacks

None.

### Verification Process

This was not verified.

### Applicable Issues

Closes #274.
