### PR TITLE
Fix MotorGroup::controllerSet() method

### DIFF
--- a/src/impl/device/motor/motorGroup.cpp
+++ b/src/impl/device/motor/motorGroup.cpp
@@ -240,7 +240,7 @@ std::int32_t MotorGroup::setVoltageLimit(const std::int32_t ilimit) const {
 
 void MotorGroup::controllerSet(const double ivalue) {
   for (auto &&elem : motors) {
-    elem.moveVelocity(ivalue);
+    elem.controllerSet(ivalue);
   }
 }
 

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -30,7 +30,7 @@ MockMotor::MockMotor() : encoder(std::make_shared<MockContinuousRotarySensor>())
 }
 
 void MockMotor::controllerSet(const double ivalue) {
-  moveVelocity((int16_t)ivalue);
+  moveVelocity(ivalue * toUnderlyingType(gearset));
 }
 
 int32_t MockMotor::moveAbsolute(const double iposition, const std::int32_t ivelocity) const {


### PR DESCRIPTION
### Description of the Change

Fixed the implementation of `MotorGroup::controllerSet()` to call `controllerSet()` on its motors instead of `moveVelocity()` and `MockMotor::controllerSet()` to call `moveVelocity()` with a scaled value instead of directly.

### Benefits

`controllerSet()` and `moveVelocity()` are not equivalent calls: `controllerSet()`'s input should be in the range [-1, 1] and be scaled to the motor's velocity bounds, while `moveVelocity()` should be passed the raw velocity.

In particular, this fixes PID auto-tuning for groups of motors. Before this fix, the auto-tuner wouldn't properly work since it was feeding small values (from -1 to 1) into (effectively) `moveVelocity()` which just barely makes the wheels move.

### Possible Drawbacks

This may break existing code which relies on this bug (my team had some until we discovered the bug and got a better understanding of how controllers are supposed to work). As far as I can tell, no code inside OkapiLib will be broken by this change, since all calls to `controllerSet()` are  in generic uses (not specific to or ever applied to `MotorGroup` objects).

### Verification Process

There may be regressions in code within this library that I did not notice or in external code using this library. Tests should possibly be added / changed to test this feature. The `MockMotor` class also had this issue, and the tests all still pass after the change, so they were evidently not verifying the validity of the `controllerSet()` implementation.

### Applicable Issues

N/A