### PR TITLE
Also log the task name in the logger

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -232,6 +232,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string getPathErrorMessage(const std::vector<Waypoint> &points, int length);
+  std::string
+  getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -229,6 +229,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string getPathErrorMessage(const std::vector<Waypoint> &points, int length);
+  std::string
+  getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -222,7 +222,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    */
   void startThread() {
     if (!task) {
-      task = new CrossplatformThread(trampoline, this);
+      task = new CrossplatformThread(trampoline, this, "AsyncWrapper");
     }
   }
 

--- a/include/okapi/api/coreProsAPI.hpp
+++ b/include/okapi/api/coreProsAPI.hpp
@@ -27,16 +27,21 @@
 
 class CrossplatformThread {
   public:
-  CrossplatformThread(void (*ptr)(void *), void *params)
+#ifdef THREADS_STD
+  CrossplatformThread(void (*ptr)(void *),
+                      void *params,
+                      const char *const = "OkapiLibCrossplatformTask")
+#else
+  CrossplatformThread(void (*ptr)(void *),
+                      void *params,
+                      const char *const name = "OkapiLibCrossplatformTask")
+#endif
     :
 #ifdef THREADS_STD
       thread(ptr, params)
 #else
-      thread(pros::c::task_create(ptr,
-                                  params,
-                                  TASK_PRIORITY_DEFAULT,
-                                  TASK_STACK_DEPTH_DEFAULT,
-                                  "OkapiLibCrossplatformTask"))
+      thread(
+        pros::c::task_create(ptr, params, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name))
 #endif
   {
   }

--- a/include/okapi/api/coreProsAPI.hpp
+++ b/include/okapi/api/coreProsAPI.hpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <sstream>
 
 #ifdef THREADS_STD
 #include <thread>
@@ -78,7 +79,9 @@ class CrossplatformThread {
 
   static std::string getName() {
 #ifdef THREADS_STD
-    return std::to_string(std::this_thread::get_id());
+    std::ostringstream ss;
+    ss << std::this_thread::get_id();
+    return ss.str();
 #else
     return std::string(pros::c::task_get_name(NULL));
 #endif

--- a/include/okapi/api/coreProsAPI.hpp
+++ b/include/okapi/api/coreProsAPI.hpp
@@ -76,5 +76,13 @@ class CrossplatformThread {
   }
 #endif
 
+  static std::string getName() {
+#ifdef THREADS_STD
+    return std::to_string(std::this_thread::get_id());
+#else
+    return std::string(pros::c::task_get_name(NULL));
+#endif
+  }
+
   CROSSPLATFORM_THREAD_T thread;
 };

--- a/include/okapi/api/util/logging.hpp
+++ b/include/okapi/api/util/logging.hpp
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "okapi/api/coreProsAPI.hpp"
 #include "okapi/api/util/abstractTimer.hpp"
 #include "okapi/api/util/mathUtil.hpp"
 #include <memory>
@@ -72,8 +73,9 @@ class Logger {
   template <typename T> constexpr void debug(T ilazyMessage) const noexcept {
     if (isDebugLevelEnabled() && logfile && timer) {
       fprintf(logfile,
-              "%ld DEBUG: %s\n",
+              "%ld (%s) DEBUG: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
+              CrossplatformThread::getName().c_str(),
               ilazyMessage());
     }
   }
@@ -85,8 +87,9 @@ class Logger {
   template <typename T> constexpr void info(T ilazyMessage) const noexcept {
     if (isInfoLevelEnabled() && logfile && timer) {
       fprintf(logfile,
-              "%ld INFO: %s\n",
+              "%ld (%s) INFO: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
+              CrossplatformThread::getName().c_str(),
               ilazyMessage());
     }
   }
@@ -98,8 +101,9 @@ class Logger {
   template <typename T> constexpr void warn(T ilazyMessage) const noexcept {
     if (isWarnLevelEnabled() && logfile && timer) {
       fprintf(logfile,
-              "%ld WARN: %s\n",
+              "%ld (%s) WARN: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
+              CrossplatformThread::getName().c_str(),
               ilazyMessage());
     }
   }
@@ -111,8 +115,9 @@ class Logger {
   template <typename T> constexpr void error(T ilazyMessage) const noexcept {
     if (isErrorLevelEnabled() && logfile && timer) {
       fprintf(logfile,
-              "%ld ERROR: %s\n",
+              "%ld (%s) ERROR: %s\n",
               static_cast<long>(timer->millis().convert(millisecond)),
+              CrossplatformThread::getName().c_str(),
               ilazyMessage());
     }
   }

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -312,7 +312,7 @@ ChassisControllerPID::getGains() const {
 
 void ChassisControllerPID::startThread() {
   if (!task) {
-    task = new CrossplatformThread(trampoline, this);
+    task = new CrossplatformThread(trampoline, this, "ChassisControllerPID");
   }
 }
 

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -67,7 +67,7 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
 
   if (length < 0) {
     std::string message = "AsyncLinearMotionProfileController: Length was negative. " +
-                          getPathErrorMessage(points, length);
+                          getPathErrorMessage(points, ipathId, length);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -85,7 +85,7 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
 
   if (trajectory == nullptr) {
     std::string message = "AsyncLinearMotionProfileController: Could not allocate trajectory. " +
-                          getPathErrorMessage(points, length);
+                          getPathErrorMessage(points, ipathId, length);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -108,19 +108,21 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
 
   paths.emplace(ipathId, TrajectoryPair{trajectory, length});
 
-  LOG_INFO_S("AsyncLinearMotionProfileController: Completely done generating path");
+  LOG_INFO("AsyncLinearMotionProfileController: Completely done generating path " + ipathId);
   LOG_DEBUG("AsyncLinearMotionProfileController: Path length: " + std::to_string(length));
 }
 
 std::string
 AsyncLinearMotionProfileController::getPathErrorMessage(const std::vector<Waypoint> &points,
+                                                        const std::string &ipathId,
                                                         const int length) {
   auto pointToString = [](Waypoint point) {
     return "Point{x=" + std::to_string(point.x) + ", y=" + std::to_string(point.y) +
            ", theta=" + std::to_string(point.angle) + "}";
   };
 
-  return "The path (length " + std::to_string(length) + ") is impossible with waypoints: " +
+  return "The path (id " + ipathId + ", length " + std::to_string(length) +
+         ") is impossible with waypoints: " +
          std::accumulate(std::next(points.begin()),
                          points.end(),
                          pointToString(points.at(0)),
@@ -289,7 +291,7 @@ bool AsyncLinearMotionProfileController::isDisabled() const {
 
 void AsyncLinearMotionProfileController::startThread() {
   if (!task) {
-    task = new CrossplatformThread(trampoline, this);
+    task = new CrossplatformThread(trampoline, this, "AsyncLinearMotionProfileController");
   }
 }
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -75,8 +75,8 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
   const int length = candidate.length;
 
   if (length < 0) {
-    std::string message =
-      "AsyncMotionProfileController: Length was negative. " + getPathErrorMessage(points, length);
+    std::string message = "AsyncMotionProfileController: Length was negative. " +
+                          getPathErrorMessage(points, ipathId, length);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -94,7 +94,7 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
 
   if (trajectory == nullptr) {
     std::string message = "AsyncMotionProfileController: Could not allocate trajectory. " +
-                          getPathErrorMessage(points, length);
+                          getPathErrorMessage(points, ipathId, length);
 
     if (candidate.laptr) {
       free(candidate.laptr);
@@ -118,7 +118,7 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
   if (leftTrajectory == nullptr || rightTrajectory == nullptr) {
     std::string message = "AsyncMotionProfileController: Could not allocate left and/or right "
                           "trajectories. " +
-                          getPathErrorMessage(points, length);
+                          getPathErrorMessage(points, ipathId, length);
 
     if (leftTrajectory) {
       free(leftTrajectory);
@@ -147,18 +147,20 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
 
   paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, length});
 
-  LOG_INFO_S("AsyncMotionProfileController: Completely done generating path");
+  LOG_INFO("AsyncMotionProfileController: Completely done generating path " + ipathId);
   LOG_DEBUG("AsyncMotionProfileController: Path length: " + std::to_string(length));
 }
 
 std::string AsyncMotionProfileController::getPathErrorMessage(const std::vector<Waypoint> &points,
+                                                              const std::string &ipathId,
                                                               int length) {
   auto pointToString = [](Waypoint point) {
     return "Point{x=" + std::to_string(point.x) + ", y=" + std::to_string(point.y) +
            ", theta=" + std::to_string(point.angle) + "}";
   };
 
-  return "The path (length " + std::to_string(length) + ") is impossible with waypoints: " +
+  return "The path (id " + ipathId + ", length " + std::to_string(length) +
+         ") is impossible with waypoints: " +
          std::accumulate(std::next(points.begin()),
                          points.end(),
                          pointToString(points.at(0)),
@@ -337,7 +339,7 @@ void AsyncMotionProfileController::tarePosition() {
 
 void AsyncMotionProfileController::startThread() {
   if (!task) {
-    task = new CrossplatformThread(trampoline, this);
+    task = new CrossplatformThread(trampoline, this, "AsyncMotionProfileController");
   }
 }
 

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -67,7 +67,8 @@ TEST_F(LoggerTest, ErrorLevel) {
   size_t len;
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+  std::string expected = "0 (" + CrossplatformThread::getName() + ") ERROR: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   if (line) {
     free(line);
@@ -84,10 +85,12 @@ TEST_F(LoggerTest, WarningLevel) {
   size_t len;
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+  std::string expected = "0 (" + CrossplatformThread::getName() + ") ERROR: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 WARN: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") WARN: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   if (line) {
     free(line);
@@ -104,13 +107,16 @@ TEST_F(LoggerTest, InfoLevel) {
   size_t len;
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+  std::string expected = "0 (" + CrossplatformThread::getName() + ") ERROR: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 WARN: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") WARN: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 INFO: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") INFO: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   if (line) {
     free(line);
@@ -127,16 +133,20 @@ TEST_F(LoggerTest, DebugLevel) {
   size_t len;
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 ERROR: MSG\n");
+  std::string expected = "0 (" + CrossplatformThread::getName() + ") ERROR: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 WARN: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") WARN: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 INFO: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") INFO: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "0 DEBUG: MSG\n");
+  expected = "0 (" + CrossplatformThread::getName() + ") DEBUG: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
 
   if (line) {
     free(line);


### PR DESCRIPTION
### Description of the Change

This PR has the `Logger` also log the task name.

### Benefits

Sometimes while reviewing someone's log file I want to know what tasks are logging what because all statements are interwoven. This will disambiguate the tasks in that case.

### Possible Drawbacks

None.

### Verification Process

This was verified by hand.

### Applicable Issues

None.
