### PR TITLE
Change the default Motor gearset to green

### DIFF
--- a/include/okapi/impl/device/motor/motor.hpp
+++ b/include/okapi/impl/device/motor/motor.hpp
@@ -539,7 +539,7 @@ class Motor : public AbstractMotor, public pros::Motor {
   virtual void controllerSet(double ivalue) override;
 
   protected:
-  AbstractMotor::gearset gearset;
+  AbstractMotor::gearset gearset{AbstractMotor::gearset::green};
 };
 
 inline namespace literals {

--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -12,7 +12,7 @@
 
 namespace okapi {
 Motor::Motor(const std::int8_t iport)
-  : Motor(std::abs(iport), iport < 0, AbstractMotor::gearset::red) {
+  : Motor(std::abs(iport), iport < 0, AbstractMotor::gearset::green) {
 }
 
 Motor::Motor(const std::uint8_t iport,


### PR DESCRIPTION
### Description of the Change

This PR changes the default Motor gearset to green.

### Benefits

The default gearset now matches what people get in their motors.

### Possible Drawbacks

This is a silent breaking change for users using the default gearset.

### Verification Process

This was not verified.

### Applicable Issues

Closes #312.
