### PR TITLE
Add ChassisControllerBuilder.withSensors three encoder options

### DIFF
--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -114,6 +114,17 @@ class ChassisControllerBuilder {
    *
    * @param ileft The left side sensor.
    * @param iright The right side sensor.
+   * @param imiddle The middle sensor.
+   * @return An ongoing builder.
+   */
+  ChassisControllerBuilder &
+  withSensors(const ADIEncoder &ileft, const ADIEncoder &iright, const ADIEncoder &imiddle);
+
+  /**
+   * Sets the sensors. The default sensors are the motor's integrated encoders.
+   *
+   * @param ileft The left side sensor.
+   * @param iright The right side sensor.
    * @return An ongoing builder.
    */
   ChassisControllerBuilder &withSensors(const IntegratedEncoder &ileft,
@@ -124,10 +135,34 @@ class ChassisControllerBuilder {
    *
    * @param ileft The left side sensor.
    * @param iright The right side sensor.
+   * @param imiddle The middle sensor.
+   * @return An ongoing builder.
+   */
+  ChassisControllerBuilder &withSensors(const IntegratedEncoder &ileft,
+                                        const IntegratedEncoder &iright,
+                                        const ADIEncoder &imiddle);
+
+  /**
+   * Sets the sensors. The default sensors are the motor's integrated encoders.
+   *
+   * @param ileft The left side sensor.
+   * @param iright The right side sensor.
    * @return An ongoing builder.
    */
   ChassisControllerBuilder &withSensors(const std::shared_ptr<ContinuousRotarySensor> &ileft,
                                         const std::shared_ptr<ContinuousRotarySensor> &iright);
+
+  /**
+   * Sets the sensors. The default sensors are the motor's integrated encoders.
+   *
+   * @param ileft The left side sensor.
+   * @param iright The right side sensor.
+   * @param imiddle The middle sensor.
+   * @return An ongoing builder.
+   */
+  ChassisControllerBuilder &withSensors(const std::shared_ptr<ContinuousRotarySensor> &ileft,
+                                        const std::shared_ptr<ContinuousRotarySensor> &iright,
+                                        const std::shared_ptr<ContinuousRotarySensor> &imiddle);
 
   /**
    * Sets the PID controller gains, causing the builder to generate a ChassisControllerPID. Uses the
@@ -242,8 +277,9 @@ class ChassisControllerBuilder {
   XDriveMotors xDriveMotors;
 
   bool sensorsSetByUser{false}; // Used so motors don't overwrite sensors set manually
-  std::shared_ptr<ContinuousRotarySensor> leftSensor;
-  std::shared_ptr<ContinuousRotarySensor> rightSensor;
+  std::shared_ptr<ContinuousRotarySensor> leftSensor{nullptr};
+  std::shared_ptr<ContinuousRotarySensor> rightSensor{nullptr};
+  std::shared_ptr<ContinuousRotarySensor> middleSensor{nullptr};
 
   bool hasGains{false}; // Whether gains were passed, no gains means CCI
   IterativePosPIDController::Gains distanceGains;

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/chassis/controller/chassisControllerBuilder.hpp"
+#include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
 #include <stdexcept>
 
 namespace okapi {
@@ -80,10 +81,27 @@ ChassisControllerBuilder &ChassisControllerBuilder::withSensors(const ADIEncoder
   return withSensors(std::make_shared<ADIEncoder>(ileft), std::make_shared<ADIEncoder>(iright));
 }
 
+ChassisControllerBuilder &ChassisControllerBuilder::withSensors(const okapi::ADIEncoder &ileft,
+                                                                const okapi::ADIEncoder &iright,
+                                                                const okapi::ADIEncoder &imiddle) {
+  return withSensors(std::make_shared<ADIEncoder>(ileft),
+                     std::make_shared<ADIEncoder>(iright),
+                     std::make_shared<ADIEncoder>(imiddle));
+}
+
 ChassisControllerBuilder &ChassisControllerBuilder::withSensors(const IntegratedEncoder &ileft,
                                                                 const IntegratedEncoder &iright) {
   return withSensors(std::make_shared<IntegratedEncoder>(ileft),
                      std::make_shared<IntegratedEncoder>(iright));
+}
+
+ChassisControllerBuilder &
+ChassisControllerBuilder::withSensors(const okapi::IntegratedEncoder &ileft,
+                                      const okapi::IntegratedEncoder &iright,
+                                      const okapi::ADIEncoder &imiddle) {
+  return withSensors(std::make_shared<IntegratedEncoder>(ileft),
+                     std::make_shared<IntegratedEncoder>(iright),
+                     std::make_shared<ADIEncoder>(imiddle));
 }
 
 ChassisControllerBuilder &
@@ -92,6 +110,17 @@ ChassisControllerBuilder::withSensors(const std::shared_ptr<ContinuousRotarySens
   sensorsSetByUser = true;
   leftSensor = ileft;
   rightSensor = iright;
+  return *this;
+}
+
+ChassisControllerBuilder &ChassisControllerBuilder::withSensors(
+  const std::shared_ptr<okapi::ContinuousRotarySensor> &ileft,
+  const std::shared_ptr<okapi::ContinuousRotarySensor> &iright,
+  const std::shared_ptr<okapi::ContinuousRotarySensor> &imiddle) {
+  sensorsSetByUser = true;
+  leftSensor = ileft;
+  rightSensor = iright;
+  middleSensor = imiddle;
   return *this;
 }
 
@@ -245,8 +274,22 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
 }
 
 std::shared_ptr<SkidSteerModel> ChassisControllerBuilder::makeSkidSteerModel() {
-  return std::make_shared<SkidSteerModel>(
-    skidSteerMotors.left, skidSteerMotors.right, leftSensor, rightSensor, maxVelocity, maxVoltage);
+  if (middleSensor != nullptr) {
+    return std::make_shared<ThreeEncoderSkidSteerModel>(skidSteerMotors.left,
+                                                        skidSteerMotors.right,
+                                                        leftSensor,
+                                                        middleSensor,
+                                                        rightSensor,
+                                                        maxVelocity,
+                                                        maxVoltage);
+  } else {
+    return std::make_shared<SkidSteerModel>(skidSteerMotors.left,
+                                            skidSteerMotors.right,
+                                            leftSensor,
+                                            rightSensor,
+                                            maxVelocity,
+                                            maxVoltage);
+  }
 }
 
 std::shared_ptr<XDriveModel> ChassisControllerBuilder::makeXDriveModel() {


### PR DESCRIPTION
### Description of the Change

This PR adds `withSensors` options to `ChassisControllerBuilder` to support three encoders.

### Benefits

Easier three encoder support.

### Possible Drawbacks

None.

### Verification Process

This was verified by hand.

### Applicable Issues

Closes #341.
