### PR TITLE
Reset middle sensor in ThreeEncoderSkidSteerModel

### DIFF
--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -37,6 +37,13 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
    */
   std::valarray<std::int32_t> getSensorVals() const override;
 
+
+  /**
+   * Reset the sensors to their zero point.
+   */
+  void resetSensors() const override;
+  
+
   protected:
   std::shared_ptr<ContinuousRotarySensor> middleSensor;
 };

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -26,4 +26,11 @@ std::valarray<std::int32_t> ThreeEncoderSkidSteerModel::getSensorVals() const {
                                      static_cast<std::int32_t>(rightSensor->get()),
                                      static_cast<std::int32_t>(middleSensor->get())};
 }
+
+void ThreeEncoderSkidSteerModel::resetSensors() const {
+  leftSensor->reset();
+  rightSensor->reset();
+  middleSensor->reset();
+}
+
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR overrides `resetSensors()` in `ThreeEncoderSkidSteerModel` so it can reset `middleSensor`.

### Benefits

Proper API behavior.

### Possible Drawbacks

None.

### Verification Process

A test was added.

### Applicable Issues

Closes #306.
