### PR TITLE
Delete move ctors and move assignment operators

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -39,7 +39,9 @@ class ChassisControllerPID : public virtual ChassisController {
                        const ChassisScales &iscales = ChassisScales({1, 1}),
                        const std::shared_ptr<Logger> &ilogger = std::make_shared<Logger>());
 
-  ChassisControllerPID(ChassisControllerPID &&other) noexcept;
+  ChassisControllerPID(ChassisControllerPID &&other) = delete;
+
+  ChassisControllerPID &operator=(ChassisControllerPID &&other) = delete;
 
   ~ChassisControllerPID() override;
 

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -41,7 +41,10 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
     const AbstractMotor::GearsetRatioPair &ipair,
     const std::shared_ptr<Logger> &ilogger = std::make_shared<Logger>());
 
-  AsyncLinearMotionProfileController(AsyncLinearMotionProfileController &&other) noexcept;
+  AsyncLinearMotionProfileController(AsyncLinearMotionProfileController &&other) = delete;
+
+  AsyncLinearMotionProfileController &
+  operator=(AsyncLinearMotionProfileController &&other) = delete;
 
   ~AsyncLinearMotionProfileController() override;
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -42,7 +42,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
                                const AbstractMotor::GearsetRatioPair &ipair,
                                const std::shared_ptr<Logger> &ilogger = std::make_shared<Logger>());
 
-  AsyncMotionProfileController(AsyncMotionProfileController &&other) noexcept;
+  AsyncMotionProfileController(AsyncMotionProfileController &&other) = delete;
+
+  AsyncMotionProfileController &operator=(AsyncMotionProfileController &&other) = delete;
 
   ~AsyncMotionProfileController() override;
 

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -48,16 +48,9 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       ratio(iratio) {
   }
 
-  AsyncWrapper(AsyncWrapper<Input, Output> &&other) noexcept
-    : logger(std::move(other.logger)),
-      rateSupplier(std::move(other.rateSupplier)),
-      input(std::move(other.input)),
-      output(std::move(other.output)),
-      controller(std::move(other.controller)),
-      ratio(other.ratio),
-      dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
-      task(other.task) {
-  }
+  AsyncWrapper(AsyncWrapper<Input, Output> &&other) = delete;
+
+  AsyncWrapper<Input, Output> &operator=(AsyncWrapper<Input, Output> &&other) = delete;
 
   ~AsyncWrapper() override {
     dtorCalled.store(true, std::memory_order_release);

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -38,23 +38,6 @@ ChassisControllerPID::ChassisControllerPID(
   setEncoderUnits(AbstractMotor::encoderUnits::degrees);
 }
 
-ChassisControllerPID::ChassisControllerPID(ChassisControllerPID &&other) noexcept
-  : ChassisController(other.model, other.maxVelocity, other.maxVoltage),
-    logger(std::move(other.logger)),
-    timeUtil(other.timeUtil),
-    distancePid(std::move(other.distancePid)),
-    turnPid(std::move(other.turnPid)),
-    anglePid(std::move(other.anglePid)),
-    scales(other.scales),
-    gearsetRatioPair(other.gearsetRatioPair),
-    doneLooping(other.doneLooping.load(std::memory_order_acquire)),
-    newMovement(other.newMovement.load(std::memory_order_acquire)),
-    dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
-    mode(other.mode),
-    task(other.task) {
-  other.task = nullptr;
-}
-
 ChassisControllerPID::~ChassisControllerPID() {
   dtorCalled.store(true, std::memory_order_release);
   delete task;

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -25,23 +25,6 @@ AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
     timeUtil(itimeUtil) {
 }
 
-AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
-  AsyncLinearMotionProfileController &&other) noexcept
-  : logger(std::move(other.logger)),
-    paths(std::move(other.paths)),
-    limits(other.limits),
-    output(std::move(other.output)),
-    diameter(other.diameter),
-    pair(other.pair),
-    timeUtil(std::move(other.timeUtil)),
-    currentPath(std::move(other.currentPath)),
-    isRunning(other.isRunning.load(std::memory_order_acquire)),
-    direction(other.direction.load(std::memory_order_acquire)),
-    disabled(other.disabled.load(std::memory_order_acquire)),
-    dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
-    task(other.task) {
-}
-
 AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -32,23 +32,6 @@ AsyncMotionProfileController::AsyncMotionProfileController(
   }
 }
 
-AsyncMotionProfileController::AsyncMotionProfileController(
-  AsyncMotionProfileController &&other) noexcept
-  : logger(std::move(other.logger)),
-    paths(std::move(other.paths)),
-    limits(other.limits),
-    model(std::move(other.model)),
-    scales(other.scales),
-    pair(other.pair),
-    timeUtil(std::move(other.timeUtil)),
-    currentPath(std::move(other.currentPath)),
-    isRunning(other.isRunning.load(std::memory_order_acquire)),
-    direction(other.direction.load(std::memory_order_acquire)),
-    disabled(other.disabled.load(std::memory_order_acquire)),
-    dtorCalled(other.dtorCalled.load(std::memory_order_acquire)),
-    task(other.task) {
-}
-
 AsyncMotionProfileController::~AsyncMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
 


### PR DESCRIPTION
### Description of the Change

This PR deletes the move constructors and move assignment operators for classes which contain internal tasks because we don't yet have a good way to move them. When we do, that will go into #328.

### Benefits

The current, problematic implementations will be removed.

### Possible Drawbacks

People that were using these will need to find a workaround (typically subclassing what they need).

### Verification Process

This was not verified.

### Applicable Issues

None.
