### PR TITLE
Add set/getGains methods to CCPID

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -14,6 +14,7 @@
 #include "okapi/api/util/timeUtil.hpp"
 #include <atomic>
 #include <memory>
+#include <tuple>
 
 namespace okapi {
 class ChassisControllerPID : public virtual ChassisController {
@@ -133,6 +134,27 @@ class ChassisControllerPID : public virtual ChassisController {
    * @param ivelocityMode Whether the controller should be in velocity or voltage mode.
    */
   void setVelocityMode(bool ivelocityMode);
+
+  /**
+   * Sets the gains for all controllers.
+   *
+   * @param idistanceGains The distance controller gains.
+   * @param iturnGains The turn controller gains.
+   * @param iangleGains The angle controller gains.
+   */
+  void setGains(const IterativePosPIDController::Gains &idistanceGains,
+                const IterativePosPIDController::Gains &iturnGains,
+                const IterativePosPIDController::Gains &iangleGains);
+
+  /**
+   * Gets the current controller gains.
+   *
+   * @return The current controller gains in the order: distance, turn, angle.
+   */
+  std::tuple<IterativePosPIDController::Gains,
+             IterativePosPIDController::Gains,
+             IterativePosPIDController::Gains>
+  getGains() const;
 
   protected:
   std::shared_ptr<Logger> logger;

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -128,16 +128,6 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   bool isSettled() override;
 
   /**
-   * Set controller gains.
-   *
-   * @param ikP proportional gain
-   * @param ikI integral gain
-   * @param ikD derivative gain
-   * @param ikBias bias (constant offset added to the output)
-   */
-  virtual void setGains(double ikP, double ikI, double ikD, double ikBias = 0);
-
-  /**
    * Set time between loops in ms.
    *
    * @param isampleTime time between loops
@@ -162,35 +152,10 @@ class IterativePosPIDController : public IterativePositionController<double, dou
   void setControllerSetTargetLimits(double itargetMax, double itargetMin) override;
 
   /**
-   * Set integrator bounds. Default bounds are [-1, 1].
-   *
-   * @param imax max integrator value
-   * @param imin min integrator value
-   */
-  virtual void setIntegralLimits(double imax, double imin);
-
-  /**
-   * Set the error sum bounds. Default bounds are [0, std::numeric_limits<double>::max()]. Error
-   * will only be added to the integral term when its absolute value is between these bounds of
-   * either side of the target.
-   *
-   * @param imax max error value that will be summed
-   * @param imin min error value that will be summed
-   */
-  virtual void setErrorSumLimits(double imax, double imin);
-
-  /**
    * Resets the controller's internal state so it is similar to when it was first initialized, while
    * keeping any user-configured information.
    */
   void reset() override;
-
-  /**
-   * Set whether the integrator should be reset when error is 0 or changes sign.
-   *
-   * @param iresetOnZero true to reset
-   */
-  virtual void setIntegratorReset(bool iresetOnZero);
 
   /**
    * Changes whether the controller is off or on. Turning the controller on after it was off will
@@ -219,6 +184,45 @@ class IterativePosPIDController : public IterativePositionController<double, dou
    * @return sample time
    */
   QTime getSampleTime() const override;
+
+  /**
+   * Set integrator bounds. Default bounds are [-1, 1].
+   *
+   * @param imax max integrator value
+   * @param imin min integrator value
+   */
+  virtual void setIntegralLimits(double imax, double imin);
+
+  /**
+   * Set the error sum bounds. Default bounds are [0, std::numeric_limits<double>::max()]. Error
+   * will only be added to the integral term when its absolute value is between these bounds of
+   * either side of the target.
+   *
+   * @param imax max error value that will be summed
+   * @param imin min error value that will be summed
+   */
+  virtual void setErrorSumLimits(double imax, double imin);
+
+  /**
+   * Set whether the integrator should be reset when error is 0 or changes sign.
+   *
+   * @param iresetOnZero true to reset
+   */
+  virtual void setIntegratorReset(bool iresetOnZero);
+
+  /**
+   * Set controller gains.
+   *
+   * @param igains The new gains.
+   */
+  virtual void setGains(const Gains &igains);
+
+  /**
+   * Gets the current gains.
+   *
+   * @return The current gains.
+   */
+  Gains getGains() const;
 
   protected:
   std::shared_ptr<Logger> logger;

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -47,6 +47,22 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
     const std::shared_ptr<Logger> &ilogger = std::make_shared<Logger>());
 
   /**
+   * Velocity PD controller.
+   *
+   * @param igains The controller gains.
+   * @param ivelMath The VelMath used for calculating velocity.
+   * @param itimeUtil see TimeUtil docs
+   * @param iderivativeFilter a filter for filtering the derivative term
+   * @param ilogger The logger this instance will log to.
+   */
+  IterativeVelPIDController(
+    const Gains &igains,
+    std::unique_ptr<VelMath> ivelMath,
+    const TimeUtil &itimeUtil,
+    std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>(),
+    const std::shared_ptr<Logger> &ilogger = std::make_shared<Logger>());
+
+  /**
    * Do one iteration of the controller. Returns the reading in the range [-1, 1] unless the
    * bounds have been changed with setOutputLimits().
    *
@@ -180,12 +196,16 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
   /**
    * Set controller gains.
    *
-   * @param ikP proportional gain
-   * @param ikD derivative gain
-   * @param ikF the feed-forward gain
-   * @param ikSF a feed-forward gain to counteract static friction
+   * @param igains The new gains.
    */
-  virtual void setGains(double ikP, double ikD, double ikF, double ikSF);
+  virtual void setGains(const Gains &igains);
+
+  /**
+   * Gets the current gains.
+   *
+   * @return The current gains.
+   */
+  Gains getGains() const;
 
   /**
    * Sets the number of encoder ticks per revolution. Default is 1800.

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -315,4 +315,19 @@ AbstractMotor::GearsetRatioPair ChassisControllerPID::getGearsetRatioPair() cons
 void ChassisControllerPID::setVelocityMode(bool ivelocityMode) {
   velocityMode = ivelocityMode;
 }
+
+void ChassisControllerPID::setGains(const okapi::IterativePosPIDController::Gains &idistanceGains,
+                                    const okapi::IterativePosPIDController::Gains &iturnGains,
+                                    const okapi::IterativePosPIDController::Gains &iangleGains) {
+  distancePid->setGains(idistanceGains);
+  turnPid->setGains(iturnGains);
+  anglePid->setGains(iangleGains);
+}
+
+std::tuple<IterativePosPIDController::Gains,
+           IterativePosPIDController::Gains,
+           IterativePosPIDController::Gains>
+ChassisControllerPID::getGains() const {
+  return std::make_tuple(distancePid->getGains(), turnPid->getGains(), anglePid->getGains());
+}
 } // namespace okapi

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -37,7 +37,7 @@ IterativePosPIDController::IterativePosPIDController(const Gains &igains,
   if (igains.kI != 0) {
     setIntegralLimits(1 / igains.kI, -1 / igains.kI);
   }
-  setOutputLimits(-1, 1);
+  setOutputLimits(1, -1);
   setGains(igains);
 }
 

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -20,28 +20,25 @@ IterativePosPIDController::IterativePosPIDController(const double ikP,
                                                      const TimeUtil &itimeUtil,
                                                      std::unique_ptr<Filter> iderivativeFilter,
                                                      const std::shared_ptr<Logger> &ilogger)
-  : logger(ilogger),
-    derivativeFilter(std::move(iderivativeFilter)),
-    loopDtTimer(itimeUtil.getTimer()),
-    settledUtil(itimeUtil.getSettledUtil()) {
-  if (ikI != 0) {
-    setIntegralLimits(1 / ikI, -1 / ikI);
-  }
-  setOutputLimits(-1, 1);
-  setGains(ikP, ikI, ikD, ikBias);
+  : IterativePosPIDController({ikP, ikI, ikD, ikBias},
+                              itimeUtil,
+                              std::move(iderivativeFilter),
+                              ilogger) {
 }
 
 IterativePosPIDController::IterativePosPIDController(const Gains &igains,
                                                      const TimeUtil &itimeUtil,
                                                      std::unique_ptr<Filter> iderivativeFilter,
                                                      const std::shared_ptr<Logger> &ilogger)
-  : IterativePosPIDController(igains.kP,
-                              igains.kI,
-                              igains.kD,
-                              igains.kBias,
-                              itimeUtil,
-                              std::move(iderivativeFilter),
-                              ilogger) {
+  : logger(ilogger),
+    derivativeFilter(std::move(iderivativeFilter)),
+    loopDtTimer(itimeUtil.getTimer()),
+    settledUtil(itimeUtil.getSettledUtil()) {
+  if (igains.kI != 0) {
+    setIntegralLimits(1 / igains.kI, -1 / igains.kI);
+  }
+  setOutputLimits(-1, 1);
+  setGains(igains);
 }
 
 void IterativePosPIDController::setTarget(const double itarget) {
@@ -112,25 +109,6 @@ void IterativePosPIDController::setControllerSetTargetLimits(double itargetMax, 
   controllerSetTargetMin = itargetMin;
 }
 
-void IterativePosPIDController::setIntegralLimits(double imax, double imin) {
-  // Always use larger value as max
-  if (imin > imax) {
-    const double temp = imax;
-    imax = imin;
-    imin = temp;
-  }
-
-  integralMax = imax;
-  integralMin = imin;
-
-  integral = std::clamp(integral, integralMin, integralMax);
-}
-
-void IterativePosPIDController::setErrorSumLimits(const double imax, const double imin) {
-  errorSumMax = imax;
-  errorSumMin = imin;
-}
-
 double IterativePosPIDController::step(const double inewReading) {
   if (controllerIsDisabled) {
     return 0;
@@ -169,17 +147,6 @@ double IterativePosPIDController::step(const double inewReading) {
   return output;
 }
 
-void IterativePosPIDController::setGains(const double ikP,
-                                         const double ikI,
-                                         const double ikD,
-                                         const double ikBias) {
-  const double sampleTimeSec = sampleTime.convert(second);
-  kP = ikP;
-  kI = ikI * sampleTimeSec;
-  kD = ikD / sampleTimeSec;
-  kBias = ikBias;
-}
-
 void IterativePosPIDController::reset() {
   LOG_INFO_S("IterativePosPIDController: Reset");
 
@@ -210,5 +177,36 @@ bool IterativePosPIDController::isDisabled() const {
 
 QTime IterativePosPIDController::getSampleTime() const {
   return sampleTime;
+}
+
+void IterativePosPIDController::setIntegralLimits(double imax, double imin) {
+  // Always use larger value as max
+  if (imin > imax) {
+    const double temp = imax;
+    imax = imin;
+    imin = temp;
+  }
+
+  integralMax = imax;
+  integralMin = imin;
+
+  integral = std::clamp(integral, integralMin, integralMax);
+}
+
+void IterativePosPIDController::setErrorSumLimits(const double imax, const double imin) {
+  errorSumMax = imax;
+  errorSumMin = imin;
+}
+
+void IterativePosPIDController::setGains(const Gains &igains) {
+  const double sampleTimeSec = sampleTime.convert(second);
+  kP = igains.kP;
+  kI = igains.kI * sampleTimeSec;
+  kD = igains.kD / sampleTimeSec;
+  kBias = igains.kBias;
+}
+
+IterativePosPIDController::Gains IterativePosPIDController::getGains() const {
+  return {kP, kI / sampleTime.convert(second), kD * sampleTime.convert(second), kBias};
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -36,6 +36,7 @@ IterativeVelPIDController::IterativeVelPIDController(const Gains &igains,
     derivativeFilter(std::move(iderivativeFilter)),
     loopDtTimer(itimeUtil.getTimer()),
     settledUtil(itimeUtil.getSettledUtil()) {
+  setOutputLimits(1, -1);
   setGains(igains);
 }
 

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -19,22 +19,24 @@ IterativeVelPIDController::IterativeVelPIDController(const double ikP,
                                                      const TimeUtil &itimeUtil,
                                                      std::unique_ptr<Filter> iderivativeFilter,
                                                      const std::shared_ptr<Logger> &ilogger)
+  : IterativeVelPIDController({ikP, ikD, ikF, ikSF},
+                              std::move(ivelMath),
+                              itimeUtil,
+                              std::move(iderivativeFilter),
+                              ilogger) {
+}
+
+IterativeVelPIDController::IterativeVelPIDController(const Gains &igains,
+                                                     std::unique_ptr<VelMath> ivelMath,
+                                                     const TimeUtil &itimeUtil,
+                                                     std::unique_ptr<Filter> iderivativeFilter,
+                                                     const std::shared_ptr<Logger> &ilogger)
   : logger(ilogger),
     velMath(std::move(ivelMath)),
     derivativeFilter(std::move(iderivativeFilter)),
     loopDtTimer(itimeUtil.getTimer()),
     settledUtil(itimeUtil.getSettledUtil()) {
-  setGains(ikP, ikD, ikF, ikSF);
-}
-
-void IterativeVelPIDController::setGains(const double ikP,
-                                         const double ikD,
-                                         const double ikF,
-                                         const double ikSF) {
-  kP = ikP;
-  kD = ikD * sampleTime.convert(second);
-  kF = ikF;
-  kSF = ikSF;
+  setGains(igains);
 }
 
 void IterativeVelPIDController::setSampleTime(const QTime isampleTime) {
@@ -155,6 +157,17 @@ void IterativeVelPIDController::flipDisable(const bool iisDisabled) {
 
 bool IterativeVelPIDController::isDisabled() const {
   return controllerIsDisabled;
+}
+
+void IterativeVelPIDController::setGains(const Gains &igains) {
+  kP = igains.kP;
+  kD = igains.kD / sampleTime.convert(second);
+  kF = igains.kF;
+  kSF = igains.kSF;
+}
+
+IterativeVelPIDController::Gains IterativeVelPIDController::getGains() const {
+  return {kP, kD * sampleTime.convert(second), kF, kSF};
 }
 
 void IterativeVelPIDController::setTicksPerRev(const double tpr) {

--- a/src/api/control/util/pidTuner.cpp
+++ b/src/api/control/util/pidTuner.cpp
@@ -90,9 +90,9 @@ PIDTuner::Output PIDTuner::autotune() {
     for (std::size_t particleIndex = 0; particleIndex < numParticles; particleIndex++) {
       LOG_INFO("PIDTuner: Particle number " + std::to_string(particleIndex));
 
-      testController.setGains(particles.at(particleIndex).kP.pos,
-                              particles.at(particleIndex).kI.pos,
-                              particles.at(particleIndex).kD.pos);
+      testController.setGains({particles.at(particleIndex).kP.pos,
+                               particles.at(particleIndex).kI.pos,
+                               particles.at(particleIndex).kD.pos});
 
       // Reverse the goal every iteration to stay in the same general area
       std::int32_t target = goal;

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -46,6 +46,7 @@ class AsyncLinearMotionProfileControllerTest : public ::testing::Test {
 };
 
 TEST_F(AsyncLinearMotionProfileControllerTest, SettledWhenDisabled) {
+  controller->generatePath({0_m, 3_m}, "A");
   assertControllerIsSettledWhenDisabled(*controller, std::string("A"));
 }
 

--- a/test/chassisControllerPidTest.cpp
+++ b/test/chassisControllerPidTest.cpp
@@ -324,3 +324,23 @@ TEST_F(ChassisControllerPIDTest, SetMaxVelocityTest) {
   controller->setMaxVelocity(42);
   EXPECT_EQ(model->maxVelocity, 42);
 }
+
+TEST_F(ChassisControllerPIDTest, GetGainsReturnsTheSetGains) {
+  controller->setGains({0.1, 0.2, 0.3, 0.4}, {0.5, 0.6, 0.7, 0.8}, {0.9, 1.0, 1.1, 1.2});
+  auto [distanceGains, turnGains, angleGains] = controller->getGains();
+
+  EXPECT_FLOAT_EQ(distanceGains.kP, 0.1);
+  EXPECT_FLOAT_EQ(distanceGains.kI, 0.2);
+  EXPECT_FLOAT_EQ(distanceGains.kD, 0.3);
+  EXPECT_FLOAT_EQ(distanceGains.kBias, 0.4);
+
+  EXPECT_FLOAT_EQ(turnGains.kP, 0.5);
+  EXPECT_FLOAT_EQ(turnGains.kI, 0.6);
+  EXPECT_FLOAT_EQ(turnGains.kD, 0.7);
+  EXPECT_FLOAT_EQ(turnGains.kBias, 0.8);
+
+  EXPECT_FLOAT_EQ(angleGains.kP, 0.9);
+  EXPECT_FLOAT_EQ(angleGains.kI, 1.0);
+  EXPECT_FLOAT_EQ(angleGains.kD, 1.1);
+  EXPECT_FLOAT_EQ(angleGains.kBias, 1.2);
+}

--- a/test/iterativeMotorVelocityControllerTest.cpp
+++ b/test/iterativeMotorVelocityControllerTest.cpp
@@ -52,17 +52,17 @@ class IterativeMotorVelocityControllerTest : public ::testing::Test {
 };
 
 TEST_F(IterativeMotorVelocityControllerTest, SettledWhenDisabled) {
-  velController->setGains(0.1, 0.1, 0.1, 0.1);
+  velController->setGains({0.1, 0.1, 0.1, 0.1});
   assertControllerIsSettledWhenDisabled(*controller, 100.0);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, DisabledLifecycle) {
-  velController->setGains(0.1, 0, 0, 0);
+  velController->setGains({0.1, 0, 0, 0});
   assertIterativeControllerFollowsDisableLifecycle(*controller);
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, TargetLifecycle) {
-  velController->setGains(0.1, 0, 0, 0);
+  velController->setGains({0.1, 0, 0, 0});
   assertControllerFollowsTargetLifecycle(*controller);
 }
 
@@ -71,7 +71,7 @@ TEST_F(IterativeMotorVelocityControllerTest, ScalesControllerSetTarget) {
 }
 
 TEST_F(IterativeMotorVelocityControllerTest, StaticFrictionGainUsesTargetSign) {
-  velController->setGains(0, 0, 0, 0.1);
+  velController->setGains({0, 0, 0, 0.1});
 
   controller->setTarget(1);
   EXPECT_DOUBLE_EQ(controller->step(0), 1 * 0.1);

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -148,10 +148,10 @@ TEST_F(IterativePosPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
 }
 
 TEST_F(IterativePosPIDControllerTest, TestGetGainsReturnsTheOriginalGains) {
-  controller->setGains({0.1, 0.1, 0.1, 0.1});
+  controller->setGains({0.1, 0.2, 0.3, 0.4});
   auto gains = controller->getGains();
-  EXPECT_EQ(gains.kP, 0.1);
-  EXPECT_EQ(gains.kI, 0.1);
-  EXPECT_EQ(gains.kD, 0.1);
-  EXPECT_EQ(gains.kBias, 0.1);
+  EXPECT_FLOAT_EQ(gains.kP, 0.1);
+  EXPECT_FLOAT_EQ(gains.kI, 0.2);
+  EXPECT_FLOAT_EQ(gains.kD, 0.3);
+  EXPECT_FLOAT_EQ(gains.kBias, 0.4);
 }

--- a/test/iterativePosPIDControllerTests.cpp
+++ b/test/iterativePosPIDControllerTests.cpp
@@ -140,9 +140,18 @@ TEST_F(IterativePosPIDControllerTest, SampleTime) {
 }
 
 TEST_F(IterativePosPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
-  controller->setGains(0, 0, 1, 0);
-  EXPECT_EQ(controller->step(1), -1);
+  controller->setGains({0, 0, 0.0001, 0});
+  EXPECT_EQ(controller->step(1), -0.01);
   EXPECT_EQ(controller->step(1), 0);
-  EXPECT_EQ(controller->step(2), -1);
+  EXPECT_EQ(controller->step(2), -0.01);
   EXPECT_EQ(controller->step(2), 0);
+}
+
+TEST_F(IterativePosPIDControllerTest, TestGetGainsReturnsTheOriginalGains) {
+  controller->setGains({0.1, 0.1, 0.1, 0.1});
+  auto gains = controller->getGains();
+  EXPECT_EQ(gains.kP, 0.1);
+  EXPECT_EQ(gains.kI, 0.1);
+  EXPECT_EQ(gains.kD, 0.1);
+  EXPECT_EQ(gains.kBias, 0.1);
 }

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -42,7 +42,7 @@ class IterativeVelPIDControllerTest : public ::testing::Test {
 };
 
 TEST_F(IterativeVelPIDControllerTest, SettledWhenDisabled) {
-  controller->setGains(0.1, 0.1, 0.1, 0.1);
+  controller->setGains({0.1, 0.1, 0.1, 0.1});
   assertControllerIsSettledWhenDisabled(*controller, 100.0);
 }
 
@@ -70,7 +70,7 @@ TEST_F(IterativeVelPIDControllerTest, DoesNotKeepTrackOfReadingsWhenDisabled) {
 }
 
 TEST_F(IterativeVelPIDControllerTest, StaticFrictionGainUsesTargetSign) {
-  controller->setGains(0, 0, 0, 0.1);
+  controller->setGains({0, 0, 0, 0.1});
 
   controller->setTarget(1);
   EXPECT_DOUBLE_EQ(controller->step(0), 1 * 0.1);
@@ -141,9 +141,18 @@ TEST_F(IterativeVelPIDControllerTest, ControllerSetWithModifiedTargetLimits) {
 }
 
 TEST_F(IterativeVelPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
-  controller->setGains(0, 1, 0, 0);
-  EXPECT_NEAR(controller->step(1), -0.349, 0.0001);
+  controller->setGains({0, 0.0001, 0, 0});
+  EXPECT_NEAR(controller->step(1), -0.35, 0.01);
   EXPECT_EQ(controller->step(1), 0);
-  EXPECT_NEAR(controller->step(2), -0.349, 0.0001);
+  EXPECT_NEAR(controller->step(2), -0.35, 0.01);
   EXPECT_EQ(controller->step(2), 0);
+}
+
+TEST_F(IterativeVelPIDControllerTest, TestGetGainsReturnsTheOriginalGains) {
+  controller->setGains({0.1, 0.1, 0.1, 0.1});
+  auto gains = controller->getGains();
+  EXPECT_EQ(gains.kP, 0.1);
+  EXPECT_EQ(gains.kD, 0.1);
+  EXPECT_EQ(gains.kF, 0.1);
+  EXPECT_EQ(gains.kSF, 0.1);
 }

--- a/test/iterativeVelPIDControllerTests.cpp
+++ b/test/iterativeVelPIDControllerTests.cpp
@@ -149,10 +149,10 @@ TEST_F(IterativeVelPIDControllerTest, TestDerivativeTermWithDefaultFilter) {
 }
 
 TEST_F(IterativeVelPIDControllerTest, TestGetGainsReturnsTheOriginalGains) {
-  controller->setGains({0.1, 0.1, 0.1, 0.1});
+  controller->setGains({0.1, 0.2, 0.3, 0.4});
   auto gains = controller->getGains();
-  EXPECT_EQ(gains.kP, 0.1);
-  EXPECT_EQ(gains.kD, 0.1);
-  EXPECT_EQ(gains.kF, 0.1);
-  EXPECT_EQ(gains.kSF, 0.1);
+  EXPECT_FLOAT_EQ(gains.kP, 0.1);
+  EXPECT_FLOAT_EQ(gains.kD, 0.2);
+  EXPECT_FLOAT_EQ(gains.kF, 0.3);
+  EXPECT_FLOAT_EQ(gains.kSF, 0.4);
 }


### PR DESCRIPTION
### Description of the Change

This PR adds `setGains` and `getGains` methods to CCPID and the pid controllers. This PR also fixes a bug where IVPC's `kD` gain was scaled incorrectly.

### Benefits

Users can now change a CCPID's gains without subclassing it.

### Possible Drawbacks

None.

### Verification Process

New tests were added.

### Applicable Issues

Closes #346.
