### PR TITLE
Override resetSensors in ThreeEncoderSkidSteerModel

### DIFF
--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -37,6 +37,11 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
    */
   std::valarray<std::int32_t> getSensorVals() const override;
 
+  /**
+   * Reset the sensors to their zero point.
+   */
+  void resetSensors() const override;
+
   protected:
   std::shared_ptr<ContinuousRotarySensor> middleSensor;
 };

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -26,4 +26,9 @@ std::valarray<std::int32_t> ThreeEncoderSkidSteerModel::getSensorVals() const {
                                      static_cast<std::int32_t>(rightSensor->get()),
                                      static_cast<std::int32_t>(middleSensor->get())};
 }
+
+void ThreeEncoderSkidSteerModel::resetSensors() const {
+  SkidSteerModel::resetSensors();
+  middleSensor->reset();
+}
 } // namespace okapi

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -13,7 +13,7 @@ using namespace okapi;
 
 class SkidSteerModelTest : public ::testing::Test {
   public:
-  SkidSteerModelTest() : model(leftMotor, rightMotor, 127) {
+  SkidSteerModelTest() : model(leftMotor, rightMotor, leftSensor, rightSensor, 127) {
   }
 
   void assertAllMotorsLastVelocity(const std::int16_t expectedLastVelocity) const {
@@ -40,6 +40,10 @@ class SkidSteerModelTest : public ::testing::Test {
 
   std::shared_ptr<MockMotor> leftMotor = std::make_shared<MockMotor>();
   std::shared_ptr<MockMotor> rightMotor = std::make_shared<MockMotor>();
+  std::shared_ptr<MockContinuousRotarySensor> leftSensor =
+    std::make_shared<MockContinuousRotarySensor>();
+  std::shared_ptr<MockContinuousRotarySensor> rightSensor =
+    std::make_shared<MockContinuousRotarySensor>();
   SkidSteerModel model;
 };
 
@@ -184,4 +188,14 @@ TEST_F(SkidSteerModelTest, GetLeftSideMotor) {
 
 TEST_F(SkidSteerModelTest, GetRightSideMotor) {
   EXPECT_EQ(model.getRightSideMotor().get(), rightMotor.get());
+}
+
+TEST_F(SkidSteerModelTest, Reset) {
+  leftSensor->value = 1;
+  rightSensor->value = 1;
+
+  model.resetSensors();
+
+  EXPECT_EQ(leftSensor->get(), 0);
+  EXPECT_EQ(rightSensor->get(), 0);
 }

--- a/test/threeEncoderSkidSteerModelTests.cpp
+++ b/test/threeEncoderSkidSteerModelTests.cpp
@@ -63,3 +63,15 @@ TEST_F(ThreeEncoderSkidSteerModelTest, GetSensorValsIsCompatibleWithXDriveModel)
   EXPECT_EQ(xDriveModelVals[0], threeEncoderSkidSteerModelVals[0]);
   EXPECT_EQ(xDriveModelVals[1], threeEncoderSkidSteerModelVals[1]);
 }
+
+TEST_F(ThreeEncoderSkidSteerModelTest, Reset) {
+  leftSensor->value = 1;
+  rightSensor->value = 1;
+  middleSensor->value = 1;
+
+  model->resetSensors();
+
+  EXPECT_EQ(leftSensor->get(), 0);
+  EXPECT_EQ(rightSensor->get(), 0);
+  EXPECT_EQ(middleSensor->get(), 0);
+}

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -13,7 +13,14 @@ using namespace okapi;
 
 class XDriveModelTest : public ::testing::Test {
   public:
-  XDriveModelTest() : model(topLeftMotor, topRightMotor, bottomRightMotor, bottomLeftMotor, 127) {
+  XDriveModelTest()
+    : model(topLeftMotor,
+            topRightMotor,
+            bottomRightMotor,
+            bottomLeftMotor,
+            leftSensor,
+            rightSensor,
+            127) {
   }
 
   void assertAllMotorsLastVelocity(const std::int16_t expectedLastVelocity) const {
@@ -50,6 +57,10 @@ class XDriveModelTest : public ::testing::Test {
   std::shared_ptr<MockMotor> topRightMotor = std::make_shared<MockMotor>();
   std::shared_ptr<MockMotor> bottomRightMotor = std::make_shared<MockMotor>();
   std::shared_ptr<MockMotor> bottomLeftMotor = std::make_shared<MockMotor>();
+  std::shared_ptr<MockContinuousRotarySensor> leftSensor =
+    std::make_shared<MockContinuousRotarySensor>();
+  std::shared_ptr<MockContinuousRotarySensor> rightSensor =
+    std::make_shared<MockContinuousRotarySensor>();
   XDriveModel model;
 };
 
@@ -307,4 +318,14 @@ TEST_F(XDriveModelTest, GetBottomLeftMotor) {
 
 TEST_F(XDriveModelTest, GetBottomRightMotor) {
   EXPECT_EQ(model.getBottomRightMotor().get(), bottomRightMotor.get());
+}
+
+TEST_F(XDriveModelTest, Reset) {
+  leftSensor->value = 1;
+  rightSensor->value = 1;
+
+  model.resetSensors();
+
+  EXPECT_EQ(leftSensor->get(), 0);
+  EXPECT_EQ(rightSensor->get(), 0);
 }


### PR DESCRIPTION
### Description of the Change

This PR overrides `resetSensors()` in `ThreeEncoderSkidSteerModel` so it resets its middle encoder.

### Benefits

`resetSensors()` will now work as expected.

### Possible Drawbacks

None.

### Verification Process

New tests were added.

### Applicable Issues

Closes #306.
