### PR TITLE
Derive ControllerInput<bool> for AbstractButton

### DIFF
--- a/include/okapi/api/device/button/abstractButton.hpp
+++ b/include/okapi/api/device/button/abstractButton.hpp
@@ -7,8 +7,10 @@
  */
 #pragma once
 
+#include "okapi/api/control/controllerInput.hpp"
+
 namespace okapi {
-class AbstractButton {
+class AbstractButton : public ControllerInput<bool> {
   public:
   virtual ~AbstractButton();
 
@@ -34,5 +36,13 @@ class AbstractButton {
    * method was called.
    **/
   virtual bool changedToReleased() = 0;
+
+  /**
+   * Get the sensor value for use in a control loop. This method might be automatically called in
+   * another thread by the controller.
+   *
+   * @return the current sensor value. This is the same as the output of the pressed() method.
+   */
+  virtual bool controllerGet() override;
 };
 } // namespace okapi

--- a/src/api/device/button/abstractButton.cpp
+++ b/src/api/device/button/abstractButton.cpp
@@ -2,4 +2,8 @@
 
 namespace okapi {
 AbstractButton::~AbstractButton() = default;
+
+bool AbstractButton::controllerGet() {
+  return isPressed();
 }
+} // namespace okapi


### PR DESCRIPTION
### Description of the Change

Buttons have a trivial implementation of `ControllerInput<bool>`: `isPressed()`. Adding this implementation allows using buttons (and limit switches, etc.) as inputs to motor controllers in user code.

### Benefits

This allows users of the library to create motor controllers which take boolean sensors as input.

### Possible Drawbacks

N/A

### Verification Process

The code is simple enough that it can be verified visually. This doesn't remove or change functionality, so it cannot introduce any regressions.

### Applicable Issues

N/A
