### PR TITLE
Fix #293 and add tests for it

### DIFF
--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -94,12 +94,12 @@ void SkidSteerModel::arcade(const double iforwardSpeed,
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
-  if (std::abs(forwardSpeed) < ithreshold) {
+  if (std::abs(forwardSpeed) <= ithreshold) {
     forwardSpeed = 0;
   }
 
   double yaw = std::clamp(iyaw, -1.0, 1.0);
-  if (std::abs(yaw) < ithreshold) {
+  if (std::abs(yaw) <= ithreshold) {
     yaw = 0;
   }
 

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -111,12 +111,12 @@ void XDriveModel::arcade(const double iforwardSpeed,
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
-  if (std::abs(forwardSpeed) < ithreshold) {
+  if (std::abs(forwardSpeed) <= ithreshold) {
     forwardSpeed = 0;
   }
 
   double yaw = std::clamp(iyaw, -1.0, 1.0);
-  if (std::abs(yaw) < ithreshold) {
+  if (std::abs(yaw) <= ithreshold) {
     yaw = 0;
   }
 

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -155,6 +155,13 @@ TEST_F(SkidSteerModelTest, ArcadeThresholds) {
   assertAllMotorsLastVoltage(0);
 }
 
+TEST_F(SkidSteerModelTest, ArcadeNegativeZero) {
+  model.arcade(-0.0, -1.0);
+  
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(-12000, 12000);
+}
+
 TEST_F(SkidSteerModelTest, SetMaxVelocity) {
   model.setMaxVelocity(2);
   model.forward(0.5);

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -174,6 +174,13 @@ TEST_F(XDriveModelTest, ArcadeThresholds) {
   assertAllMotorsLastVoltage(0);
 }
 
+TEST_F(XDriveModelTest, ArcadeNegativeZero) {
+  model.arcade(-0.0, -1.0);
+  
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(-12000, 12000);
+}
+
 TEST_F(XDriveModelTest, XArcadeHalfPowerForward) {
   model.xArcade(0, 0.5, 0);
 


### PR DESCRIPTION
### Description of the Change

Currently, when SkidSteerModel's `.arcade` is passed `(-0.0, -1.0)`, it goes backwards. This is not the expected behavior, turning counter-clockwise. This issue is caused by the ability of `std::copysign` to extract the raw sign bit of a `double` number. To fix this, I've changed the comparison of the inputs to the threshold from `<` to `<=`. This will catch -0, and set it to +0.

### Benefits

This will make `.arcade` properly when it's inputs are negated. This is useful for more complex operator control code, like our team's, which has a reverse button.

### Possible Drawbacks

Before, if you passed 0.5 as a threshold, and 0.5 as an input, it would stay 0.5. This change will change that, and make it 0. I believe that this is fine, it is unlikely that this will affect anything in practice.

### Verification Process

I added a test to make sure that a negative 0 as the forward speed does not change the behavior of turning.

### Applicable Issues

Closes #293.
