### PR TITLE
Add lazy logging

### DIFF
--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -70,7 +70,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * Sets the target for the controller.
    */
   void setTarget(const Input itarget) override {
-    logger->info("AsyncWrapper: Set target to " + std::to_string(itarget));
+    LOG_INFO("AsyncWrapper: Set target to " + std::to_string(itarget));
     hasFirstTarget = true;
     controller->setTarget(itarget * ratio);
     lastTarget = itarget;
@@ -174,7 +174,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * keeping any user-configured information.
    */
   void reset() override {
-    logger->info("AsyncWrapper: Reset");
+    LOG_INFO_S("AsyncWrapper: Reset");
     controller->reset();
     hasFirstTarget = false;
   }
@@ -184,7 +184,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * cause the controller to move to its last set target, unless it was reset in that time.
    */
   void flipDisable() override {
-    logger->info("AsyncWrapper: flipDisable " + std::to_string(!controller->isDisabled()));
+    LOG_INFO("AsyncWrapper: flipDisable " + std::to_string(!controller->isDisabled()));
     controller->flipDisable();
     resumeMovement();
   }
@@ -196,7 +196,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * @param iisDisabled whether the controller is disabled
    */
   void flipDisable(const bool iisDisabled) override {
-    logger->info("AsyncWrapper: flipDisable " + std::to_string(iisDisabled));
+    LOG_INFO("AsyncWrapper: flipDisable " + std::to_string(iisDisabled));
     controller->flipDisable(iisDisabled);
     resumeMovement();
   }
@@ -215,13 +215,13 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    * implementation-dependent.
    */
   void waitUntilSettled() override {
-    logger->info("AsyncWrapper: Waiting to settle");
+    LOG_INFO_S("AsyncWrapper: Waiting to settle");
 
     while (!isSettled()) {
       loopRate->delayUntil(motorUpdateRate);
     }
 
-    logger->info("AsyncWrapper: Done waiting to settle");
+    LOG_INFO_S("AsyncWrapper: Done waiting to settle");
   }
 
   /**

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -11,6 +11,18 @@
 #include "okapi/api/util/mathUtil.hpp"
 #include <memory>
 
+#define LOG_DEBUG(msg) logger->debug([&]() { return (msg).c_str(); })
+#define LOG_DEBUG_S(msg) logger->debug([&]() { return msg; })
+
+#define LOG_INFO(msg) logger->info([&]() { return (msg).c_str(); })
+#define LOG_INFO_S(msg) logger->info([&]() { return msg; })
+
+#define LOG_WARN(msg) logger->warn([&]() { return (msg).c_str(); })
+#define LOG_WARN_S(msg) logger->warn([&]() { return msg; })
+
+#define LOG_ERROR(msg) logger->error([&]() { return (msg).c_str(); })
+#define LOG_ERROR_S(msg) logger->error([&]() { return msg; })
+
 namespace okapi {
 class Logger {
   public:
@@ -57,12 +69,12 @@ class Logger {
     return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::debug);
   }
 
-  constexpr void debug(std::string_view message) const noexcept {
+  template <typename T> constexpr void debug(T ilazyMessage) const noexcept {
     if (isDebugLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld DEBUG: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
-              message.data());
+              ilazyMessage());
     }
   }
 
@@ -70,12 +82,12 @@ class Logger {
     return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info);
   }
 
-  constexpr void info(std::string_view message) const noexcept {
+  template <typename T> constexpr void info(T ilazyMessage) const noexcept {
     if (isInfoLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld INFO: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
-              message.data());
+              ilazyMessage());
     }
   }
 
@@ -83,12 +95,12 @@ class Logger {
     return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::warn);
   }
 
-  constexpr void warn(std::string_view message) const noexcept {
+  template <typename T> constexpr void warn(T ilazyMessage) const noexcept {
     if (isWarnLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld WARN: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
-              message.data());
+              ilazyMessage());
     }
   }
 
@@ -96,19 +108,19 @@ class Logger {
     return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::error);
   }
 
-  constexpr void error(std::string_view message) const noexcept {
+  template <typename T> constexpr void error(T ilazyMessage) const noexcept {
     if (isErrorLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld ERROR: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
-              message.data());
+              ilazyMessage());
     }
   }
 
   /**
    * Closes the connection to the log file.
    */
-  void close() noexcept {
+  constexpr void close() noexcept {
     if (logfile) {
       fclose(logfile);
       logfile = nullptr;
@@ -116,8 +128,8 @@ class Logger {
   }
 
   private:
-  std::unique_ptr<AbstractTimer> timer;
+  const std::unique_ptr<AbstractTimer> timer;
   FILE *logfile;
-  LogLevel logLevel;
+  const LogLevel logLevel;
 };
 } // namespace okapi

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -53,8 +53,12 @@ class Logger {
     }
   }
 
+  constexpr bool isDebugLevelEnabled() const noexcept {
+    return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::debug);
+  }
+
   constexpr void debug(std::string_view message) const noexcept {
-    if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info) && logfile && timer) {
+    if (isDebugLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld DEBUG: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
@@ -62,8 +66,12 @@ class Logger {
     }
   }
 
+  constexpr bool isInfoLevelEnabled() const noexcept {
+    return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info);
+  }
+
   constexpr void info(std::string_view message) const noexcept {
-    if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::info) && logfile && timer) {
+    if (isInfoLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld INFO: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
@@ -71,8 +79,12 @@ class Logger {
     }
   }
 
+  constexpr bool isWarnLevelEnabled() const noexcept {
+    return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::warn);
+  }
+
   constexpr void warn(std::string_view message) const noexcept {
-    if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::warn) && logfile && timer) {
+    if (isWarnLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld WARN: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
@@ -80,8 +92,12 @@ class Logger {
     }
   }
 
+  constexpr bool isErrorLevelEnabled() const noexcept {
+    return toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::error);
+  }
+
   constexpr void error(std::string_view message) const noexcept {
-    if (toUnderlyingType(logLevel) >= toUnderlyingType(LogLevel::error) && logfile && timer) {
+    if (isErrorLevelEnabled() && logfile && timer) {
       fprintf(logfile,
               "%ld ERROR: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -26,8 +26,8 @@ ChassisControllerIntegrated::ChassisControllerIntegrated(
     scales(iscales),
     gearsetRatioPair(igearset) {
   if (igearset.ratio == 0) {
-    logger->error("ChassisControllerIntegrated: The gear ratio cannot be zero! Check if you are "
-                  "using integer division.");
+    LOG_ERROR_S("ChassisControllerIntegrated: The gear ratio cannot be zero! Check if you are "
+                "using integer division.");
     throw std::invalid_argument("ChassisControllerIntegrated: The gear ratio cannot be zero! Check "
                                 "if you are using integer division.");
   }
@@ -47,8 +47,8 @@ void ChassisControllerIntegrated::moveDistance(const double itarget) {
 }
 
 void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
-  logger->info("ChassisControllerIntegrated: moving " + std::to_string(itarget.convert(meter)) +
-               " meters");
+  LOG_INFO("ChassisControllerIntegrated: moving " + std::to_string(itarget.convert(meter)) +
+           " meters");
 
   leftController->reset();
   rightController->reset();
@@ -57,8 +57,7 @@ void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
 
   const double newTarget = itarget.convert(meter) * scales.straight * gearsetRatioPair.ratio;
 
-  logger->info("ChassisControllerIntegrated: moving " + std::to_string(newTarget) +
-               " motor degrees");
+  LOG_INFO("ChassisControllerIntegrated: moving " + std::to_string(newTarget) + " motor degrees");
 
   const auto enc = model->getSensorVals();
   leftController->setTarget(newTarget + enc[0]);
@@ -81,8 +80,8 @@ void ChassisControllerIntegrated::turnAngle(const double idegTarget) {
 }
 
 void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
-  logger->info("ChassisControllerIntegrated: turning " +
-               std::to_string(idegTarget.convert(degree)) + " degrees");
+  LOG_INFO("ChassisControllerIntegrated: turning " + std::to_string(idegTarget.convert(degree)) +
+           " degrees");
 
   leftController->reset();
   rightController->reset();
@@ -92,8 +91,7 @@ void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
   const double newTarget =
     idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
 
-  logger->info("ChassisControllerIntegrated: turning " + std::to_string(newTarget) +
-               " motor degrees");
+  LOG_INFO("ChassisControllerIntegrated: turning " + std::to_string(newTarget) + " motor degrees");
 
   const auto enc = model->getSensorVals();
   leftController->setTarget(newTarget + enc[0]);
@@ -106,7 +104,8 @@ void ChassisControllerIntegrated::turnAngleAsync(const double idegTarget) {
 }
 
 void ChassisControllerIntegrated::waitUntilSettled() {
-  logger->info("ChassisControllerIntegrated: Waiting to settle");
+  LOG_INFO_S("ChassisControllerIntegrated: Waiting to settle");
+
   while (!(leftController->isSettled() && rightController->isSettled())) {
     rate->delayUntil(10_ms);
   }
@@ -115,7 +114,7 @@ void ChassisControllerIntegrated::waitUntilSettled() {
   rightController->flipDisable(true);
   model->stop();
 
-  logger->info("ChassisControllerIntegrated: Done waiting to settle");
+  LOG_INFO_S("ChassisControllerIntegrated: Done waiting to settle");
 }
 
 void ChassisControllerIntegrated::stop() {

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -29,8 +29,8 @@ ChassisControllerPID::ChassisControllerPID(
     scales(iscales),
     gearsetRatioPair(igearset) {
   if (igearset.ratio == 0) {
-    logger->error("ChassisControllerPID: The gear ratio cannot be zero! Check if you are using "
-                  "integer division.");
+    LOG_ERROR_S("ChassisControllerPID: The gear ratio cannot be zero! Check if you are using "
+                "integer division.");
     throw std::invalid_argument("ChassisControllerPID: The gear ratio cannot be zero! Check if you "
                                 "are using integer division.");
   }
@@ -111,8 +111,7 @@ void ChassisControllerPID::trampoline(void *context) {
 }
 
 void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
-  logger->info("ChassisControllerPID: moving " + std::to_string(itarget.convert(meter)) +
-               " meters");
+  LOG_INFO("ChassisControllerPID: moving " + std::to_string(itarget.convert(meter)) + " meters");
 
   distancePid->reset();
   anglePid->reset();
@@ -123,7 +122,7 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
 
   const double newTarget = itarget.convert(meter) * scales.straight * gearsetRatioPair.ratio;
 
-  logger->info("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor degrees");
+  LOG_INFO("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor degrees");
 
   distancePid->setTarget(newTarget);
   anglePid->setTarget(0);
@@ -148,8 +147,8 @@ void ChassisControllerPID::moveDistance(const double itarget) {
 }
 
 void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
-  logger->info("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
-               " degrees");
+  LOG_INFO("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
+           " degrees");
 
   turnPid->reset();
   turnPid->flipDisable(false);
@@ -160,7 +159,7 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   const double newTarget =
     idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
 
-  logger->info("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
+  LOG_INFO("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor degrees");
 
   turnPid->setTarget(newTarget);
 
@@ -184,7 +183,8 @@ void ChassisControllerPID::turnAngle(const double idegTarget) {
 }
 
 void ChassisControllerPID::waitUntilSettled() {
-  logger->info("ChassisControllerPID: Waiting to settle");
+  LOG_INFO_S("ChassisControllerPID: Waiting to settle");
+
   bool completelySettled = false;
 
   while (!completelySettled) {
@@ -215,7 +215,8 @@ void ChassisControllerPID::waitUntilSettled() {
 
   // Stop after the thread has run at least once
   stopAfterSettled();
-  logger->info("ChassisControllerPID: Done waiting to settle");
+
+  LOG_INFO_S("ChassisControllerPID: Done waiting to settle");
 }
 
 /**
@@ -224,12 +225,12 @@ void ChassisControllerPID::waitUntilSettled() {
  * @return true if done settling; false if settling should be tried again
  */
 bool ChassisControllerPID::waitForDistanceSettled() {
-  logger->info("ChassisControllerPID: Waiting to settle in distance mode");
+  LOG_INFO_S("ChassisControllerPID: Waiting to settle in distance mode");
 
   while (!(distancePid->isSettled() && anglePid->isSettled())) {
     if (mode == angle) {
       // False will cause the loop to re-enter the switch
-      logger->warn("ChassisControllerPID: Mode changed to angle while waiting in distance!");
+      LOG_WARN_S("ChassisControllerPID: Mode changed to angle while waiting in distance!");
       return false;
     }
 
@@ -246,12 +247,12 @@ bool ChassisControllerPID::waitForDistanceSettled() {
  * @return true if done settling; false if settling should be tried again
  */
 bool ChassisControllerPID::waitForAngleSettled() {
-  logger->info("ChassisControllerPID: Waiting to settle in angle mode");
+  LOG_INFO_S("ChassisControllerPID: Waiting to settle in angle mode");
 
   while (!turnPid->isSettled()) {
     if (mode == distance) {
       // False will cause the loop to re-enter the switch
-      logger->warn("ChassisControllerPID: Mode changed to distance while waiting in angle!");
+      LOG_WARN_S("ChassisControllerPID: Mode changed to distance while waiting in angle!");
       return false;
     }
 

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -56,8 +56,8 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
                                                       const std::string &ipathId) {
   if (iwaypoints.size() == 0) {
     // No point in generating a path
-    logger->warn(
-      "AsyncLinearMotionProfileController: Not generating a path because no waypoints were given.");
+    LOG_WARN_S("AsyncLinearMotionProfileController: Not generating a path because no waypoints were"
+               " given.");
     return;
   }
 
@@ -67,8 +67,9 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
     points.push_back(Waypoint{point.convert(meter), 0, 0});
   }
 
+  LOG_INFO_S("AsyncLinearMotionProfileController: Preparing trajectory");
+
   TrajectoryCandidate candidate;
-  logger->info("AsyncLinearMotionProfileController: Preparing trajectory");
   pathfinder_prepare(points.data(),
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
@@ -95,8 +96,6 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
                       pointToString(points.at(0)),
                       [&](std::string a, Waypoint b) { return a + ", " + pointToString(b); });
 
-    logger->error(message);
-
     if (candidate.laptr) {
       free(candidate.laptr);
     }
@@ -105,6 +104,7 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
       free(candidate.saptr);
     }
 
+    LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
@@ -114,7 +114,6 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
     std::string message =
       "AsyncLinearMotionProfileController: Could not allocate trajectory. The path (length " +
       std::to_string(length) + ") is probably impossible.";
-    logger->error(message);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -124,18 +123,21 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
       free(candidate.saptr);
     }
 
+    LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
-  logger->info("AsyncLinearMotionProfileController: Generating path");
+  LOG_INFO_S("AsyncLinearMotionProfileController: Generating path");
+
   pathfinder_generate(&candidate, trajectory);
 
   // Free the old path before overwriting it
   removePath(ipathId);
 
   paths.emplace(ipathId, TrajectoryPair{trajectory, length});
-  logger->info("AsyncLinearMotionProfileController: Completely done generating path");
-  logger->info("AsyncLinearMotionProfileController: Path length: " + std::to_string(length));
+
+  LOG_INFO_S("AsyncLinearMotionProfileController: Completely done generating path");
+  LOG_INFO("AsyncLinearMotionProfileController: Path length: " + std::to_string(length));
 }
 
 void AsyncLinearMotionProfileController::removePath(const std::string &ipathId) {
@@ -183,21 +185,22 @@ void AsyncLinearMotionProfileController::loop() {
 
   while (!dtorCalled.load(std::memory_order_acquire)) {
     if (isRunning.load(std::memory_order_acquire) && !isDisabled()) {
-      logger->info("AsyncLinearMotionProfileController: Running with path: " + currentPath);
+      LOG_INFO("AsyncLinearMotionProfileController: Running with path: " + currentPath);
+
       auto path = paths.find(currentPath);
 
       if (path == paths.end()) {
-        logger->warn(
+        LOG_WARN(
           "AsyncLinearMotionProfileController: Target was set to non-existent path with name: " +
           currentPath);
       } else {
-        logger->debug("AsyncLinearMotionProfileController: Path length is " +
-                      std::to_string(path->second.length));
+        LOG_DEBUG("AsyncLinearMotionProfileController: Path length is " +
+                  std::to_string(path->second.length));
 
         executeSinglePath(path->second, timeUtil.getRate());
         output->controllerSet(0);
 
-        logger->info("AsyncLinearMotionProfileController: Done moving");
+        LOG_INFO_S("AsyncLinearMotionProfileController: Done moving");
       }
 
       isRunning.store(false, std::memory_order_release);
@@ -232,14 +235,14 @@ void AsyncLinearMotionProfileController::trampoline(void *context) {
 }
 
 void AsyncLinearMotionProfileController::waitUntilSettled() {
-  logger->info("AsyncLinearMotionProfileController: Waiting to settle");
+  LOG_INFO_S("AsyncLinearMotionProfileController: Waiting to settle");
 
   auto rate = timeUtil.getRate();
   while (!isSettled()) {
     rate->delayUntil(10_ms);
   }
 
-  logger->info("AsyncLinearMotionProfileController: Done waiting to settle");
+  LOG_INFO_S("AsyncLinearMotionProfileController: Done waiting to settle");
 }
 
 void AsyncLinearMotionProfileController::moveTo(const QLength &iposition,
@@ -282,7 +285,7 @@ void AsyncLinearMotionProfileController::flipDisable() {
 }
 
 void AsyncLinearMotionProfileController::flipDisable(const bool iisDisabled) {
-  logger->info("AsyncLinearMotionProfileController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("AsyncLinearMotionProfileController: flipDisable " + std::to_string(iisDisabled));
   disabled.store(iisDisabled, std::memory_order_release);
   // loop() will set the output to 0 when executeSinglePath() is done
   // the default implementation of executeSinglePath() breaks when disabled

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -24,8 +24,8 @@ AsyncMotionProfileController::AsyncMotionProfileController(
     pair(ipair),
     timeUtil(itimeUtil) {
   if (ipair.ratio == 0) {
-    logger->error("AsyncMotionProfileController: The gear ratio cannot be zero! Check if you are "
-                  "using integer division.");
+    LOG_ERROR_S("AsyncMotionProfileController: The gear ratio cannot be zero! Check if you are "
+                "using integer division.");
     throw std::invalid_argument(
       "AsyncMotionProfileController: The gear ratio cannot be zero! Check "
       "if you are using integer division.");
@@ -64,8 +64,9 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                                                 const std::string &ipathId) {
   if (iwaypoints.size() == 0) {
     // No point in generating a path
-    logger->warn(
+    LOG_WARN_S(
       "AsyncMotionProfileController: Not generating a path because no waypoints were given.");
+
     return;
   }
 
@@ -76,8 +77,9 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
       Waypoint{point.x.convert(meter), point.y.convert(meter), point.theta.convert(radian)});
   }
 
+  LOG_INFO_S("AsyncMotionProfileController: Preparing trajectory");
+
   TrajectoryCandidate candidate;
-  logger->info("AsyncMotionProfileController: Preparing trajectory");
   pathfinder_prepare(points.data(),
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
@@ -104,8 +106,6 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                       pointToString(points.at(0)),
                       [&](std::string a, Waypoint b) { return a + ", " + pointToString(b); });
 
-    logger->error(message);
-
     if (candidate.laptr) {
       free(candidate.laptr);
     }
@@ -114,6 +114,7 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
       free(candidate.saptr);
     }
 
+    LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
@@ -123,7 +124,6 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
     std::string message =
       "AsyncMotionProfileController: Could not allocate trajectory. The path (length " +
       std::to_string(length) + ") is probably impossible.";
-    logger->error(message);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -133,10 +133,12 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
       free(candidate.saptr);
     }
 
+    LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
-  logger->info("AsyncMotionProfileController: Generating path");
+  LOG_INFO_S("AsyncMotionProfileController: Generating path");
+
   pathfinder_generate(&candidate, trajectory);
 
   auto *leftTrajectory = (Segment *)malloc(sizeof(Segment) * length);
@@ -146,7 +148,6 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
     std::string message = "AsyncMotionProfileController: Could not allocate left and/or right "
                           "trajectories. The path (length " +
                           std::to_string(length) + ") is probably impossible.";
-    logger->error(message);
 
     if (leftTrajectory) {
       free(leftTrajectory);
@@ -160,10 +161,11 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
       free(trajectory);
     }
 
+    LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
-  logger->info("AsyncMotionProfileController: Modifying for tank drive");
+  LOG_INFO_S("AsyncMotionProfileController: Modifying for tank drive");
   pathfinder_modify_tank(
     trajectory, length, leftTrajectory, rightTrajectory, scales.wheelbaseWidth.convert(meter));
 
@@ -173,8 +175,9 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
   removePath(ipathId);
 
   paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, length});
-  logger->info("AsyncMotionProfileController: Completely done generating path");
-  logger->info("AsyncMotionProfileController: Path length: " + std::to_string(length));
+
+  LOG_INFO_S("AsyncMotionProfileController: Completely done generating path");
+  LOG_INFO("AsyncMotionProfileController: Path length: " + std::to_string(length));
 }
 
 void AsyncMotionProfileController::removePath(const std::string &ipathId) {
@@ -222,21 +225,20 @@ void AsyncMotionProfileController::loop() {
 
   while (!dtorCalled.load(std::memory_order_acquire)) {
     if (isRunning.load(std::memory_order_acquire) && !isDisabled()) {
-      logger->info("AsyncMotionProfileController: Running with path: " + currentPath);
-      auto path = paths.find(currentPath);
+      LOG_INFO("AsyncMotionProfileController: Running with path: " + currentPath);
 
+      auto path = paths.find(currentPath);
       if (path == paths.end()) {
-        logger->warn(
-          "AsyncMotionProfileController: Target was set to non-existent path with name: " +
-          currentPath);
+        LOG_WARN("AsyncMotionProfileController: Target was set to non-existent path with name: " +
+                 currentPath);
       } else {
-        logger->debug("AsyncMotionProfileController: Path length is " +
-                      std::to_string(path->second.length));
+        LOG_DEBUG("AsyncMotionProfileController: Path length is " +
+                  std::to_string(path->second.length));
 
         executeSinglePath(path->second, timeUtil.getRate());
         model->stop();
 
-        logger->info("AsyncMotionProfileController: Done moving");
+        LOG_INFO_S("AsyncMotionProfileController: Done moving");
       }
 
       isRunning.store(false, std::memory_order_release);
@@ -285,14 +287,14 @@ void AsyncMotionProfileController::trampoline(void *context) {
 }
 
 void AsyncMotionProfileController::waitUntilSettled() {
-  logger->info("AsyncMotionProfileController: Waiting to settle");
+  LOG_INFO_S("AsyncMotionProfileController: Waiting to settle");
 
   auto rate = timeUtil.getRate();
   while (!isSettled()) {
     rate->delayUntil(10_ms);
   }
 
-  logger->info("AsyncMotionProfileController: Done waiting to settle");
+  LOG_INFO_S("AsyncMotionProfileController: Done waiting to settle");
 }
 
 void AsyncMotionProfileController::moveTo(std::initializer_list<Point> iwaypoints,
@@ -330,7 +332,7 @@ void AsyncMotionProfileController::flipDisable() {
 }
 
 void AsyncMotionProfileController::flipDisable(const bool iisDisabled) {
-  logger->info("AsyncMotionProfileController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("AsyncMotionProfileController: flipDisable " + std::to_string(iisDisabled));
   disabled.store(iisDisabled, std::memory_order_release);
   // loop() will stop the chassis when executeSinglePath() is done
   // the default implementation of executeSinglePath() breaks when disabled

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -22,8 +22,8 @@ AsyncPosIntegratedController::AsyncPosIntegratedController(
     settledUtil(itimeUtil.getSettledUtil()),
     rate(itimeUtil.getRate()) {
   if (ipair.ratio == 0) {
-    logger->error("AsyncPosIntegratedController: The gear ratio cannot be zero! Check if you are "
-                  "using integer division.");
+    LOG_ERROR_S("AsyncPosIntegratedController: The gear ratio cannot be zero! Check if you are "
+                "using integer division.");
     throw std::invalid_argument("AsyncPosIntegratedController: The gear ratio cannot be zero! "
                                 "Check if you are using integer division.");
   }
@@ -32,7 +32,7 @@ AsyncPosIntegratedController::AsyncPosIntegratedController(
 }
 
 void AsyncPosIntegratedController::setTarget(const double itarget) {
-  logger->info("AsyncPosIntegratedController: Set target to " + std::to_string(itarget));
+  LOG_INFO("AsyncPosIntegratedController: Set target to " + std::to_string(itarget));
 
   hasFirstTarget = true;
 
@@ -56,7 +56,7 @@ bool AsyncPosIntegratedController::isSettled() {
 }
 
 void AsyncPosIntegratedController::reset() {
-  logger->info("AsyncPosIntegratedController: Reset");
+  LOG_INFO_S("AsyncPosIntegratedController: Reset");
   hasFirstTarget = false;
   settledUtil->reset();
 }
@@ -66,7 +66,7 @@ void AsyncPosIntegratedController::flipDisable() {
 }
 
 void AsyncPosIntegratedController::flipDisable(const bool iisDisabled) {
-  logger->info("AsyncPosIntegratedController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("AsyncPosIntegratedController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
   resumeMovement();
 }
@@ -86,13 +86,13 @@ void AsyncPosIntegratedController::resumeMovement() {
 }
 
 void AsyncPosIntegratedController::waitUntilSettled() {
-  logger->info("AsyncPosIntegratedController: Waiting to settle");
+  LOG_INFO_S("AsyncPosIntegratedController: Waiting to settle");
 
   while (!isSettled()) {
     rate->delayUntil(motorUpdateRate);
   }
 
-  logger->info("AsyncPosIntegratedController: Done waiting to settle");
+  LOG_INFO_S("AsyncPosIntegratedController: Done waiting to settle");
 }
 
 void AsyncPosIntegratedController::controllerSet(double ivalue) {

--- a/src/api/control/async/asyncVelIntegratedController.cpp
+++ b/src/api/control/async/asyncVelIntegratedController.cpp
@@ -22,8 +22,8 @@ AsyncVelIntegratedController::AsyncVelIntegratedController(
     settledUtil(itimeUtil.getSettledUtil()),
     rate(itimeUtil.getRate()) {
   if (ipair.ratio == 0) {
-    logger->error("AsyncVelIntegratedController: The gear ratio cannot be zero! Check if you are "
-                  "using integer division.");
+    LOG_ERROR_S("AsyncVelIntegratedController: The gear ratio cannot be zero! Check if you are "
+                "using integer division.");
     throw std::invalid_argument("AsyncVelIntegratedController: The gear ratio cannot be zero! "
                                 "Check if you are using integer division.");
   }
@@ -38,7 +38,7 @@ void AsyncVelIntegratedController::setTarget(const double itarget) {
     boundedTarget = maxVelocity;
   }
 
-  logger->info("AsyncVelIntegratedController: Set target to " + std::to_string(boundedTarget));
+  LOG_INFO("AsyncVelIntegratedController: Set target to " + std::to_string(boundedTarget));
 
   hasFirstTarget = true;
 
@@ -62,7 +62,7 @@ bool AsyncVelIntegratedController::isSettled() {
 }
 
 void AsyncVelIntegratedController::reset() {
-  logger->info("AsyncVelIntegratedController: Reset");
+  LOG_INFO_S("AsyncVelIntegratedController: Reset");
   hasFirstTarget = false;
   settledUtil->reset();
 }
@@ -72,7 +72,7 @@ void AsyncVelIntegratedController::flipDisable() {
 }
 
 void AsyncVelIntegratedController::flipDisable(const bool iisDisabled) {
-  logger->info("AsyncVelIntegratedController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("AsyncVelIntegratedController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
   resumeMovement();
 }
@@ -92,11 +92,13 @@ void AsyncVelIntegratedController::resumeMovement() {
 }
 
 void AsyncVelIntegratedController::waitUntilSettled() {
-  logger->info("AsyncVelIntegratedController: Waiting to settle");
+  LOG_INFO_S("AsyncVelIntegratedController: Waiting to settle");
+
   while (!isSettled()) {
     rate->delayUntil(motorUpdateRate);
   }
-  logger->info("AsyncVelIntegratedController: Done waiting to settle");
+
+  LOG_INFO_S("AsyncVelIntegratedController: Done waiting to settle");
 }
 
 void AsyncVelIntegratedController::controllerSet(double ivalue) {

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -45,7 +45,7 @@ IterativePosPIDController::IterativePosPIDController(const Gains &igains,
 }
 
 void IterativePosPIDController::setTarget(const double itarget) {
-  logger->info("IterativePosPIDController: Set target to " + std::to_string(itarget));
+  LOG_INFO("IterativePosPIDController: Set target to " + std::to_string(itarget));
   target = itarget;
 }
 
@@ -181,7 +181,8 @@ void IterativePosPIDController::setGains(const double ikP,
 }
 
 void IterativePosPIDController::reset() {
-  logger->info("IterativePosPIDController: Reset");
+  LOG_INFO_S("IterativePosPIDController: Reset");
+
   error = 0;
   lastError = 0;
   lastReading = 0;
@@ -199,7 +200,7 @@ void IterativePosPIDController::flipDisable() {
 }
 
 void IterativePosPIDController::flipDisable(const bool iisDisabled) {
-  logger->info("IterativePosPIDController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("IterativePosPIDController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
 }
 

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -106,7 +106,7 @@ double IterativeVelPIDController::step(const double inewReading) {
 }
 
 void IterativeVelPIDController::setTarget(const double itarget) {
-  logger->info("IterativeVelPIDController: Set target to " + std::to_string(itarget));
+  LOG_INFO("IterativeVelPIDController: Set target to " + std::to_string(itarget));
   target = itarget;
 }
 
@@ -139,7 +139,8 @@ bool IterativeVelPIDController::isSettled() {
 }
 
 void IterativeVelPIDController::reset() {
-  logger->info("IterativeVelPIDController: Reset");
+  LOG_INFO_S("IterativeVelPIDController: Reset");
+
   error = 0;
   outputSum = 0;
   output = 0;
@@ -151,7 +152,7 @@ void IterativeVelPIDController::flipDisable() {
 }
 
 void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
-  logger->info("IterativeVelPIDController: flipDisable " + std::to_string(iisDisabled));
+  LOG_INFO("IterativeVelPIDController: flipDisable " + std::to_string(iisDisabled));
   controllerIsDisabled = iisDisabled;
 }
 

--- a/src/api/control/util/pidTuner.cpp
+++ b/src/api/control/util/pidTuner.cpp
@@ -84,11 +84,12 @@ PIDTuner::Output PIDTuner::autotune() {
 
   // Run the optimization
   for (std::size_t iteration = 0; iteration < numIterations; iteration++) {
-    logger->info("PIDTuner: Iteration number " + std::to_string(iteration));
+    LOG_INFO("PIDTuner: Iteration number " + std::to_string(iteration));
+
     bool firstGoal = true;
 
     for (std::size_t particleIndex = 0; particleIndex < numParticles; particleIndex++) {
-      logger->info("PIDTuner: Particle number " + std::to_string(particleIndex));
+      LOG_INFO("PIDTuner: Particle number " + std::to_string(particleIndex));
 
       testController.setGains(particles.at(particleIndex).kP.pos,
                               particles.at(particleIndex).kI.pos,
@@ -128,7 +129,7 @@ PIDTuner::Output PIDTuner::autotune() {
 
       const double error = kSettle * settleTime.convert(millisecond) + kITAE * itae;
 
-      logger->info("PIDTuner: New error is " + std::to_string(error));
+      LOG_INFO("PIDTuner: New error is " + std::to_string(error));
 
       if (error < particles.at(particleIndex).bestError) {
         particles.at(particleIndex).kP.best = particles.at(particleIndex).kP.pos;

--- a/src/api/filter/velMath.cpp
+++ b/src/api/filter/velMath.cpp
@@ -23,8 +23,8 @@ VelMath::VelMath(const double iticksPerRev,
     loopDtTimer(std::move(iloopDtTimer)),
     filter(std::move(ifilter)) {
   if (iticksPerRev == 0) {
-    logger->error(
-      "VelMath: The ticks per revolution cannot be zero! Check if you are using integer division.");
+    LOG_ERROR_S("VelMath: The ticks per revolution cannot be zero! Check if you are using integer "
+                "division.");
     throw std::invalid_argument(
       "VelMath: The ticks per revolution cannot be zero! Check if you are using integer division.");
   }

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -163,7 +163,7 @@ ChassisControllerBuilder::withLogger(const std::shared_ptr<Logger> &ilogger) {
 
 std::shared_ptr<ChassisController> ChassisControllerBuilder::build() {
   if (!hasMotors) {
-    logger->error("ChassisControllerBuilder: No motors given.");
+    LOG_ERROR_S("ChassisControllerBuilder: No motors given.");
     throw std::runtime_error("ChassisControllerBuilder: No motors given.");
   }
 

--- a/src/impl/control/async/asyncMotionProfileControllerBuilder.cpp
+++ b/src/impl/control/async/asyncMotionProfileControllerBuilder.cpp
@@ -87,12 +87,12 @@ AsyncMotionProfileControllerBuilder::withLogger(const std::shared_ptr<Logger> &i
 std::shared_ptr<AsyncLinearMotionProfileController>
 AsyncMotionProfileControllerBuilder::buildLinearMotionProfileController() {
   if (!hasOutput) {
-    logger->error("AsyncMotionProfileControllerBuilder: No output given.");
+    LOG_ERROR_S("AsyncMotionProfileControllerBuilder: No output given.");
     throw std::runtime_error("AsyncMotionProfileControllerBuilder: No output given.");
   }
 
   if (!hasLimits) {
-    logger->error("AsyncMotionProfileControllerBuilder: No limits given.");
+    LOG_ERROR_S("AsyncMotionProfileControllerBuilder: No limits given.");
     throw std::runtime_error("AsyncMotionProfileControllerBuilder: No limits given.");
   }
 
@@ -105,12 +105,12 @@ AsyncMotionProfileControllerBuilder::buildLinearMotionProfileController() {
 std::shared_ptr<AsyncMotionProfileController>
 AsyncMotionProfileControllerBuilder::buildMotionProfileController() {
   if (!hasModel) {
-    logger->error("AsyncMotionProfileControllerBuilder: No model given.");
+    LOG_ERROR_S("AsyncMotionProfileControllerBuilder: No model given.");
     throw std::runtime_error("AsyncMotionProfileControllerBuilder: No model given.");
   }
 
   if (!hasLimits) {
-    logger->error("AsyncMotionProfileControllerBuilder: No limits given.");
+    LOG_ERROR_S("AsyncMotionProfileControllerBuilder: No limits given.");
     throw std::runtime_error("AsyncMotionProfileControllerBuilder: No limits given.");
   }
 

--- a/src/impl/control/async/asyncPosControllerBuilder.cpp
+++ b/src/impl/control/async/asyncPosControllerBuilder.cpp
@@ -98,7 +98,7 @@ AsyncPosControllerBuilder::withLogger(const std::shared_ptr<Logger> &ilogger) {
 
 std::shared_ptr<AsyncPositionController<double, double>> AsyncPosControllerBuilder::build() {
   if (!hasMotors) {
-    logger->error("AsyncPosControllerBuilder: No motors given.");
+    LOG_ERROR_S("AsyncPosControllerBuilder: No motors given.");
     throw std::runtime_error("AsyncPosControllerBuilder: No motors given.");
   }
 

--- a/src/impl/control/async/asyncVelControllerBuilder.cpp
+++ b/src/impl/control/async/asyncVelControllerBuilder.cpp
@@ -105,13 +105,13 @@ AsyncVelControllerBuilder::withLogger(const std::shared_ptr<Logger> &ilogger) {
 
 std::shared_ptr<AsyncVelocityController<double, double>> AsyncVelControllerBuilder::build() {
   if (!hasMotors) {
-    logger->error("AsyncVelControllerBuilder: No motors given.");
+    LOG_ERROR_S("AsyncVelControllerBuilder: No motors given.");
     throw std::runtime_error("AsyncVelControllerBuilder: No motors given.");
   }
 
   if (hasGains) {
     if (!hasVelMath) {
-      logger->error("AsyncVelControllerBuilder: No VelMath given.");
+      LOG_ERROR_S("AsyncVelControllerBuilder: No VelMath given.");
       throw std::runtime_error("AsyncVelControllerBuilder: No VelMath given.");
     }
 

--- a/src/impl/device/motor/motorGroup.cpp
+++ b/src/impl/device/motor/motorGroup.cpp
@@ -9,11 +9,11 @@
 
 namespace okapi {
 MotorGroup::MotorGroup(const std::initializer_list<Motor> &imotors,
-                       const std::shared_ptr<Logger> &ilogger)
+                       const std::shared_ptr<Logger> &logger)
   : motors(imotors) {
   if (motors.empty()) {
-    ilogger->error(
-      "MotorGroup: A MotorGroup must be created with at least one motor. No motors were given.");
+    LOG_ERROR_S("MotorGroup: A MotorGroup must be created with at least one motor. No motors were"
+                " given.");
     throw std::invalid_argument(
       "MotorGroup: A MotorGroup must be created with at least one motor. No motors were given.");
   }

--- a/src/test/allImplTests.cpp
+++ b/src/test/allImplTests.cpp
@@ -10,9 +10,9 @@
 #include "test/tests/impl/asyncMotionProfileControllerBuilderIntegrationTests.hpp"
 #include "test/tests/impl/asyncPosControllerBuilderIntegrationTests.hpp"
 #include "test/tests/impl/asyncPosIntegratedControllerTests.hpp"
-#include "test/tests/impl/chassisControllerPidTests.hpp"
 #include "test/tests/impl/asyncVelControllerBuilderIntegrationTests.hpp"
 #include "test/tests/impl/chassisControllerBuilderIntegrationTests.hpp"
+#include "test/tests/impl/chassisControllerPidTests.hpp"
 #include "test/tests/impl/controllerTests.hpp"
 #include "test/tests/impl/utilTests.hpp"
 

--- a/src/test/chassisControllerPidTests.cpp
+++ b/src/test/chassisControllerPidTests.cpp
@@ -15,7 +15,6 @@ void testWaitUntilSettledExitsProperly() {
   printf("Testing waitUntilSettled() exits properly\n");
   resetHardware();
 
-  const double power = 0.3;
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
                  .withGearset(MOTOR_GEARSET)

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -26,10 +26,10 @@ class LoggerTest : public ::testing::Test {
   }
 
   void logData(const std::shared_ptr<Logger> &ilogger) const {
-    ilogger->error("MSG");
-    ilogger->warn("MSG");
-    ilogger->info("MSG");
-    ilogger->debug("MSG");
+    LOG_ERROR_S("MSG");
+    LOG_WARN_S("MSG");
+    LOG_INFO_S("MSG");
+    LOG_DEBUG_S("MSG");
   }
 
   FILE *logFile;


### PR DESCRIPTION
### Description of the Change

This PR adds lazy logging using lambdas. Log messages are now inside lambdas so they can be evaluated only if the log level is turned on.

### Benefits

Log messages are no longer constructed regardless of whether that log level is turned on, so logging can be used more frequently.

### Possible Drawbacks

None.

### Verification Process

I sprinkled in some log statements to some integration tests, everything appears to work.

### Applicable Issues

Closes #324.
