### PR TITLE
Add a flag to mirror AMPC movements

### DIFF
--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -87,8 +87,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    *
    * @param ipathId A unique identifier for the path, previously passed to generatePath().
    * @param ibackwards Whether to follow the profile backwards.
+   * @param imirrored Whether to follow the profile mirrored.
    */
-  void setTarget(std::string ipathId, bool ibackwards);
+  void setTarget(std::string ipathId, bool ibackwards, bool imirrored = false);
 
   /**
    * Writes the value of the controller output. This method might be automatically called in another
@@ -115,8 +116,10 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    *
    * @param iwaypoints The waypoints to hit on the path.
    * @param ibackwards Whether to follow the profile backwards.
+   * @param imirrored Whether to follow the profile mirrored.
    */
-  void moveTo(std::initializer_list<Point> iwaypoints, bool ibackwards = false);
+  void
+  moveTo(std::initializer_list<Point> iwaypoints, bool ibackwards = false, bool imirrored = false);
 
   /**
    * Returns the last error of the controller. This implementation always returns zero since the
@@ -196,6 +199,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   std::string currentPath{""};
   std::atomic_bool isRunning{false};
   std::atomic_int direction{1};
+  std::atomic_bool mirrored{false};
   std::atomic_bool disabled{false};
   std::atomic_bool dtorCalled{false};
   CrossplatformThread *task{nullptr};

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -200,10 +200,13 @@ void AsyncMotionProfileController::setTarget(std::string ipathId) {
   setTarget(ipathId, false);
 }
 
-void AsyncMotionProfileController::setTarget(std::string ipathId, const bool ibackwards) {
+void AsyncMotionProfileController::setTarget(std::string ipathId,
+                                             const bool ibackwards,
+                                             const bool imirrored) {
   currentPath = ipathId;
   isRunning.store(true, std::memory_order_release);
   direction.store(boolToSign(!ibackwards), std::memory_order_release);
+  mirrored.store(imirrored, std::memory_order_release);
 }
 
 void AsyncMotionProfileController::controllerSet(std::string ivalue) {
@@ -245,16 +248,29 @@ void AsyncMotionProfileController::loop() {
 
 void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
                                                      std::unique_ptr<AbstractRate> rate) {
-  const auto reversed = direction.load(std::memory_order_acquire);
+  const int reversed = direction.load(std::memory_order_acquire);
+  const bool followMirrored = mirrored.load(std::memory_order_acquire);
 
-  for (int i = 0; i < path.length && !isDisabled(); ++i) {
-    const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
-    const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
+  if (followMirrored) {
+    for (int i = 0; i < path.length && !isDisabled(); ++i) {
+      const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
+      const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
 
-    model->left(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
-    model->right(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
+      model->left(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
+      model->right(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-    rate->delayUntil(1_ms);
+      rate->delayUntil(1_ms);
+    }
+  } else {
+    for (int i = 0; i < path.length && !isDisabled(); ++i) {
+      const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
+      const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
+
+      model->left(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
+      model->right(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
+
+      rate->delayUntil(1_ms);
+    }
   }
 }
 
@@ -280,10 +296,11 @@ void AsyncMotionProfileController::waitUntilSettled() {
 }
 
 void AsyncMotionProfileController::moveTo(std::initializer_list<Point> iwaypoints,
-                                          const bool ibackwards) {
+                                          const bool ibackwards,
+                                          const bool imirrored) {
   std::string name = reinterpret_cast<const char *>(this); // hmmmm...
   generatePath(iwaypoints, name);
-  setTarget(name, ibackwards);
+  setTarget(name, ibackwards, imirrored);
   waitUntilSettled();
   removePath(name);
 }

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -216,3 +216,45 @@ TEST_F(AsyncMotionProfileControllerTest, FollowPathBackwards) {
   // still running
   controller->flipDisable(true);
 }
+
+TEST_F(AsyncMotionProfileControllerTest, FollowPathNotMirrored) {
+  controller->generatePath({Point{0_m, 0_m, 0_deg}, Point{1_ft, 1_ft, 0_deg}}, "A");
+  controller->setTarget("A");
+
+  auto rate = createTimeUtil().getRate();
+  while (!controller->executeSinglePathCalled) {
+    rate->delayUntil(1_ms);
+  }
+
+  // Wait a little longer so we get into the path
+  rate->delayUntil(200_ms);
+
+  EXPECT_GT(leftMotor->lastVelocity, 0);
+  EXPECT_GT(rightMotor->lastVelocity, 0);
+  EXPECT_GT(rightMotor->maxVelocity, leftMotor->maxVelocity);
+
+  // Disable the controller so gtest doesn't clean up the test fixture while the internal thread is
+  // still running
+  controller->flipDisable(true);
+}
+
+TEST_F(AsyncMotionProfileControllerTest, FollowPathMirrored) {
+  controller->generatePath({Point{0_m, 0_m, 0_deg}, Point{1_ft, 1_ft, 0_deg}}, "A");
+  controller->setTarget("A", false, true);
+
+  auto rate = createTimeUtil().getRate();
+  while (!controller->executeSinglePathCalled) {
+    rate->delayUntil(1_ms);
+  }
+
+  // Wait a little longer so we get into the path
+  rate->delayUntil(200_ms);
+
+  EXPECT_GT(leftMotor->lastVelocity, 0);
+  EXPECT_GT(rightMotor->lastVelocity, 0);
+  EXPECT_GT(leftMotor->maxVelocity, rightMotor->maxVelocity);
+
+  // Disable the controller so gtest doesn't clean up the test fixture while the internal thread is
+  // still running
+  controller->flipDisable(true);
+}


### PR DESCRIPTION
### Description of the Change

This PR adds a flag to `AMPC::setTarget()` to follow paths mirrored.

### Benefits

:) | (:

### Possible Drawbacks

None.

### Verification Process

Tests were added.

### Applicable Issues
Closes #290.
