### PR TITLE
Initialize member variables in VelMath

### DIFF
--- a/include/okapi/api/filter/velMath.hpp
+++ b/include/okapi/api/filter/velMath.hpp
@@ -78,7 +78,7 @@ class VelMath {
   Logger *logger;
   QAngularSpeed vel{0_rpm};
   QAngularSpeed lastVel{0_rpm};
-  QAngularAcceleration accel{0_rpm / 0_s};
+  QAngularAcceleration accel{0.0};
   double lastPos{0};
   double ticksPerRev;
 

--- a/include/okapi/api/filter/velMath.hpp
+++ b/include/okapi/api/filter/velMath.hpp
@@ -76,10 +76,10 @@ class VelMath {
 
   protected:
   Logger *logger;
-  QAngularSpeed vel;
-  QAngularSpeed lastVel;
-  QAngularAcceleration accel;
-  double lastPos = 0;
+  QAngularSpeed vel{0_rpm};
+  QAngularSpeed lastVel{0_rpm};
+  QAngularAcceleration accel{0_rpm / 0_s};
+  double lastPos{0};
   double ticksPerRev;
 
   QTime sampleTime;

--- a/test/filterTests.cpp
+++ b/test/filterTests.cpp
@@ -226,3 +226,11 @@ TEST(VelMathTest, ZeroTPRThrowsException) {
       0, std::make_shared<PassthroughFilter>(), 0_ms, std::make_unique<ConstantMockTimer>(10_ms)),
     std::invalid_argument);
 }
+
+TEST(VelMathTest, VelEqualToZeroWithoutStep) {
+  VelMath velMath(
+    360, std::make_shared<PassthroughFilter>(), 10_ms, std::make_unique<ConstantMockTimer>(10_ms));
+
+  EXPECT_EQ(velMath.getVelocity().convert(rpm), 0);
+  EXPECT_EQ(velMath.getAccel().convert(rpm / second), 0);
+}


### PR DESCRIPTION
### Description of the Change
Initialize default values for `VelMath` so calling `step()` with dT of 0 will not result in undefined behavior.

### Benefits
Prevent `VelMath` from reporting erroneous velocity values until minimum dT is satisfied.

### Possible Drawbacks
None.

### Verification Process
Add a test to confirm `getVelocity()` and `getAccel()` return 0 after initialization.
