### PR TITLE
Add two more bounds for the controllerSet target

### DIFF
--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -141,6 +141,17 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  void setControllerSetTargetLimits(double itargetMax, double itargetMin) {
+    controller->setControllerSetTargetLimits(itargetMax, itargetMin);
+  }
+
+  /**
    * Get the upper output bound.
    *
    * @return  the upper output bound

--- a/include/okapi/api/control/iterative/iterativeController.hpp
+++ b/include/okapi/api/control/iterative/iterativeController.hpp
@@ -42,6 +42,15 @@ class IterativeController : public ClosedLoopController<Input, Output> {
   virtual void setOutputLimits(Output imax, Output imin) = 0;
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  virtual void setControllerSetTargetLimits(Output itargetMax, Output itargetMin) = 0;
+
+  /**
    * Get the upper output bound.
    *
    * @return  the upper output bound

--- a/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
+++ b/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
@@ -98,6 +98,15 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
   void setOutputLimits(double imax, double imin) override;
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  void setControllerSetTargetLimits(double itargetMax, double itargetMin) override;
+
+  /**
    * Resets the controller's internal state so it is similar to when it was first initialized, while
    * keeping any user-configured information.
    */

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -153,6 +153,15 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   void setOutputLimits(double imax, double imin) override;
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  void setControllerSetTargetLimits(double itargetMax, double itargetMin) override;
+
+  /**
    * Set integrator bounds. Default bounds are [-1, 1].
    *
    * @param imax max integrator value
@@ -236,6 +245,8 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   double output{0};
   double outputMax{1};
   double outputMin{-1};
+  double controllerSetTargetMax{1};
+  double controllerSetTargetMin{-1};
 
   // Reset the integrated when the controller crosses 0 or not
   bool shouldResetOnCross{true};

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -127,6 +127,15 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   void setOutputLimits(double imax, double imin) override;
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  void setControllerSetTargetLimits(double itargetMax, double itargetMin) override;
+
+  /**
    * Resets the controller's internal state so it is similar to when it was first initialized, while
    * keeping any user-configured information.
    */
@@ -177,15 +186,6 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
    * @param ikSF a feed-forward gain to counteract static friction
    */
   virtual void setGains(double ikP, double ikD, double ikF, double ikSF);
-
-  /**
-   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
-   * computed by controllerSet() is scaled from [-1, 1] into the range [-itargetMin, itargetMax].
-   *
-   * @param itargetMax The new max target for controllerSet().
-   * @param itargetMin The new min target for controllerSet().
-   */
-  virtual void setControllerSetTargetLimits(double itargetMax, double itargetMin);
 
   /**
    * Sets the number of encoder ticks per revolution. Default is 1800.

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -179,6 +179,15 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   virtual void setGains(double ikP, double ikD, double ikF, double ikSF);
 
   /**
+   * Sets the (soft) limits for the target range that controllerSet() scales into. The target
+   * computed by controllerSet() is scaled from [-1, 1] into the range [-itargetMin, itargetMax].
+   *
+   * @param itargetMax The new max target for controllerSet().
+   * @param itargetMin The new min target for controllerSet().
+   */
+  virtual void setControllerSetTargetLimits(double itargetMax, double itargetMin);
+
+  /**
    * Sets the number of encoder ticks per revolution. Default is 1800.
    *
    * @param tpr number of measured units per revolution
@@ -201,6 +210,8 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   double output{0};
   double outputMax{1};
   double outputMin{-1};
+  double controllerSetTargetMax{1};
+  double controllerSetTargetMin{-1};
   bool controllerIsDisabled{false};
 
   std::unique_ptr<VelMath> velMath;

--- a/src/api/control/iterative/iterativeMotorVelocityController.cpp
+++ b/src/api/control/iterative/iterativeMotorVelocityController.cpp
@@ -59,6 +59,11 @@ void IterativeMotorVelocityController::setOutputLimits(double imax, double imin)
   controller->setOutputLimits(imax, imin);
 }
 
+void IterativeMotorVelocityController::setControllerSetTargetLimits(double itargetMax,
+                                                                    double itargetMin) {
+  controller->setControllerSetTargetLimits(itargetMax, itargetMin);
+}
+
 void IterativeMotorVelocityController::reset() {
   controller->reset();
 }

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -50,7 +50,7 @@ void IterativePosPIDController::setTarget(const double itarget) {
 }
 
 void IterativePosPIDController::controllerSet(const double ivalue) {
-  target = remapRange(ivalue, -1, 1, outputMin, outputMax);
+  target = remapRange(ivalue, -1, 1, controllerSetTargetMin, controllerSetTargetMax);
 }
 
 double IterativePosPIDController::getTarget() {
@@ -98,6 +98,18 @@ void IterativePosPIDController::setOutputLimits(double imax, double imin) {
   outputMin = imin;
 
   output = std::clamp(output, outputMin, outputMax);
+}
+
+void IterativePosPIDController::setControllerSetTargetLimits(double itargetMax, double itargetMin) {
+  // Always use larger value as max
+  if (itargetMin > itargetMax) {
+    const double temp = itargetMax;
+    itargetMax = itargetMin;
+    itargetMin = temp;
+  }
+
+  controllerSetTargetMax = itargetMax;
+  controllerSetTargetMin = itargetMin;
 }
 
 void IterativePosPIDController::setIntegralLimits(double imax, double imin) {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -99,7 +99,7 @@ void IterativeVelPIDController::setTarget(const double itarget) {
 }
 
 void IterativeVelPIDController::controllerSet(const double ivalue) {
-  target = remapRange(ivalue, -1, 1, outputMin, outputMax);
+  target = remapRange(ivalue, -1, 1, controllerSetTargetMin, controllerSetTargetMax);
 }
 
 double IterativeVelPIDController::getTarget() {
@@ -145,6 +145,12 @@ void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
 
 bool IterativeVelPIDController::isDisabled() const {
   return controllerIsDisabled;
+}
+
+void IterativeVelPIDController::setControllerSetTargetLimits(const double itargetMax,
+                                                             const double itargetMin) {
+  controllerSetTargetMax = itargetMax;
+  controllerSetTargetMin = itargetMin;
 }
 
 void IterativeVelPIDController::setTicksPerRev(const double tpr) {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -59,6 +59,18 @@ void IterativeVelPIDController::setOutputLimits(double imax, double imin) {
   output = std::clamp(output, outputMin, outputMax);
 }
 
+void IterativeVelPIDController::setControllerSetTargetLimits(double itargetMax, double itargetMin) {
+  // Always use larger value as max
+  if (itargetMin > itargetMax) {
+    const double temp = itargetMax;
+    itargetMax = itargetMin;
+    itargetMin = temp;
+  }
+
+  controllerSetTargetMax = itargetMax;
+  controllerSetTargetMin = itargetMin;
+}
+
 QAngularSpeed IterativeVelPIDController::stepVel(const double inewReading) {
   return velMath->step(inewReading);
 }
@@ -145,12 +157,6 @@ void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
 
 bool IterativeVelPIDController::isDisabled() const {
   return controllerIsDisabled;
-}
-
-void IterativeVelPIDController::setControllerSetTargetLimits(const double itargetMax,
-                                                             const double itargetMin) {
-  controllerSetTargetMax = itargetMax;
-  controllerSetTargetMin = itargetMin;
 }
 
 void IterativeVelPIDController::setTicksPerRev(const double tpr) {

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -518,14 +518,14 @@ void assertControllerFollowsTargetLifecycle(ClosedLoopController<double, double>
 void assertIterativeControllerScalesControllerSetTargets(
   IterativeController<double, double> &controller) {
   EXPECT_DOUBLE_EQ(controller.getTarget(), 0);
-  controller.setOutputLimits(-100, 100);
+  controller.setControllerSetTargetLimits(-100, 100);
   controller.controllerSet(0.5);
   EXPECT_DOUBLE_EQ(controller.getTarget(), 50);
 }
 
 void assertAsyncWrapperScalesControllerSetTargets(AsyncWrapper<double, double> &controller) {
   EXPECT_DOUBLE_EQ(controller.getTarget(), 0);
-  controller.setOutputLimits(-100, 100);
+  controller.setControllerSetTargetLimits(-100, 100);
   controller.controllerSet(0.5);
   EXPECT_DOUBLE_EQ(controller.getTarget(), 50);
 }

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -133,3 +133,9 @@ TEST_F(IterativeVelPIDControllerTest, SampleTime) {
   // 20_ms
   EXPECT_EQ(controller->step(-1), 0);
 }
+
+TEST_F(IterativeVelPIDControllerTest, ControllerSetWithModifiedTargetLimits) {
+  controller->setControllerSetTargetLimits(10, 0);
+  controller->controllerSet(0.5);
+  EXPECT_EQ(controller->getTarget(), 7.5);
+}


### PR DESCRIPTION
### Description of the Change

This PR adds two more target bounds so that `IterativeVelPIDController::controllerSet()` can scale its target independently of the output limits.

### Benefits

Better target scaling.

### Possible Drawbacks

None.

### Verification Process

Added a test.

### Applicable Issues

Closes #291.
