### PR TITLE
Fix `MotorGroup::controllerSet`

### DIFF
--- a/src/impl/device/motor/motorGroup.cpp
+++ b/src/impl/device/motor/motorGroup.cpp
@@ -240,7 +240,7 @@ std::int32_t MotorGroup::setVoltageLimit(const std::int32_t ilimit) const {
 
 void MotorGroup::controllerSet(const double ivalue) {
   for (auto &&elem : motors) {
-    elem.moveVelocity(ivalue);
+    elem.controllerSet(ivalue);
   }
 }
 


### PR DESCRIPTION
### Description of the Change

`MotorGroup::controllerSet` currently calls `moveVelocity`, which just moves the motor at +/- 1RPM. It should call `controllerSet` to get the value scaled by the gearset.

### Benefits

This code change will fix `MotorGroup`'s controllerSet so that controllers like the PIDTuner can use it as a controller output.

### Possible Drawbacks

Any code that relies on the bug's behavior will break.

### Verification Process

I have not verified the effects of this change.

### Applicable Issues

Closes #317.
