### PR TITLE
Fix CCPID using the same Rate in multiple places

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -127,7 +127,6 @@ class ChassisControllerPID : public virtual ChassisController {
   protected:
   std::shared_ptr<Logger> logger;
   TimeUtil timeUtil;
-  std::unique_ptr<AbstractRate> rate;
   std::unique_ptr<IterativePosPIDController> distancePid;
   std::unique_ptr<IterativePosPIDController> turnPid;
   std::unique_ptr<IterativePosPIDController> anglePid;

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -126,8 +126,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   void moveTo(const QLength &iposition, const QLength &itarget, bool ibackwards = false);
 
   /**
-   * Returns the last error of the controller. Returns zero if there is no path currently being
-   * followed.
+   * Returns the last error of the controller. Does not update when disabled. Returns zero if there
+   * is no path currently being followed.
    *
    * @return the last error
    */

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -122,9 +122,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   moveTo(std::initializer_list<Point> iwaypoints, bool ibackwards = false, bool imirrored = false);
 
   /**
-   * Returns the last error of the controller. This implementation always returns zero since the
-   * robot is assumed to perfectly follow the path. Subclasses can override this to be more
-   * accurate using odometry information.
+   * Returns the last error of the controller. Does not update when disabled. This implementation
+   * always returns zero since the robot is assumed to perfectly follow the path. Subclasses can
+   * override this to be more accurate using odometry information.
    *
    * @return the last error
    */

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -48,7 +48,7 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
   double getTarget() override;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   double getError() const override;
 

--- a/include/okapi/api/control/async/asyncVelIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncVelIntegratedController.hpp
@@ -49,7 +49,7 @@ class AsyncVelIntegratedController : public AsyncVelocityController<double, doub
   double getTarget() override;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   double getError() const override;
 

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -103,7 +103,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   }
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   Output getError() const override {
     return controller->getError();

--- a/include/okapi/api/control/closedLoopController.hpp
+++ b/include/okapi/api/control/closedLoopController.hpp
@@ -37,7 +37,7 @@ class ClosedLoopController : public ControllerOutput<Input> {
   virtual Input getTarget() = 0;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    *
    * @return the last error
    */

--- a/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
+++ b/include/okapi/api/control/iterative/iterativeMotorVelocityController.hpp
@@ -70,7 +70,7 @@ class IterativeMotorVelocityController : public IterativeVelocityController<doub
   double getMinOutput() override;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   double getError() const override;
 

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -113,7 +113,7 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   double getMinOutput() override;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   double getError() const override;
 

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -97,7 +97,7 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   double getMinOutput() override;
 
   /**
-   * Returns the last error of the controller.
+   * Returns the last error of the controller. Does not update when disabled.
    */
   double getError() const override;
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -22,7 +22,6 @@ ChassisControllerPID::ChassisControllerPID(
   : ChassisController(imodel, toUnderlyingType(igearset.internalGearset)),
     logger(ilogger),
     timeUtil(itimeUtil),
-    rate(itimeUtil.getRate()),
     distancePid(std::move(idistanceController)),
     turnPid(std::move(iturnController)),
     anglePid(std::move(iangleController)),
@@ -43,7 +42,6 @@ ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcep
   : ChassisController(other.model, other.maxVelocity, other.maxVoltage),
     logger(std::move(other.logger)),
     timeUtil(other.timeUtil),
-    rate(std::move(other.rate)),
     distancePid(std::move(other.distancePid)),
     turnPid(std::move(other.turnPid)),
     anglePid(std::move(other.anglePid)),
@@ -67,6 +65,7 @@ void ChassisControllerPID::loop() {
   std::valarray<std::int32_t> encVals;
   double distanceElapsed = 0, angleChange = 0;
   modeType pastMode = none;
+  auto rate = timeUtil.getRate();
 
   while (!dtorCalled.load(std::memory_order_acquire)) {
     /**
@@ -230,6 +229,7 @@ void ChassisControllerPID::waitUntilSettled() {
 bool ChassisControllerPID::waitForDistanceSettled() {
   LOG_INFO_S("ChassisControllerPID: Waiting to settle in distance mode");
 
+  auto rate = timeUtil.getRate();
   while (!(distancePid->isSettled() && anglePid->isSettled())) {
     if (mode == angle) {
       // False will cause the loop to re-enter the switch
@@ -252,6 +252,7 @@ bool ChassisControllerPID::waitForDistanceSettled() {
 bool ChassisControllerPID::waitForAngleSettled() {
   LOG_INFO_S("ChassisControllerPID: Waiting to settle in angle mode");
 
+  auto rate = timeUtil.getRate();
   while (!turnPid->isSettled()) {
     if (mode == distance) {
       // False will cause the loop to re-enter the switch

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -132,8 +132,6 @@ void IterativePosPIDController::setErrorSumLimits(const double imax, const doubl
 }
 
 double IterativePosPIDController::step(const double inewReading) {
-  const double readingDiff = inewReading - lastReading;
-  lastReading = inewReading;
 
   if (controllerIsDisabled) {
     return 0;
@@ -141,6 +139,9 @@ double IterativePosPIDController::step(const double inewReading) {
     loopDtTimer->placeHardMark();
 
     if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
+      const double readingDiff = inewReading - lastReading;
+      lastReading = inewReading;
+
       error = getError();
 
       if ((std::abs(error) < target - errorSumMin && std::abs(error) > target - errorSumMax) ||

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -132,7 +132,6 @@ void IterativePosPIDController::setErrorSumLimits(const double imax, const doubl
 }
 
 double IterativePosPIDController::step(const double inewReading) {
-
   if (controllerIsDisabled) {
     return 0;
   } else {

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -76,14 +76,14 @@ QAngularSpeed IterativeVelPIDController::stepVel(const double inewReading) {
 }
 
 double IterativeVelPIDController::step(const double inewReading) {
-  if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
-    stepVel(inewReading);
-  }
-
   if (!controllerIsDisabled) {
     loopDtTimer->placeHardMark();
 
     if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
+      if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
+        stepVel(inewReading);
+      }
+
       error = getError();
 
       // Derivative over measurement to eliminate derivative kick on setpoint change

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -67,7 +67,7 @@ TEST_F(IterativePosPIDControllerTest, ScalesControllerSetTarget) {
   assertIterativeControllerScalesControllerSetTargets(*controller);
 }
 
-TEST_F(IterativePosPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
+TEST_F(IterativePosPIDControllerTest, DoesNotKeepTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getError(), 0);
   controller->flipDisable(true);
   EXPECT_TRUE(controller->isDisabled());
@@ -75,7 +75,7 @@ TEST_F(IterativePosPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getTarget(), 2);
   EXPECT_EQ(controller->step(1), 0);
   EXPECT_EQ(controller->getOutput(), 0);
-  EXPECT_EQ(controller->getError(), 1);
+  EXPECT_EQ(controller->getError(), 0);
 }
 
 TEST_F(IterativePosPIDControllerTest, SetIntegralLimitsWithCtorTest) {

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -75,7 +75,7 @@ TEST_F(IterativePosPIDControllerTest, DoesNotKeepTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getTarget(), 2);
   EXPECT_EQ(controller->step(1), 0);
   EXPECT_EQ(controller->getOutput(), 0);
-  EXPECT_EQ(controller->getError(), 0);
+  EXPECT_EQ(controller->getError(), 2);
 }
 
 TEST_F(IterativePosPIDControllerTest, SetIntegralLimitsWithCtorTest) {

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -58,7 +58,7 @@ TEST_F(IterativeVelPIDControllerTest, ScalesControllerSetTarget) {
   assertIterativeControllerScalesControllerSetTargets(*controller);
 }
 
-TEST_F(IterativeVelPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
+TEST_F(IterativeVelPIDControllerTest, DoesNotKeepTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getError(), 0);
   controller->flipDisable(true);
   EXPECT_TRUE(controller->isDisabled());
@@ -66,7 +66,7 @@ TEST_F(IterativeVelPIDControllerTest, KeepsTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getTarget(), 2);
   EXPECT_EQ(controller->step(1), 0);
   EXPECT_EQ(controller->getOutput(), 0);
-  EXPECT_NEAR(controller->getError(), -1, 0.5); // Velocity calculation gets a little weird here
+  EXPECT_EQ(controller->getError(), 0);
 }
 
 TEST_F(IterativeVelPIDControllerTest, StaticFrictionGainUsesTargetSign) {

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -66,7 +66,7 @@ TEST_F(IterativeVelPIDControllerTest, DoesNotKeepTrackOfReadingsWhenDisabled) {
   EXPECT_EQ(controller->getTarget(), 2);
   EXPECT_EQ(controller->step(1), 0);
   EXPECT_EQ(controller->getOutput(), 0);
-  EXPECT_EQ(controller->getError(), 0);
+  EXPECT_EQ(controller->getError(), 2);
 }
 
 TEST_F(IterativeVelPIDControllerTest, StaticFrictionGainUsesTargetSign) {


### PR DESCRIPTION
### Description of the Change

This PR fixes a bug which caused the IPPC derivative term to be zero most of the time, causing people to think the derivative term did not work. This symptom is a red herring. The real problem was that CCPID re-used `rate` in multiple places, causing some calls to `delayUntil` to not delay. This PR also fixes CCPID starving the LVGL task.

### Benefits

^ :)

### Possible Drawbacks

`getError()` no longer updates while disabled. This has been specified in the docs.

### Verification Process

This was verified by hand with a real robot.

### Applicable Issues

Closes #332.
