### PR TITLE
Fix Issue #298

### DIFF
--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -132,6 +132,7 @@ void IterativePosPIDController::setErrorSumLimits(const double imax, const doubl
 }
 
 double IterativePosPIDController::step(const double inewReading) {
+  const double readingDiff = inewReading - lastReading;
   lastReading = inewReading;
 
   if (controllerIsDisabled) {
@@ -154,7 +155,7 @@ double IterativePosPIDController::step(const double inewReading) {
       integral = std::clamp(integral, integralMin, integralMax);
 
       // Derivative over measurement to eliminate derivative kick on setpoint change
-      derivative = derivativeFilter->filter(inewReading - lastReading);
+      derivative = derivativeFilter->filter(readingDiff);
 
       output = std::clamp(kP * error + integral - kD * derivative + kBias, outputMin, outputMax);
 

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -140,7 +140,7 @@ TEST_F(IterativePosPIDControllerTest, SampleTime) {
 }
 
 TEST_F(IterativePosPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
-  controller->setGains(0, 0, 1);
+  controller->setGains(0, 0, 1, 0);
   EXPECT_EQ(controller->step(1), -0.01);
   EXPECT_EQ(controller->step(1), 0);
   EXPECT_EQ(controller->step(2), -0.01);

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -138,3 +138,11 @@ TEST_F(IterativePosPIDControllerTest, SampleTime) {
   // 20_ms
   EXPECT_EQ(controller->step(-1), 0);
 }
+
+TEST_F(IterativePosPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
+  controller->setGains(0, 0, 1);
+  EXPECT_EQ(controller->step(1), -0.01);
+  EXPECT_EQ(controller->step(1), 0);
+  EXPECT_EQ(controller->step(2), -0.01);
+  EXPECT_EQ(controller->step(2), 0);
+}

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -139,3 +139,11 @@ TEST_F(IterativeVelPIDControllerTest, ControllerSetWithModifiedTargetLimits) {
   controller->controllerSet(0.5);
   EXPECT_EQ(controller->getTarget(), 7.5);
 }
+
+TEST_F(IterativeVelPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
+  controller->setGains(0, 1, 0, 0);
+  EXPECT_NEAR(controller->step(1), -0.349, 0.0001);
+  EXPECT_EQ(controller->step(1), 0);
+  EXPECT_NEAR(controller->step(2), -0.349, 0.0001);
+  EXPECT_EQ(controller->step(2), 0);
+}


### PR DESCRIPTION
### Description of the Change

`IterativePosPIDController` wrote to `lastReading` before calculating the derivative error term, which caused the term to always equal zero. This PR introduces an additional term, `readingDiff`, which is calculated before writing to `lastReading`.

### Benefits

Fixes #298.

### Possible Drawbacks

None.

### Verification Process

New tests were added.

### Applicable Issues

Closes #298.
