### PR TITLE
Add CCPID voltage mode

### DIFF
--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -104,7 +104,7 @@ class ChassisController : public ChassisModel {
    *
    * @param ipower motor power
    */
-  void forward(double ispeed) const override;
+  void forward(double ispeed) override;
 
   /**
    * Drive the robot in an arc (using open-loop control).
@@ -115,14 +115,25 @@ class ChassisController : public ChassisModel {
    * @param iforwardSpeed speed in the forward direction
    * @param iyaw speed around the vertical axis
    */
-  void driveVector(double iforwardSpeed, double iyaw) const override;
+  void driveVector(double iforwardSpeed, double iyaw) override;
+
+  /**
+   * Drive the robot in an arc. Uses voltage mode.
+   * The algorithm is (approximately):
+   *   leftPower = forwardSpeed + yaw
+   *   rightPower = forwardSpeed - yaw
+   *
+   * @param iforwadSpeed speed in the forward direction
+   * @param iyaw speed around the vertical axis
+   */
+  void driveVectorVoltage(double iforwardSpeed, double iyaw) override;
 
   /**
    * Turn the robot clockwise (using open-loop control).
    *
    * @param ipower motor power
    */
-  void rotate(double ispeed) const override;
+  void rotate(double ispeed) override;
 
   /**
    * Stop the robot (set all the motors to 0).
@@ -136,7 +147,7 @@ class ChassisController : public ChassisModel {
    * @param irightSpeed right side speed
    * @param ithreshold deadband on joystick values
    */
-  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) const override;
+  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) override;
 
   /**
    * Drive the robot with an arcade drive layout.
@@ -145,21 +156,21 @@ class ChassisController : public ChassisModel {
    * @param iyaw speed around the vertical axis
    * @param ithreshold deadband on joystick values
    */
-  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) const override;
+  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
    * Power the left side motors.
    *
    * @param ipower motor power
    */
-  void left(double ispeed) const override;
+  void left(double ispeed) override;
 
   /**
    * Power the right side motors.
    *
    * @param ipower motor power
    */
-  void right(double ispeed) const override;
+  void right(double ispeed) override;
 
   /**
    * Read the sensors.
@@ -171,28 +182,28 @@ class ChassisController : public ChassisModel {
   /**
    * Reset the sensors to their zero point.
    */
-  void resetSensors() const override;
+  void resetSensors() override;
 
   /**
    * Set the brake mode for each motor.
    *
    * @param mode new brake mode
    */
-  void setBrakeMode(AbstractMotor::brakeMode mode) const override;
+  void setBrakeMode(AbstractMotor::brakeMode mode) override;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  void setEncoderUnits(AbstractMotor::encoderUnits units) const override;
+  void setEncoderUnits(AbstractMotor::encoderUnits units) override;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  void setGearing(AbstractMotor::gearset gearset) const override;
+  void setGearing(AbstractMotor::gearset gearset) override;
 
   /**
    * Sets new PID constants.
@@ -202,7 +213,7 @@ class ChassisController : public ChassisModel {
    * @param ikI the integral constant
    * @param ikD the derivative constant
    */
-  void setPosPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setPosPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -223,7 +234,7 @@ class ChassisController : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Sets new PID constants.
@@ -233,7 +244,7 @@ class ChassisController : public ChassisModel {
    * @param ikI the integral constant
    * @param ikD the derivative constant
    */
-  void setVelPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setVelPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -254,7 +265,7 @@ class ChassisController : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Sets a new maximum velocity in RPM [0-600].

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -100,14 +100,14 @@ class ChassisController : public ChassisModel {
   virtual void waitUntilSettled() = 0;
 
   /**
-   * Drive the robot forwards (using open-loop control).
+   * Drive the robot forwards (using open-loop control). Uses velocity mode.
    *
    * @param ipower motor power
    */
   void forward(double ispeed) override;
 
   /**
-   * Drive the robot in an arc (using open-loop control).
+   * Drive the robot in an arc (using open-loop control). Uses velocity mode.
    * The algorithm is (approximately):
    *   leftPower = forwardSpeed + yaw
    *   rightPower = forwardSpeed - yaw
@@ -129,14 +129,14 @@ class ChassisController : public ChassisModel {
   void driveVectorVoltage(double iforwardSpeed, double iyaw) override;
 
   /**
-   * Turn the robot clockwise (using open-loop control).
+   * Turn the robot clockwise (using open-loop control). Uses velocity mode.
    *
    * @param ipower motor power
    */
   void rotate(double ispeed) override;
 
   /**
-   * Stop the robot (set all the motors to 0).
+   * Stop the robot (set all the motors to 0). Uses velocity mode.
    */
   void stop() override;
 
@@ -150,7 +150,7 @@ class ChassisController : public ChassisModel {
   void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) override;
 
   /**
-   * Drive the robot with an arcade drive layout.
+   * Drive the robot with an arcade drive layout. Uses voltage mode.
    *
    * @param iforwardSpeed speed in the forward direction
    * @param iyaw speed around the vertical axis
@@ -159,14 +159,14 @@ class ChassisController : public ChassisModel {
   void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
-   * Power the left side motors.
+   * Power the left side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */
   void left(double ispeed) override;
 
   /**
-   * Power the right side motors.
+   * Power the right side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -104,7 +104,7 @@ class ChassisControllerPID : public virtual ChassisController {
   void waitUntilSettled() override;
 
   /**
-   * Stop the robot (set all the motors to 0 and stops the PID controllers).
+   * Stops the robot (set all the motors to 0 and stops the PID controllers).
    */
   void stop() override;
 
@@ -115,14 +115,24 @@ class ChassisControllerPID : public virtual ChassisController {
   void startThread();
 
   /**
-   * Get the ChassisScales.
+   * Gets the ChassisScales.
    */
   ChassisScales getChassisScales() const override;
 
   /**
-   * Get the GearsetRatioPair.
+   * Gets the GearsetRatioPair.
    */
   AbstractMotor::GearsetRatioPair getGearsetRatioPair() const override;
+
+  /**
+   * Sets the velocity mode flag. When the controller is in velocity mode, the control loop will
+   * set motor velocities. When the controller is in voltage mode (ivelocityMode = false), the
+   * control loop will set motor voltages. Additionally, when the controller is in voltage mode,
+   * it will not obey maximum velocity limits.
+   *
+   * @param ivelocityMode Whether the controller should be in velocity or voltage mode.
+   */
+  void setVelocityMode(bool ivelocityMode);
 
   protected:
   std::shared_ptr<Logger> logger;
@@ -132,6 +142,7 @@ class ChassisControllerPID : public virtual ChassisController {
   std::unique_ptr<IterativePosPIDController> anglePid;
   ChassisScales scales;
   AbstractMotor::GearsetRatioPair gearsetRatioPair;
+  bool velocityMode{true};
   std::atomic_bool doneLooping{true};
   std::atomic_bool doneLoopingSeen{true};
   std::atomic_bool newMovement{false};

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -27,14 +27,14 @@ class ChassisModel : public ReadOnlyChassisModel {
   ChassisModel &operator=(const ChassisModel &) = delete;
 
   /**
-   * Drive the robot forwards (using open-loop control).
+   * Drive the robot forwards (using open-loop control). Uses velocity mode.
    *
    * @param ipower motor power
    */
-  virtual void forward(double ispeed) const = 0;
+  virtual void forward(double ispeed) = 0;
 
   /**
-   * Drive the robot in an arc (using open-loop control).
+   * Drive the robot in an arc (using open-loop control). Uses velocity mode.
    * The algorithm is (approximately):
    *   leftPower = forwardSpeed + yaw
    *   rightPower = forwardSpeed - yaw
@@ -42,17 +42,28 @@ class ChassisModel : public ReadOnlyChassisModel {
    * @param iforwadSpeed speed in the forward direction
    * @param iyaw speed around the vertical axis
    */
-  virtual void driveVector(double iforwardSpeed, double iyaw) const = 0;
+  virtual void driveVector(double iforwardSpeed, double iyaw) = 0;
 
   /**
-   * Turn the robot clockwise (using open-loop control).
+   * Drive the robot in an arc. Uses voltage mode.
+   * The algorithm is (approximately):
+   *   leftPower = forwardSpeed + yaw
+   *   rightPower = forwardSpeed - yaw
+   *
+   * @param iforwadSpeed speed in the forward direction
+   * @param iyaw speed around the vertical axis
+   */
+  virtual void driveVectorVoltage(double iforwardSpeed, double iyaw) = 0;
+
+  /**
+   * Turn the robot clockwise (using open-loop control). Uses velocity mode.
    *
    * @param ispeed motor power
    */
-  virtual void rotate(double ispeed) const = 0;
+  virtual void rotate(double ispeed) = 0;
 
   /**
-   * Stop the robot (set all the motors to 0).
+   * Stop the robot (set all the motors to 0). Uses velocity mode.
    */
   virtual void stop() = 0;
 
@@ -63,7 +74,7 @@ class ChassisModel : public ReadOnlyChassisModel {
    * @param irightSpeed right side speed
    * @param ithreshold deadband on joystick values
    */
-  virtual void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) const = 0;
+  virtual void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) = 0;
 
   /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
@@ -72,47 +83,47 @@ class ChassisModel : public ReadOnlyChassisModel {
    * @param iyaw speed around the vertical axis
    * @param ithreshold deadband on joystick values
    */
-  virtual void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) const = 0;
+  virtual void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) = 0;
 
   /**
-   * Power the left side motors.
+   * Power the left side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */
-  virtual void left(double ispeed) const = 0;
+  virtual void left(double ispeed) = 0;
 
   /**
-   * Power the right side motors.
+   * Power the right side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */
-  virtual void right(double ispeed) const = 0;
+  virtual void right(double ispeed) = 0;
 
   /**
    * Reset the sensors to their zero point.
    */
-  virtual void resetSensors() const = 0;
+  virtual void resetSensors() = 0;
 
   /**
    * Set the brake mode for each motor.
    *
    * @param mode new brake mode
    */
-  virtual void setBrakeMode(AbstractMotor::brakeMode mode) const = 0;
+  virtual void setBrakeMode(AbstractMotor::brakeMode mode) = 0;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  virtual void setEncoderUnits(AbstractMotor::encoderUnits units) const = 0;
+  virtual void setEncoderUnits(AbstractMotor::encoderUnits units) = 0;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  virtual void setGearing(AbstractMotor::gearset gearset) const = 0;
+  virtual void setGearing(AbstractMotor::gearset gearset) = 0;
 
   /**
    * Sets new PID constants.
@@ -122,7 +133,7 @@ class ChassisModel : public ReadOnlyChassisModel {
    * @param ikI the integral constant
    * @param ikD the derivative constant
    */
-  virtual void setPosPID(double ikF, double ikP, double ikI, double ikD) const = 0;
+  virtual void setPosPID(double ikF, double ikP, double ikI, double ikD) = 0;
 
   /**
    * Sets new PID constants.
@@ -143,7 +154,7 @@ class ChassisModel : public ReadOnlyChassisModel {
                              double ifilter,
                              double ilimit,
                              double ithreshold,
-                             double iloopSpeed) const = 0;
+                             double iloopSpeed) = 0;
 
   /**
    * Sets new PID constants.
@@ -153,7 +164,7 @@ class ChassisModel : public ReadOnlyChassisModel {
    * @param ikI the integral constant
    * @param ikD the derivative constant
    */
-  virtual void setVelPID(double ikF, double ikP, double ikI, double ikD) const = 0;
+  virtual void setVelPID(double ikF, double ikP, double ikI, double ikD) = 0;
 
   /**
    * Sets new PID constants.
@@ -174,7 +185,7 @@ class ChassisModel : public ReadOnlyChassisModel {
                              double ifilter,
                              double ilimit,
                              double ithreshold,
-                             double iloopSpeed) const = 0;
+                             double iloopSpeed) = 0;
 
   /**
    * Sets a new maximum velocity in RPM [0-600].

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -50,7 +50,7 @@ class SkidSteerModel : public ChassisModel {
    *
    * @param ispeed motor power
    */
-  void forward(double ispeed) const override;
+  void forward(double ispeed) override;
 
   /**
    * Drive the robot in an arc (using open-loop control). Uses velocity mode.
@@ -61,14 +61,25 @@ class SkidSteerModel : public ChassisModel {
    * @param iySpeed speed on y axis (forward)
    * @param izRotation speed around z axis (up)
    */
-  void driveVector(double iySpeed, double izRotation) const override;
+  void driveVector(double iySpeed, double izRotation) override;
+
+  /**
+   * Drive the robot in an arc. Uses voltage mode.
+   * The algorithm is (approximately):
+   *   leftPower = forwardSpeed + yaw
+   *   rightPower = forwardSpeed - yaw
+   *
+   * @param iforwadSpeed speed in the forward direction
+   * @param iyaw speed around the vertical axis
+   */
+  void driveVectorVoltage(double iforwardSpeed, double iyaw) override;
 
   /**
    * Turn the robot clockwise (using open-loop control). Uses velocity mode.
    *
    * @param ispeed motor power
    */
-  void rotate(double ispeed) const override;
+  void rotate(double ispeed) override;
 
   /**
    * Stop the robot (set all the motors to 0). Uses velocity mode.
@@ -82,7 +93,7 @@ class SkidSteerModel : public ChassisModel {
    * @param irightSpeed right side speed
    * @param ithreshold deadband on joystick values
    */
-  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) const override;
+  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) override;
 
   /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
@@ -91,21 +102,21 @@ class SkidSteerModel : public ChassisModel {
    * @param iyaw speed around the vertical axis
    * @param ithreshold deadband on joystick values
    */
-  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) const override;
+  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
    * Power the left side motors. Uses velocity mode.
    *
    * @param ispeed motor power
    */
-  void left(double ispeed) const override;
+  void left(double ispeed) override;
 
   /**
    * Power the right side motors. Uses velocity mode.
    *
    * @param ispeed motor power
    */
-  void right(double ispeed) const override;
+  void right(double ispeed) override;
 
   /**
    * Read the sensors.
@@ -117,28 +128,28 @@ class SkidSteerModel : public ChassisModel {
   /**
    * Reset the sensors to their zero point.
    */
-  void resetSensors() const override;
+  void resetSensors() override;
 
   /**
    * Set the brake mode for each motor.
    *
    * @param mode new brake mode
    */
-  void setBrakeMode(AbstractMotor::brakeMode mode) const override;
+  void setBrakeMode(AbstractMotor::brakeMode mode) override;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  void setEncoderUnits(AbstractMotor::encoderUnits units) const override;
+  void setEncoderUnits(AbstractMotor::encoderUnits units) override;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  void setGearing(AbstractMotor::gearset gearset) const override;
+  void setGearing(AbstractMotor::gearset gearset) override;
 
   /**
    * Sets new PID constants.
@@ -149,7 +160,7 @@ class SkidSteerModel : public ChassisModel {
    * @param ikD the derivative constant
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  void setPosPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setPosPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -171,7 +182,7 @@ class SkidSteerModel : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Sets new PID constants.
@@ -182,7 +193,7 @@ class SkidSteerModel : public ChassisModel {
    * @param ikD the derivative constant
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  void setVelPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setVelPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -204,7 +215,7 @@ class SkidSteerModel : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Returns the left side motor.

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -40,7 +40,7 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
   /**
    * Reset the sensors to their zero point.
    */
-  void resetSensors() const override;
+  void resetSensors() override;
 
   protected:
   std::shared_ptr<ContinuousRotarySensor> middleSensor;

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -58,7 +58,7 @@ class XDriveModel : public ChassisModel {
    *
    * @param ispeed motor power
    */
-  void forward(double ipower) const override;
+  void forward(double ipower) override;
 
   /**
    * Drive the robot in an arc (using open-loop control). Uses velocity mode.
@@ -69,14 +69,25 @@ class XDriveModel : public ChassisModel {
    * @param iforwardSpeed speed in the forward direction
    * @param iyaw speed around the vertical axis
    */
-  void driveVector(double iforwardSpeed, double iyaw) const override;
+  void driveVector(double iforwardSpeed, double iyaw) override;
+
+  /**
+   * Drive the robot in an arc. Uses voltage mode.
+   * The algorithm is (approximately):
+   *   leftPower = forwardSpeed + yaw
+   *   rightPower = forwardSpeed - yaw
+   *
+   * @param iforwadSpeed speed in the forward direction
+   * @param iyaw speed around the vertical axis
+   */
+  void driveVectorVoltage(double iforwardSpeed, double iyaw) override;
 
   /**
    * Turn the robot clockwise (using open-loop control). Uses velocity mode.
    *
    * @param ipower motor power
    */
-  void rotate(double ipower) const override;
+  void rotate(double ipower) override;
 
   /**
    * Stop the robot (set all the motors to 0). Uses velocity mode.
@@ -90,7 +101,7 @@ class XDriveModel : public ChassisModel {
    * @param irightSpeed right side speed
    * @param ithreshold deadband on joystick values
    */
-  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) const override;
+  void tank(double ileftSpeed, double irightSpeed, double ithreshold = 0) override;
 
   /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
@@ -99,7 +110,7 @@ class XDriveModel : public ChassisModel {
    * @param iyaw speed around the vertical axis
    * @param ithreshold deadband on joystick values
    */
-  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) const override;
+  void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
@@ -110,21 +121,21 @@ class XDriveModel : public ChassisModel {
    * @param ithreshold deadband on joystick values
    */
   virtual void
-  xArcade(double irightSpeed, double iforwardSpeed, double iyaw, double ithreshold = 0) const;
+  xArcade(double irightSpeed, double iforwardSpeed, double iyaw, double ithreshold = 0);
 
   /**
    * Power the left side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */
-  void left(double ipower) const override;
+  void left(double ipower) override;
 
   /**
    * Power the right side motors. Uses velocity mode.
    *
    * @param ipower motor power
    */
-  void right(double ipower) const override;
+  void right(double ipower) override;
 
   /**
    * Read the sensors.
@@ -136,28 +147,28 @@ class XDriveModel : public ChassisModel {
   /**
    * Reset the sensors to their zero point.
    */
-  void resetSensors() const override;
+  void resetSensors() override;
 
   /**
    * Set the brake mode for each motor.
    *
    * @param mode new brake mode
    */
-  void setBrakeMode(AbstractMotor::brakeMode mode) const override;
+  void setBrakeMode(AbstractMotor::brakeMode mode) override;
 
   /**
    * Set the encoder units for each motor.
    *
    * @param units new motor encoder units
    */
-  void setEncoderUnits(AbstractMotor::encoderUnits units) const override;
+  void setEncoderUnits(AbstractMotor::encoderUnits units) override;
 
   /**
    * Set the gearset for each motor.
    *
    * @param gearset new motor gearset
    */
-  void setGearing(AbstractMotor::gearset gearset) const override;
+  void setGearing(AbstractMotor::gearset gearset) override;
 
   /**
    * Sets new PID constants.
@@ -168,7 +179,7 @@ class XDriveModel : public ChassisModel {
    * @param ikD the derivative constant
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  void setPosPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setPosPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -190,7 +201,7 @@ class XDriveModel : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Sets new PID constants.
@@ -201,7 +212,7 @@ class XDriveModel : public ChassisModel {
    * @param ikD the derivative constant
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
-  void setVelPID(double ikF, double ikP, double ikI, double ikD) const override;
+  void setVelPID(double ikF, double ikP, double ikI, double ikD) override;
 
   /**
    * Sets new PID constants.
@@ -223,7 +234,7 @@ class XDriveModel : public ChassisModel {
                      double ifilter,
                      double ilimit,
                      double ithreshold,
-                     double iloopSpeed) const override;
+                     double iloopSpeed) override;
 
   /**
    * Returns the top left motor.

--- a/src/api/chassis/controller/chassisController.cpp
+++ b/src/api/chassis/controller/chassisController.cpp
@@ -21,15 +21,19 @@ void ChassisController::setTurnsMirrored(const bool ishouldMirror) {
   normalTurns = !ishouldMirror;
 }
 
-void ChassisController::forward(const double ispeed) const {
+void ChassisController::forward(const double ispeed) {
   model->forward(ispeed);
 }
 
-void ChassisController::driveVector(const double iforwardSpeed, const double iyaw) const {
+void ChassisController::driveVector(const double iforwardSpeed, const double iyaw) {
   model->driveVector(iforwardSpeed, iyaw);
 }
 
-void ChassisController::rotate(const double ispeed) const {
+void ChassisController::driveVectorVoltage(double iforwardSpeed, double iyaw) {
+  model->driveVectorVoltage(iforwardSpeed, iyaw);
+}
+
+void ChassisController::rotate(const double ispeed) {
   model->rotate(ispeed);
 }
 
@@ -39,21 +43,21 @@ void ChassisController::stop() {
 
 void ChassisController::tank(const double ileftSpeed,
                              const double irightSpeed,
-                             const double ithreshold) const {
+                             const double ithreshold) {
   model->tank(ileftSpeed, irightSpeed, ithreshold);
 }
 
 void ChassisController::arcade(const double iforwardSpeed,
                                const double iyaw,
-                               const double ithreshold) const {
+                               const double ithreshold) {
   model->arcade(iforwardSpeed, iyaw, ithreshold);
 }
 
-void ChassisController::left(const double ispeed) const {
+void ChassisController::left(const double ispeed) {
   model->left(ispeed);
 }
 
-void ChassisController::right(const double ispeed) const {
+void ChassisController::right(const double ispeed) {
   model->right(ispeed);
 }
 
@@ -61,26 +65,26 @@ std::valarray<std::int32_t> ChassisController::getSensorVals() const {
   return model->getSensorVals();
 }
 
-void ChassisController::resetSensors() const {
+void ChassisController::resetSensors() {
   model->resetSensors();
 }
 
-void ChassisController::setBrakeMode(const AbstractMotor::brakeMode mode) const {
+void ChassisController::setBrakeMode(const AbstractMotor::brakeMode mode) {
   model->setBrakeMode(mode);
 }
 
-void ChassisController::setEncoderUnits(const AbstractMotor::encoderUnits units) const {
+void ChassisController::setEncoderUnits(const AbstractMotor::encoderUnits units) {
   model->setEncoderUnits(units);
 }
 
-void ChassisController::setGearing(const AbstractMotor::gearset gearset) const {
+void ChassisController::setGearing(const AbstractMotor::gearset gearset) {
   model->setGearing(gearset);
 }
 
 void ChassisController::setPosPID(const double ikF,
                                   const double ikP,
                                   const double ikI,
-                                  const double ikD) const {
+                                  const double ikD) {
   model->setPosPID(ikF, ikP, ikI, ikD);
 }
 
@@ -91,14 +95,14 @@ void ChassisController::setPosPIDFull(const double ikF,
                                       const double ifilter,
                                       const double ilimit,
                                       const double ithreshold,
-                                      const double iloopSpeed) const {
+                                      const double iloopSpeed) {
   model->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
 }
 
 void ChassisController::setVelPID(const double ikF,
                                   const double ikP,
                                   const double ikI,
-                                  const double ikD) const {
+                                  const double ikD) {
   model->setVelPID(ikF, ikP, ikI, ikD);
 }
 
@@ -109,7 +113,7 @@ void ChassisController::setVelPIDFull(const double ikF,
                                       const double ifilter,
                                       const double ilimit,
                                       const double ithreshold,
-                                      const double iloopSpeed) const {
+                                      const double iloopSpeed) {
   model->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
 }
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -86,13 +86,29 @@ void ChassisControllerPID::loop() {
         distanceElapsed = static_cast<double>((encVals[0] + encVals[1])) / 2.0;
         angleChange = static_cast<double>(encVals[0] - encVals[1]);
 
-        model->driveVector(distancePid->step(distanceElapsed), anglePid->step(angleChange));
+        distancePid->step(distanceElapsed);
+        anglePid->step(angleChange);
+
+        if (velocityMode) {
+          model->driveVector(distancePid->getOutput(), anglePid->getOutput());
+        } else {
+          model->driveVectorVoltage(distancePid->getOutput(), anglePid->getOutput());
+        }
+
         break;
 
       case angle:
         encVals = model->getSensorVals() - encStartVals;
         angleChange = (encVals[0] - encVals[1]) / 2.0;
-        model->rotate(turnPid->step(angleChange));
+
+        turnPid->step(angleChange);
+
+        if (velocityMode) {
+          model->driveVector(0, turnPid->getOutput());
+        } else {
+          model->driveVectorVoltage(0, turnPid->getOutput());
+        }
+
         break;
 
       default:

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -85,6 +85,7 @@ void ChassisControllerPID::loop() {
         encVals = model->getSensorVals() - encStartVals;
         distanceElapsed = static_cast<double>((encVals[0] + encVals[1])) / 2.0;
         angleChange = static_cast<double>(encVals[0] - encVals[1]);
+
         model->driveVector(distancePid->step(distanceElapsed), anglePid->step(angleChange));
         break;
 
@@ -293,5 +294,9 @@ ChassisScales ChassisControllerPID::getChassisScales() const {
 
 AbstractMotor::GearsetRatioPair ChassisControllerPID::getGearsetRatioPair() const {
   return gearsetRatioPair;
+}
+
+void ChassisControllerPID::setVelocityMode(bool ivelocityMode) {
+  velocityMode = ivelocityMode;
 }
 } // namespace okapi

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -34,13 +34,13 @@ SkidSteerModel::SkidSteerModel(const std::shared_ptr<AbstractMotor> &ileftSideMo
     rightSensor(irightSideMotor->getEncoder()) {
 }
 
-void SkidSteerModel::forward(const double ispeed) const {
+void SkidSteerModel::forward(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   rightSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
-void SkidSteerModel::driveVector(const double iforwardSpeed, const double iyaw) const {
+void SkidSteerModel::driveVector(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
@@ -58,7 +58,25 @@ void SkidSteerModel::driveVector(const double iforwardSpeed, const double iyaw) 
   rightSideMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVelocity));
 }
 
-void SkidSteerModel::rotate(const double ispeed) const {
+void SkidSteerModel::driveVectorVoltage(double iforwardSpeed, double iyaw) {
+  // This code is taken from WPIlib. All credit goes to them. Link:
+  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  const double yaw = std::clamp(iyaw, -1.0, 1.0);
+
+  double leftOutput = forwardSpeed + yaw;
+  double rightOutput = forwardSpeed - yaw;
+  if (const double maxInputMag = std::max<double>(std::abs(leftOutput), std::abs(rightOutput));
+      maxInputMag > 1) {
+    leftOutput /= maxInputMag;
+    rightOutput /= maxInputMag;
+  }
+
+  leftSideMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
+  rightSideMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxVoltage));
+}
+
+void SkidSteerModel::rotate(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   leftSideMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   rightSideMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxVelocity));
@@ -71,7 +89,7 @@ void SkidSteerModel::stop() {
 
 void SkidSteerModel::tank(const double ileftSpeed,
                           const double irightSpeed,
-                          const double ithreshold) const {
+                          const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double leftSpeed = std::clamp(ileftSpeed, -1.0, 1.0);
@@ -90,7 +108,7 @@ void SkidSteerModel::tank(const double ileftSpeed,
 
 void SkidSteerModel::arcade(const double iforwardSpeed,
                             const double iyaw,
-                            const double ithreshold) const {
+                            const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
@@ -130,11 +148,11 @@ void SkidSteerModel::arcade(const double iforwardSpeed,
     static_cast<int16_t>(std::clamp(rightOutput, -1.0, 1.0) * maxVoltage));
 }
 
-void SkidSteerModel::left(const double ispeed) const {
+void SkidSteerModel::left(const double ispeed) {
   leftSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
-void SkidSteerModel::right(const double ispeed) const {
+void SkidSteerModel::right(const double ispeed) {
   rightSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }
 
@@ -143,22 +161,22 @@ std::valarray<std::int32_t> SkidSteerModel::getSensorVals() const {
                                      static_cast<std::int32_t>(rightSensor->get())};
 }
 
-void SkidSteerModel::resetSensors() const {
+void SkidSteerModel::resetSensors() {
   leftSensor->reset();
   rightSensor->reset();
 }
 
-void SkidSteerModel::setBrakeMode(const AbstractMotor::brakeMode mode) const {
+void SkidSteerModel::setBrakeMode(const AbstractMotor::brakeMode mode) {
   leftSideMotor->setBrakeMode(mode);
   rightSideMotor->setBrakeMode(mode);
 }
 
-void SkidSteerModel::setEncoderUnits(const AbstractMotor::encoderUnits units) const {
+void SkidSteerModel::setEncoderUnits(const AbstractMotor::encoderUnits units) {
   leftSideMotor->setEncoderUnits(units);
   rightSideMotor->setEncoderUnits(units);
 }
 
-void SkidSteerModel::setGearing(const AbstractMotor::gearset gearset) const {
+void SkidSteerModel::setGearing(const AbstractMotor::gearset gearset) {
   leftSideMotor->setGearing(gearset);
   rightSideMotor->setGearing(gearset);
 }
@@ -166,7 +184,7 @@ void SkidSteerModel::setGearing(const AbstractMotor::gearset gearset) const {
 void SkidSteerModel::setPosPID(const double ikF,
                                const double ikP,
                                const double ikI,
-                               const double ikD) const {
+                               const double ikD) {
   leftSideMotor->setPosPID(ikF, ikP, ikI, ikD);
   rightSideMotor->setPosPID(ikF, ikP, ikI, ikD);
 }
@@ -178,7 +196,7 @@ void SkidSteerModel::setPosPIDFull(const double ikF,
                                    const double ifilter,
                                    const double ilimit,
                                    const double ithreshold,
-                                   const double iloopSpeed) const {
+                                   const double iloopSpeed) {
   leftSideMotor->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   rightSideMotor->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
 }
@@ -186,7 +204,7 @@ void SkidSteerModel::setPosPIDFull(const double ikF,
 void SkidSteerModel::setVelPID(const double ikF,
                                const double ikP,
                                const double ikI,
-                               const double ikD) const {
+                               const double ikD) {
   leftSideMotor->setVelPID(ikF, ikP, ikI, ikD);
   rightSideMotor->setVelPID(ikF, ikP, ikI, ikD);
 }
@@ -198,7 +216,7 @@ void SkidSteerModel::setVelPIDFull(const double ikF,
                                    const double ifilter,
                                    const double ilimit,
                                    const double ithreshold,
-                                   const double iloopSpeed) const {
+                                   const double iloopSpeed) {
   leftSideMotor->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   rightSideMotor->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
 }

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -27,7 +27,7 @@ std::valarray<std::int32_t> ThreeEncoderSkidSteerModel::getSensorVals() const {
                                      static_cast<std::int32_t>(middleSensor->get())};
 }
 
-void ThreeEncoderSkidSteerModel::resetSensors() const {
+void ThreeEncoderSkidSteerModel::resetSensors() {
   SkidSteerModel::resetSensors();
   middleSensor->reset();
 }

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -84,9 +84,9 @@ void XDriveModel::driveVectorVoltage(double iforwardSpeed, double iyaw) {
   }
 
   topLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
-  topRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVoltage));
-  bottomRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVoltage));
-  bottomLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVoltage));
+  topRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
 }
 
 void XDriveModel::rotate(const double ispeed) {

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -41,7 +41,7 @@ XDriveModel::XDriveModel(const std::shared_ptr<AbstractMotor> &itopLeftMotor,
     rightSensor(itopRightMotor->getEncoder()) {
 }
 
-void XDriveModel::forward(const double ispeed) const {
+void XDriveModel::forward(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   topRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
@@ -49,7 +49,7 @@ void XDriveModel::forward(const double ispeed) const {
   bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
-void XDriveModel::driveVector(const double iforwardSpeed, const double iyaw) const {
+void XDriveModel::driveVector(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
@@ -69,7 +69,27 @@ void XDriveModel::driveVector(const double iforwardSpeed, const double iyaw) con
   bottomLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVelocity));
 }
 
-void XDriveModel::rotate(const double ispeed) const {
+void XDriveModel::driveVectorVoltage(double iforwardSpeed, double iyaw) {
+  // This code is taken from WPIlib. All credit goes to them. Link:
+  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  const double yaw = std::clamp(iyaw, -1.0, 1.0);
+
+  double leftOutput = forwardSpeed + yaw;
+  double rightOutput = forwardSpeed - yaw;
+  if (const double maxInputMag = std::max<double>(std::abs(leftOutput), std::abs(rightOutput));
+      maxInputMag > 1) {
+    leftOutput /= maxInputMag;
+    rightOutput /= maxInputMag;
+  }
+
+  topLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
+  topRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomRightMotor->moveVelocity(static_cast<int16_t>(rightOutput * maxVoltage));
+  bottomLeftMotor->moveVelocity(static_cast<int16_t>(leftOutput * maxVoltage));
+}
+
+void XDriveModel::rotate(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   topRightMotor->moveVelocity(static_cast<int16_t>(-1 * speed * maxVelocity));
@@ -84,9 +104,7 @@ void XDriveModel::stop() {
   bottomLeftMotor->moveVelocity(0);
 }
 
-void XDriveModel::tank(const double ileftSpeed,
-                       const double irightSpeed,
-                       const double ithreshold) const {
+void XDriveModel::tank(const double ileftSpeed, const double irightSpeed, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double leftSpeed = std::clamp(ileftSpeed, -1.0, 1.0);
@@ -105,9 +123,7 @@ void XDriveModel::tank(const double ileftSpeed,
   bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
 }
 
-void XDriveModel::arcade(const double iforwardSpeed,
-                         const double iyaw,
-                         const double ithreshold) const {
+void XDriveModel::arcade(const double iforwardSpeed, const double iyaw, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
@@ -154,7 +170,7 @@ void XDriveModel::arcade(const double iforwardSpeed,
 void XDriveModel::xArcade(const double ixSpeed,
                           const double iforwardSpeed,
                           const double iyaw,
-                          const double ithreshold) const {
+                          const double ithreshold) {
   double xSpeed = std::clamp(ixSpeed, -1.0, 1.0);
   if (std::abs(xSpeed) < ithreshold) {
     xSpeed = 0;
@@ -180,13 +196,13 @@ void XDriveModel::xArcade(const double ixSpeed,
     static_cast<int16_t>(std::clamp(forwardSpeed - xSpeed + yaw, -1.0, 1.0) * maxVoltage));
 }
 
-void XDriveModel::left(const double ispeed) const {
+void XDriveModel::left(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   topLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   bottomLeftMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
 }
 
-void XDriveModel::right(const double ispeed) const {
+void XDriveModel::right(const double ispeed) {
   const double speed = std::clamp(ispeed, -1.0, 1.0);
   topRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
   bottomRightMotor->moveVelocity(static_cast<int16_t>(speed * maxVelocity));
@@ -197,26 +213,26 @@ std::valarray<std::int32_t> XDriveModel::getSensorVals() const {
                                      static_cast<std::int32_t>(rightSensor->get())};
 }
 
-void XDriveModel::resetSensors() const {
+void XDriveModel::resetSensors() {
   leftSensor->reset();
   rightSensor->reset();
 }
 
-void XDriveModel::setBrakeMode(const AbstractMotor::brakeMode mode) const {
+void XDriveModel::setBrakeMode(const AbstractMotor::brakeMode mode) {
   topLeftMotor->setBrakeMode(mode);
   topRightMotor->setBrakeMode(mode);
   bottomRightMotor->setBrakeMode(mode);
   bottomLeftMotor->setBrakeMode(mode);
 }
 
-void XDriveModel::setEncoderUnits(const AbstractMotor::encoderUnits units) const {
+void XDriveModel::setEncoderUnits(const AbstractMotor::encoderUnits units) {
   topLeftMotor->setEncoderUnits(units);
   topRightMotor->setEncoderUnits(units);
   bottomRightMotor->setEncoderUnits(units);
   bottomLeftMotor->setEncoderUnits(units);
 }
 
-void XDriveModel::setGearing(const AbstractMotor::gearset gearset) const {
+void XDriveModel::setGearing(const AbstractMotor::gearset gearset) {
   topLeftMotor->setGearing(gearset);
   topRightMotor->setGearing(gearset);
   bottomRightMotor->setGearing(gearset);
@@ -226,7 +242,7 @@ void XDriveModel::setGearing(const AbstractMotor::gearset gearset) const {
 void XDriveModel::setPosPID(const double ikF,
                             const double ikP,
                             const double ikI,
-                            const double ikD) const {
+                            const double ikD) {
   topLeftMotor->setPosPID(ikF, ikP, ikI, ikD);
   topRightMotor->setPosPID(ikF, ikP, ikI, ikD);
   bottomRightMotor->setPosPID(ikF, ikP, ikI, ikD);
@@ -240,7 +256,7 @@ void XDriveModel::setPosPIDFull(const double ikF,
                                 const double ifilter,
                                 const double ilimit,
                                 const double ithreshold,
-                                const double iloopSpeed) const {
+                                const double iloopSpeed) {
   topLeftMotor->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   topRightMotor->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   bottomRightMotor->setPosPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
@@ -250,7 +266,7 @@ void XDriveModel::setPosPIDFull(const double ikF,
 void XDriveModel::setVelPID(const double ikF,
                             const double ikP,
                             const double ikI,
-                            const double ikD) const {
+                            const double ikD) {
   topLeftMotor->setVelPID(ikF, ikP, ikI, ikD);
   topRightMotor->setVelPID(ikF, ikP, ikI, ikD);
   bottomRightMotor->setVelPID(ikF, ikP, ikI, ikD);
@@ -264,7 +280,7 @@ void XDriveModel::setVelPIDFull(const double ikF,
                                 const double ifilter,
                                 const double ilimit,
                                 const double ithreshold,
-                                const double iloopSpeed) const {
+                                const double iloopSpeed) {
   topLeftMotor->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   topRightMotor->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);
   bottomRightMotor->setVelPIDFull(ikF, ikP, ikI, ikD, ifilter, ilimit, ithreshold, iloopSpeed);

--- a/test/chassisControllerTests.cpp
+++ b/test/chassisControllerTests.cpp
@@ -16,16 +16,21 @@ class MockChassisModel : public ChassisModel {
   MockChassisModel() : ChassisModel(100) {
   }
 
-  void forward(double ispeed) const override {
+  void forward(double ispeed) override {
     lastForward = ispeed;
   }
 
-  void driveVector(double iySpeed, double izRotation) const override {
+  void driveVector(double iySpeed, double izRotation) override {
     lastVectorY = iySpeed;
     lastVectorZ = izRotation;
   }
 
-  void rotate(double ispeed) const override {
+  void driveVectorVoltage(double iySpeed, double izRotation) override {
+    lastVectorY = iySpeed;
+    lastVectorZ = izRotation;
+  }
+
+  void rotate(double ispeed) override {
     lastRotate = ispeed;
   }
 
@@ -33,37 +38,37 @@ class MockChassisModel : public ChassisModel {
     stopWasCalled = true;
   }
 
-  void tank(double ileftSpeed, double irightSpeed, double) const override {
+  void tank(double ileftSpeed, double irightSpeed, double) override {
     lastTankLeft = ileftSpeed;
     lastTankRight = irightSpeed;
   }
 
-  void arcade(double iySpeed, double izRotation, double) const override {
+  void arcade(double iySpeed, double izRotation, double) override {
     lastArcadeY = iySpeed;
     lastArcadeZ = izRotation;
   }
 
-  void left(double ispeed) const override {
+  void left(double ispeed) override {
     lastLeft = ispeed;
   }
 
-  void right(double ispeed) const override {
+  void right(double ispeed) override {
     lastRight = ispeed;
   }
 
-  void resetSensors() const override {
+  void resetSensors() override {
     resetSensorsWasCalled = true;
   }
 
-  void setBrakeMode(AbstractMotor::brakeMode mode) const override {
+  void setBrakeMode(AbstractMotor::brakeMode mode) override {
     lastBrakeMode = mode;
   }
 
-  void setEncoderUnits(AbstractMotor::encoderUnits units) const override {
+  void setEncoderUnits(AbstractMotor::encoderUnits units) override {
     lastEncoderUnits = units;
   }
 
-  void setGearing(AbstractMotor::gearset gearset) const override {
+  void setGearing(AbstractMotor::gearset gearset) override {
     lastGearset = gearset;
   }
 
@@ -71,18 +76,16 @@ class MockChassisModel : public ChassisModel {
     return {0, 0};
   }
 
-  void setPosPID(double, double, double, double) const override {
+  void setPosPID(double, double, double, double) override {
   }
 
-  void
-  setPosPIDFull(double, double, double, double, double, double, double, double) const override {
+  void setPosPIDFull(double, double, double, double, double, double, double, double) override {
   }
 
-  void setVelPID(double, double, double, double) const override {
+  void setVelPID(double, double, double, double) override {
   }
 
-  void
-  setVelPIDFull(double, double, double, double, double, double, double, double) const override {
+  void setVelPIDFull(double, double, double, double, double, double, double, double) override {
   }
 
   mutable double lastForward{0};

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -77,6 +77,18 @@ TEST_F(SkidSteerModelTest, DriveVectorBoundsInput) {
   assertLeftAndRightMotorsLastVelocity(127, 71);
 }
 
+TEST_F(SkidSteerModelTest, DriveVectorAndRotateAreEquivalent) {
+  for (double i = -1; i < 1;) {
+    model.driveVector(0, i);
+    auto lastLeft = leftMotor->lastVelocity;
+    auto lastRight = rightMotor->lastVelocity;
+    model.rotate(i);
+    EXPECT_FLOAT_EQ(leftMotor->lastVelocity, lastLeft);
+    EXPECT_FLOAT_EQ(rightMotor->lastVelocity, lastRight);
+    i += 0.001;
+  }
+}
+
 TEST_F(SkidSteerModelTest, DriveVectorVoltageHalfPower) {
   model.driveVectorVoltage(0.25, 0.25);
   assertLeftAndRightMotorsLastVoltage(6000, 0);

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -77,6 +77,16 @@ TEST_F(SkidSteerModelTest, DriveVectorBoundsInput) {
   assertLeftAndRightMotorsLastVelocity(127, 71);
 }
 
+TEST_F(SkidSteerModelTest, DriveVectorVoltageHalfPower) {
+  model.driveVectorVoltage(0.25, 0.25);
+  assertLeftAndRightMotorsLastVoltage(6000, 0);
+}
+
+TEST_F(SkidSteerModelTest, DriveVectorVoltageBoundsInput) {
+  model.driveVectorVoltage(0.9, 0.25);
+  assertLeftAndRightMotorsLastVoltage(12000, 6782);
+}
+
 TEST_F(SkidSteerModelTest, StopTest) {
   leftMotor->lastVelocity = 100;
   rightMotor->lastVelocity = 100;
@@ -157,7 +167,7 @@ TEST_F(SkidSteerModelTest, ArcadeThresholds) {
 
 TEST_F(SkidSteerModelTest, ArcadeNegativeZero) {
   model.arcade(-0.0, -1.0);
-  
+
   assertAllMotorsLastVelocity(0);
   assertLeftAndRightMotorsLastVoltage(-12000, 12000);
 }

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -94,6 +94,22 @@ TEST_F(XDriveModelTest, DriveVectorBoundsInput) {
   assertLeftAndRightMotorsLastVelocity(127, 71);
 }
 
+TEST_F(XDriveModelTest, DriveVectorAndRotateAreEquivalent) {
+  for (double i = -1; i < 1;) {
+    model.driveVector(0, i);
+    auto lastTopLeft = topLeftMotor->lastVelocity;
+    auto lastTopRight = topRightMotor->lastVelocity;
+    auto lastBottomRight = bottomRightMotor->lastVelocity;
+    auto lastBottomLeft = bottomLeftMotor->lastVelocity;
+    model.rotate(i);
+    EXPECT_FLOAT_EQ(topLeftMotor->lastVelocity, lastTopLeft);
+    EXPECT_FLOAT_EQ(topRightMotor->lastVelocity, lastTopRight);
+    EXPECT_FLOAT_EQ(bottomRightMotor->lastVelocity, lastBottomRight);
+    EXPECT_FLOAT_EQ(bottomLeftMotor->lastVelocity, lastBottomLeft);
+    i += 0.001;
+  }
+}
+
 TEST_F(XDriveModelTest, DriveVectorVoltageHalfPower) {
   model.driveVectorVoltage(0.25, 0.25);
   assertLeftAndRightMotorsLastVoltage(6000, 0);

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -94,6 +94,16 @@ TEST_F(XDriveModelTest, DriveVectorBoundsInput) {
   assertLeftAndRightMotorsLastVelocity(127, 71);
 }
 
+TEST_F(XDriveModelTest, DriveVectorVoltageHalfPower) {
+  model.driveVectorVoltage(0.25, 0.25);
+  assertLeftAndRightMotorsLastVoltage(6000, 0);
+}
+
+TEST_F(XDriveModelTest, DriveVectorVoltageBoundsInput) {
+  model.driveVectorVoltage(0.9, 0.25);
+  assertLeftAndRightMotorsLastVoltage(12000, 6782);
+}
+
 TEST_F(XDriveModelTest, StopTest) {
   topLeftMotor->lastVelocity = 100;
   topRightMotor->lastVelocity = 100;
@@ -176,7 +186,7 @@ TEST_F(XDriveModelTest, ArcadeThresholds) {
 
 TEST_F(XDriveModelTest, ArcadeNegativeZero) {
   model.arcade(-0.0, -1.0);
-  
+
   assertAllMotorsLastVelocity(0);
   assertLeftAndRightMotorsLastVoltage(-12000, 12000);
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a flag to CCPID to run the control loop in voltage mode, instead of in velocity mode (which is the default now).

### Benefits

Some users would rather not run the PID controller outputs through the built-in velocity control.

### Possible Drawbacks

None.

### Verification Process

`driveVectorVoltage(0, x)` has been tested to be equivalent to `rotate(x)`.

### Applicable Issues

Closes #338.
