### PR TITLE
Don't check IVPC loopDtTimer twice

### DIFF
--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -80,10 +80,7 @@ double IterativeVelPIDController::step(const double inewReading) {
     loopDtTimer->placeHardMark();
 
     if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
-      if (loopDtTimer->getDtFromHardMark() >= sampleTime) {
-        stepVel(inewReading);
-      }
-
+      stepVel(inewReading);
       error = getError();
 
       // Derivative over measurement to eliminate derivative kick on setpoint change

--- a/test/chassisControllerPidIntegrationTest.cpp
+++ b/test/chassisControllerPidIntegrationTest.cpp
@@ -25,9 +25,12 @@ class ChassisControllerPIDIntegrationTest : public ::testing::Test {
     leftMotor = new ThreadedMockMotor();
     rightMotor = new ThreadedMockMotor();
 
-    distanceController = new IterativePosPIDController(0.1, 0, 0, 0, createTimeUtil());
-    angleController = new IterativePosPIDController(0.1, 0, 0, 0, createTimeUtil());
-    turnController = new IterativePosPIDController(0.1, 0, 0, 0, createTimeUtil());
+    auto controllerTimeUtil = createTimeUtil(
+      Supplier<std::unique_ptr<SettledUtil>>([]() { return createSettledUtilPtr(250, 5, 1_s); }));
+
+    distanceController = new IterativePosPIDController(0.1, 0, 0, 0, controllerTimeUtil);
+    angleController = new IterativePosPIDController(0.1, 0, 0, 0, controllerTimeUtil);
+    turnController = new IterativePosPIDController(0.1, 0, 0, 0, controllerTimeUtil);
 
     model = new SkidSteerModel(
       std::unique_ptr<AbstractMotor>(leftMotor), std::unique_ptr<AbstractMotor>(rightMotor), 200);


### PR DESCRIPTION
### Description of the Change

There is no need to check `loopDtTimer` twice back-to-back in `IterativeVelPIDController`. 

### Applicable Issues

Closes #340.
