### PR TITLE
Fix CCPID turns

### DIFF
--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -85,7 +85,7 @@ void ChassisControllerPID::loop() {
 
       case angle:
         encVals = model->getSensorVals() - encStartVals;
-        angleChange = static_cast<double>(encVals[0] - encVals[1]);
+        angleChange = (encVals[0] - encVals[1]) / 2.0;
         model->rotate(turnPid->step(angleChange));
         break;
 


### PR DESCRIPTION
### Description of the Change

This PR fixes a bug where CCPID turns half as much as it should. It now turns as much as CCI does.

### Benefits

Accurate turns.

### Possible Drawbacks

This is a silent breaking change.

### Verification Process

Tested manually.

### Applicable Issues

Closes #313.
