### PR TITLE
Allow per-path profile limits

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -27,7 +27,7 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   /**
    * An Async Controller which generates and follows 1D motion profiles.
    *
-   * @param ilimits The limits.
+   * @param ilimits The default limits.
    * @param ioutput The output to write velocity targets to.
    * @param idiameter The effective diameter for whatever the motor spins.
    * @param ipair The gearset.
@@ -60,6 +60,22 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param ipathId A unique identifier to save the path with.
    */
   void generatePath(std::initializer_list<QLength> iwaypoints, const std::string &ipathId);
+
+  /**
+   * Generates a path which intersects the given waypoints and saves it internally with a key of
+   * pathId. Call executePath() with the same pathId to run it.
+   *
+   * If the waypoints form a path which is impossible to achieve, an instance of std::runtime_error
+   * is thrown (and an error is logged) which describes the waypoints. If there are no waypoints,
+   * no path is generated.
+   *
+   * @param iwaypoints The waypoints to hit on the path.
+   * @param ipathId A unique identifier to save the path with.
+   * @param ilimits The limits to use for this path only.
+   */
+  void generatePath(std::initializer_list<QLength> iwaypoints,
+                    const std::string &ipathId,
+                    const PathfinderLimits &ilimits);
 
   /**
    * Removes a path and frees the memory it used.
@@ -127,6 +143,20 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    * @param ibackwards Whether to follow the profile backwards.
    */
   void moveTo(const QLength &iposition, const QLength &itarget, bool ibackwards = false);
+
+  /**
+   * Generates a new path from the position (typically the current position) to the target and
+   * blocks until the controller has settled. Does not save the path which was generated.
+   *
+   * @param iposition The starting position.
+   * @param itarget The target position.
+   * @param ilimits The limits to use for this path only.
+   * @param ibackwards Whether to follow the profile backwards.
+   */
+  void moveTo(const QLength &iposition,
+              const QLength &itarget,
+              const PathfinderLimits &ilimits,
+              bool ibackwards = false);
 
   /**
    * Returns the last error of the controller. Does not update when disabled. Returns zero if there

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -29,7 +29,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * An Async Controller which generates and follows 2D motion profiles. Throws a
    * std::invalid_argument exception if the gear ratio is zero.
    *
-   * @param ilimits The limits.
+   * @param ilimits The default limits.
    * @param imodel The chassis model to control.
    * @param iscales The chassis dimensions.
    * @param ipair The gearset.
@@ -60,6 +60,22 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * @param ipathId A unique identifier to save the path with.
    */
   void generatePath(std::initializer_list<Point> iwaypoints, const std::string &ipathId);
+
+  /**
+   * Generates a path which intersects the given waypoints and saves it internally with a key of
+   * pathId. Call executePath() with the same pathId to run it.
+   *
+   * If the waypoints form a path which is impossible to achieve, an instance of std::runtime_error
+   * is thrown (and an error is logged) which describes the waypoints. If there are no waypoints,
+   * no path is generated.
+   *
+   * @param iwaypoints The waypoints to hit on the path.
+   * @param ipathId A unique identifier to save the path with.
+   * @param ilimits The limits to use for this path only.
+   */
+  void generatePath(std::initializer_list<Point> iwaypoints,
+                    const std::string &ipathId,
+                    const PathfinderLimits &ilimits);
 
   /**
    * Removes a path and frees the memory it used.
@@ -122,6 +138,20 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   void
   moveTo(std::initializer_list<Point> iwaypoints, bool ibackwards = false, bool imirrored = false);
+
+  /**
+   * Generates a new path from the position (typically the current position) to the target and
+   * blocks until the controller has settled. Does not save the path which was generated.
+   *
+   * @param iwaypoints The waypoints to hit on the path.
+   * @param ilimits The limits to use for this path only.
+   * @param ibackwards Whether to follow the profile backwards.
+   * @param imirrored Whether to follow the profile mirrored.
+   */
+  void moveTo(std::initializer_list<Point> iwaypoints,
+              const PathfinderLimits &ilimits,
+              bool ibackwards = false,
+              bool imirrored = false);
 
   /**
    * Returns the last error of the controller. Does not update when disabled. This implementation

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -35,8 +35,15 @@ AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
   delete task;
 }
 
+void AsyncLinearMotionProfileController::generatePath(
+  std::initializer_list<okapi::QLength> iwaypoints,
+  const std::string &ipathId) {
+  generatePath(iwaypoints, ipathId, limits);
+}
+
 void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLength> iwaypoints,
-                                                      const std::string &ipathId) {
+                                                      const std::string &ipathId,
+                                                      const PathfinderLimits &ilimits) {
   if (iwaypoints.size() == 0) {
     // No point in generating a path
     LOG_WARN_S("AsyncLinearMotionProfileController: Not generating a path because no waypoints were"
@@ -58,9 +65,9 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
                      FIT_HERMITE_CUBIC,
                      PATHFINDER_SAMPLES_FAST,
                      0.001,
-                     limits.maxVel,
-                     limits.maxAccel,
-                     limits.maxJerk,
+                     ilimits.maxVel,
+                     ilimits.maxAccel,
+                     ilimits.maxJerk,
                      &candidate);
 
   const int length = candidate.length;
@@ -237,11 +244,18 @@ void AsyncLinearMotionProfileController::waitUntilSettled() {
   LOG_INFO_S("AsyncLinearMotionProfileController: Done waiting to settle");
 }
 
+void AsyncLinearMotionProfileController::moveTo(const okapi::QLength &iposition,
+                                                const okapi::QLength &itarget,
+                                                bool ibackwards) {
+  moveTo(iposition, itarget, limits, ibackwards);
+}
+
 void AsyncLinearMotionProfileController::moveTo(const QLength &iposition,
                                                 const QLength &itarget,
+                                                const PathfinderLimits &ilimits,
                                                 const bool ibackwards) {
   std::string name = reinterpret_cast<const char *>(this); // hmmmm...
-  generatePath({iposition, itarget}, name);
+  generatePath({iposition, itarget}, name, ilimits);
   setTarget(name, ibackwards);
   waitUntilSettled();
   removePath(name);

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -35,9 +35,8 @@ AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
   delete task;
 }
 
-void AsyncLinearMotionProfileController::generatePath(
-  std::initializer_list<okapi::QLength> iwaypoints,
-  const std::string &ipathId) {
+void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLength> iwaypoints,
+                                                      const std::string &ipathId) {
   generatePath(iwaypoints, ipathId, limits);
 }
 
@@ -244,8 +243,8 @@ void AsyncLinearMotionProfileController::waitUntilSettled() {
   LOG_INFO_S("AsyncLinearMotionProfileController: Done waiting to settle");
 }
 
-void AsyncLinearMotionProfileController::moveTo(const okapi::QLength &iposition,
-                                                const okapi::QLength &itarget,
+void AsyncLinearMotionProfileController::moveTo(const QLength &iposition,
+                                                const QLength &itarget,
                                                 bool ibackwards) {
   moveTo(iposition, itarget, limits, ibackwards);
 }

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -43,7 +43,7 @@ AsyncMotionProfileController::~AsyncMotionProfileController() {
   delete task;
 }
 
-void AsyncMotionProfileController::generatePath(std::initializer_list<okapi::Point> iwaypoints,
+void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwaypoints,
                                                 const std::string &ipathId) {
   generatePath(iwaypoints, ipathId, limits);
 }
@@ -293,7 +293,7 @@ void AsyncMotionProfileController::waitUntilSettled() {
   LOG_INFO_S("AsyncMotionProfileController: Done waiting to settle");
 }
 
-void AsyncMotionProfileController::moveTo(std::initializer_list<okapi::Point> iwaypoints,
+void AsyncMotionProfileController::moveTo(std::initializer_list<Point> iwaypoints,
                                           bool ibackwards,
                                           bool imirrored) {
   moveTo(iwaypoints, limits, ibackwards, imirrored);

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -43,8 +43,14 @@ AsyncMotionProfileController::~AsyncMotionProfileController() {
   delete task;
 }
 
-void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwaypoints,
+void AsyncMotionProfileController::generatePath(std::initializer_list<okapi::Point> iwaypoints,
                                                 const std::string &ipathId) {
+  generatePath(iwaypoints, ipathId, limits);
+}
+
+void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwaypoints,
+                                                const std::string &ipathId,
+                                                const PathfinderLimits &ilimits) {
   if (iwaypoints.size() == 0) {
     // No point in generating a path
     LOG_WARN_S(
@@ -67,9 +73,9 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                      FIT_HERMITE_CUBIC,
                      PATHFINDER_SAMPLES_FAST,
                      0.001,
-                     limits.maxVel,
-                     limits.maxAccel,
-                     limits.maxJerk,
+                     ilimits.maxVel,
+                     ilimits.maxAccel,
+                     ilimits.maxJerk,
                      &candidate);
 
   const int length = candidate.length;
@@ -287,11 +293,18 @@ void AsyncMotionProfileController::waitUntilSettled() {
   LOG_INFO_S("AsyncMotionProfileController: Done waiting to settle");
 }
 
+void AsyncMotionProfileController::moveTo(std::initializer_list<okapi::Point> iwaypoints,
+                                          bool ibackwards,
+                                          bool imirrored) {
+  moveTo(iwaypoints, limits, ibackwards, imirrored);
+}
+
 void AsyncMotionProfileController::moveTo(std::initializer_list<Point> iwaypoints,
+                                          const PathfinderLimits &ilimits,
                                           const bool ibackwards,
                                           const bool imirrored) {
   std::string name = reinterpret_cast<const char *>(this); // hmmmm...
-  generatePath(iwaypoints, name);
+  generatePath(iwaypoints, name, ilimits);
   setTarget(name, ibackwards, imirrored);
   waitUntilSettled();
   removePath(name);


### PR DESCRIPTION
### Description of the Change

This PR adds an option to specify Pathfinder limits per-profile.

### Benefits

Some users have wanted different limits for certain profiles.

### Possible Drawbacks

None.

### Verification Process

This was not verified.

### Applicable Issues

#353.
