### PR TITLE
Fix setGains kD scale

### DIFF
--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -176,7 +176,7 @@ void IterativePosPIDController::setGains(const double ikP,
   const double sampleTimeSec = sampleTime.convert(second);
   kP = ikP;
   kI = ikI * sampleTimeSec;
-  kD = ikD * sampleTimeSec;
+  kD = ikD / sampleTimeSec;
   kBias = ikBias;
 }
 

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -141,8 +141,8 @@ TEST_F(IterativePosPIDControllerTest, SampleTime) {
 
 TEST_F(IterativePosPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
   controller->setGains(0, 0, 1, 0);
-  EXPECT_EQ(controller->step(1), -0.01);
+  EXPECT_EQ(controller->step(1), -1);
   EXPECT_EQ(controller->step(1), 0);
-  EXPECT_EQ(controller->step(2), -0.01);
+  EXPECT_EQ(controller->step(2), -1);
   EXPECT_EQ(controller->step(2), 0);
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes IPPC's `setGains` method scaling `kD` by multiplying by `sampleTime` instead of dividing by it.

### Benefits

`kD` scaling is fixed in IPPC.

### Possible Drawbacks

People will have to adjust their `kD` gains.

### Verification Process

The test for the derivative term was fixed.

### Applicable Issues

Closes #333.
