### PR TITLE
Issue #358: Implement saving/loading paths

### DIFF
--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -286,6 +286,6 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * @param filename The file name in the directory
    * @return the fully qualified and legal path name
    */
-  static std::string makePath(std::string directory, std::string filename);
+  static std::string makeFilePath(std::string directory, std::string filename);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -292,7 +292,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   static std::string makeFilePath(std::string directory, std::string filename);
 
-  void internalStorePath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId);
-  void internalLoadPath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId);
+  void internalStorePath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId);
+  void internalLoadPath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -277,7 +277,15 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string
-  getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
+  std::string getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
+  
+  /**
+   * Joins and escapes a directory and file name
+   * 
+   * @param directory The directory path, separated by forward slashes (/) and with or without a trailing slash
+   * @param filename The file name in the directory
+   * @return the fully qualified and legal path name
+   */
+  static std::string makePath(std::string directory, std::string filename);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -220,6 +220,24 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   CrossplatformThread *getThread() const;
 
+  /**
+   * Saves a generated path to files.
+   * Paths are stored as <ipathId>.<left/right>.csv
+   * The directory must exist.
+   * 
+   * @param idirectory The directory to store the path files in
+   * @param ipathId The path ID of the generated path
+   */
+  void storePath(std::string idirectory, std::string ipathId);
+
+  /**
+   * Loads a path from a directory containing path CSV files.
+   * 
+   * @param idirectory The directory that the path files are stored in
+   * @param ipathId The path ID that the paths are stored under (and will be loaded into)
+   */
+  void loadPath(std::string ifilename, std::string ipathId);
+
   protected:
   struct TrajectoryPair {
     Segment *left;

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -291,5 +291,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * @return the fully qualified and legal path name
    */
   static std::string makeFilePath(std::string directory, std::string filename);
+
+  void internalStorePath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId);
+  void internalLoadPath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -223,7 +223,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   /**
    * Saves a generated path to files.
    * Paths are stored as <ipathId>.<left/right>.csv
-   * The directory must exist.
+   * An SD card must be inserted into the brain and the directory must exist.
+   * idirectory can be prefixed with /usd/, but it this is not required.
    * 
    * @param idirectory The directory to store the path files in
    * @param ipathId The path ID of the generated path
@@ -231,7 +232,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   void storePath(std::string idirectory, std::string ipathId);
 
   /**
-   * Loads a path from a directory containing path CSV files.
+   * Loads a path from a directory on the SD card containing path CSV files.
+   * /usd/ is automatically prepended to idirectory if it is not specified.
    * 
    * @param idirectory The directory that the path files are stored in
    * @param ipathId The path ID that the paths are stored under (and will be loaded into)

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -225,7 +225,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * Paths are stored as <ipathId>.<left/right>.csv
    * An SD card must be inserted into the brain and the directory must exist.
    * idirectory can be prefixed with /usd/, but it this is not required.
-   * 
+   *
    * @param idirectory The directory to store the path files in
    * @param ipathId The path ID of the generated path
    */
@@ -234,7 +234,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   /**
    * Loads a path from a directory on the SD card containing path CSV files.
    * /usd/ is automatically prepended to idirectory if it is not specified.
-   * 
+   *
    * @param idirectory The directory that the path files are stored in
    * @param ipathId The path ID that the paths are stored under (and will be loaded into)
    */
@@ -279,12 +279,14 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
-  
+  std::string
+  getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
+
   /**
    * Joins and escapes a directory and file name
-   * 
-   * @param directory The directory path, separated by forward slashes (/) and with or without a trailing slash
+   *
+   * @param directory The directory path, separated by forward slashes (/) and with or without a
+   * trailing slash
    * @param filename The file name in the directory
    * @return the fully qualified and legal path name
    */

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -236,7 +236,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * @param idirectory The directory that the path files are stored in
    * @param ipathId The path ID that the paths are stored under (and will be loaded into)
    */
-  void loadPath(std::string ifilename, std::string ipathId);
+  void loadPath(std::string idirectory, std::string ipathId);
 
   protected:
   struct TrajectoryPair {

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -463,8 +463,6 @@ std::string AsyncMotionProfileController::makeFilePath(std::string directory,
                                                        std::string filename) {
   std::string path(directory);
 
-  // Make sure this is an absolute path beginning /usd/<subdirs>
-
   // Checks first substring
   if (path.rfind("/usd", 0) == std::string::npos) {
     if (path.rfind("usd", 0) != std::string::npos) {

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -362,8 +362,8 @@ CrossplatformThread *AsyncMotionProfileController::getThread() const {
 }
 
 void AsyncMotionProfileController::storePath(std::string idirectory, std::string ipathId) {
-  FILE* leftPathFile = fopen(makePath(idirectory, ipathId + ".left.csv").c_str(), "w");
-  FILE* rightPathFile = fopen(makePath(idirectory, ipathId + ".right.csv").c_str(), "w");
+  FILE* leftPathFile = fopen(makeFilePath(idirectory, ipathId + ".left.csv").c_str(), "w");
+  FILE* rightPathFile = fopen(makeFilePath(idirectory, ipathId + ".right.csv").c_str(), "w");
 
   // Make sure we can open the file successfully
   if (leftPathFile == NULL || rightPathFile == NULL) {
@@ -395,8 +395,8 @@ void AsyncMotionProfileController::storePath(std::string idirectory, std::string
 }
 
 void AsyncMotionProfileController::loadPath(std::string idirectory, std::string ipathId) {
-  FILE* leftPathFile = fopen(makePath(idirectory, ipathId + ".left.csv").c_str(), "r");
-  FILE* rightPathFile = fopen(makePath(idirectory, ipathId + ".right.csv").c_str(), "r");
+  FILE* leftPathFile = fopen(makeFilePath(idirectory, ipathId + ".left.csv").c_str(), "r");
+  FILE* rightPathFile = fopen(makeFilePath(idirectory, ipathId + ".right.csv").c_str(), "r");
 
   // Make sure we can open the file successfully
   if (leftPathFile == NULL || rightPathFile == NULL) {
@@ -432,7 +432,7 @@ void AsyncMotionProfileController::loadPath(std::string idirectory, std::string 
   paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, count});
 }
 
-std::string AsyncMotionProfileController::makePath(std::string directory, std::string filename) {
+std::string AsyncMotionProfileController::makeFilePath(std::string directory, std::string filename) {
   std::string path(directory);
   if (directory.length() == 0 || directory.back() != '/') {
     path.append("/");

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -371,11 +371,15 @@ void AsyncMotionProfileController::storePath(std::string idirectory, std::string
   // Make sure we can open the file successfully
   if (leftPathFile == NULL) {
     LOG_WARN("AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for writing");
+    if (rightPathFile != NULL) {
+      fclose(rightPathFile);
+    }
     return;
   }
   if (rightPathFile == NULL) {
     LOG_WARN("AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for writing");
-    return; // cppcheck thinks this is a resource leak, but fclose(NULL) is undefined behavior
+    fclose(leftPathFile);
+    return;
   }
 
   auto pathData = this->paths.find(ipathId);
@@ -406,11 +410,15 @@ void AsyncMotionProfileController::loadPath(std::string idirectory, std::string 
   // Make sure we can open the file successfully
   if (leftPathFile == NULL) {
     LOG_WARN("AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for reading");
-    return;
+    if (rightPathFile != NULL) {
+      fclose(rightPathFile);
+    }
+    return; 
   }
   if (rightPathFile == NULL) {
     LOG_WARN("AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for reading");
-    return; // cppcheck thinks this is a resource leak, but fclose(NULL) is undefined behavior
+    fclose(leftPathFile);
+    return;
   }
 
   // Count lines in file, remove one for headers

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -7,9 +7,9 @@
  */
 #include "okapi/api/control/async/asyncMotionProfileController.hpp"
 #include "okapi/api/util/mathUtil.hpp"
-#include <numeric>
 #include <algorithm>
 #include <iostream>
+#include <numeric>
 
 namespace okapi {
 AsyncMotionProfileController::AsyncMotionProfileController(
@@ -365,38 +365,34 @@ CrossplatformThread *AsyncMotionProfileController::getThread() const {
 void AsyncMotionProfileController::storePath(std::string idirectory, std::string ipathId) {
   std::string leftFilePath = makeFilePath(idirectory, ipathId + ".left.csv");
   std::string rightFilePath = makeFilePath(idirectory, ipathId + ".right.csv");
-  FILE* leftPathFile = fopen(leftFilePath.c_str(), "w");
-  FILE* rightPathFile = fopen(rightFilePath.c_str(), "w");
+  FILE *leftPathFile = fopen(leftFilePath.c_str(), "w");
+  FILE *rightPathFile = fopen(rightFilePath.c_str(), "w");
 
   // Make sure we can open the file successfully
   if (leftPathFile == NULL) {
-    LOG_WARN(
-      "AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for writing");
+    LOG_WARN("AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for writing");
     return;
   }
   if (rightPathFile == NULL) {
-    LOG_WARN(
-      "AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for writing");
-    return;
+    LOG_WARN("AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for writing");
+    return; // cppcheck thinks this is a resource leak, but fclose(NULL) is undefined behavior
   }
 
   auto pathData = this->paths.find(ipathId);
 
   // Make sure path exists
   if (pathData == paths.end()) {
-    LOG_WARN(
-      "AsyncMotionProfileController: Controller was asked to serialize non-existent path " +
-      ipathId);
+    LOG_WARN("AsyncMotionProfileController: Controller was asked to serialize non-existent path " +
+             ipathId);
     // Do nothing- can't serialize nonexistent path
-  }
-  else {
+  } else {
     int len = pathData->second.length;
 
     // Serialize paths
     pathfinder_serialize_csv(leftPathFile, pathData->second.left, len);
     pathfinder_serialize_csv(rightPathFile, pathData->second.right, len);
   }
-  
+
   fclose(leftPathFile);
   fclose(rightPathFile);
 }
@@ -404,19 +400,17 @@ void AsyncMotionProfileController::storePath(std::string idirectory, std::string
 void AsyncMotionProfileController::loadPath(std::string idirectory, std::string ipathId) {
   std::string leftFilePath = makeFilePath(idirectory, ipathId + ".left.csv");
   std::string rightFilePath = makeFilePath(idirectory, ipathId + ".right.csv");
-  FILE* leftPathFile = fopen(leftFilePath.c_str(), "r");
-  FILE* rightPathFile = fopen(rightFilePath.c_str(), "r");
+  FILE *leftPathFile = fopen(leftFilePath.c_str(), "r");
+  FILE *rightPathFile = fopen(rightFilePath.c_str(), "r");
 
   // Make sure we can open the file successfully
   if (leftPathFile == NULL) {
-    LOG_WARN(
-      "AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for reading");
+    LOG_WARN("AsyncMotionProfileController: Couldn't open file " + leftFilePath + " for reading");
     return;
   }
   if (rightPathFile == NULL) {
-    LOG_WARN(
-      "AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for reading");
-    return;
+    LOG_WARN("AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for reading");
+    return; // cppcheck thinks this is a resource leak, but fclose(NULL) is undefined behavior
   }
 
   // Count lines in file, remove one for headers
@@ -445,7 +439,8 @@ void AsyncMotionProfileController::loadPath(std::string idirectory, std::string 
   paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, count});
 }
 
-std::string AsyncMotionProfileController::makeFilePath(std::string directory, std::string filename) {
+std::string AsyncMotionProfileController::makeFilePath(std::string directory,
+                                                       std::string filename) {
   std::string path(directory);
 
   // Make sure this is an absolute path beginning /usd/<subdirs>
@@ -455,13 +450,11 @@ std::string AsyncMotionProfileController::makeFilePath(std::string directory, st
     if (path.rfind("usd", 0) != std::string::npos) {
       // There's a usd, but no beginning slash
       path.insert(0, "/"); // We just need a slash
-    } 
-    else { // There's nothing at all
+    } else {               // There's nothing at all
       if (path.front() == '/') {
         // Don't double up on slashes
         path.insert(0, "/usd");
-      }
-      else {
+      } else {
         path.insert(0, "/usd/");
       }
     }

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -400,7 +400,7 @@ void AsyncMotionProfileController::loadPath(std::string idirectory, std::string 
     if (rightPathFile != NULL) {
       fclose(rightPathFile);
     }
-    return; 
+    return;
   }
   if (rightPathFile == NULL) {
     LOG_WARN("AsyncMotionProfileController: Couldn't open file " + rightFilePath + " for reading");
@@ -414,7 +414,9 @@ void AsyncMotionProfileController::loadPath(std::string idirectory, std::string 
   fclose(rightPathFile);
 }
 
-void AsyncMotionProfileController::internalStorePath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId) {
+void AsyncMotionProfileController::internalStorePath(FILE *leftPathFile,
+                                                     FILE *rightPathFile,
+                                                     std::string ipathId) {
   auto pathData = this->paths.find(ipathId);
 
   // Make sure path exists
@@ -431,7 +433,9 @@ void AsyncMotionProfileController::internalStorePath(FILE* leftPathFile, FILE* r
   }
 }
 
-void AsyncMotionProfileController::internalLoadPath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId) {
+void AsyncMotionProfileController::internalLoadPath(FILE *leftPathFile,
+                                                    FILE *rightPathFile,
+                                                    std::string ipathId) {
   // Count lines in file, remove one for headers
   int count = 0;
   for (int c = getc(leftPathFile); c != EOF; c = getc(leftPathFile)) {
@@ -483,7 +487,7 @@ std::string AsyncMotionProfileController::makeFilePath(std::string directory,
   std::string filenameCopy(filename);
   // Remove restricted characters from filename
   static const std::string illegalChars = "\\/:?*\"<>|";
-  for (auto it = filenameCopy.begin() ; it < filenameCopy.end(); it++) {
+  for (auto it = filenameCopy.begin(); it < filenameCopy.end(); it++) {
     if (illegalChars.rfind(*it) != std::string::npos) {
       it = filenameCopy.erase(it);
     }

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -481,9 +481,13 @@ std::string AsyncMotionProfileController::makeFilePath(std::string directory,
     path.append("/");
   }
   std::string filenameCopy(filename);
-  // Remove / from filename
-  // Requires testing- unsure of filename limitations
-  std::replace(filenameCopy.begin(), filenameCopy.end(), '/', '_');
+  // Remove restricted characters from filename
+  static const std::string illegalChars = "\\/:?*\"<>|";
+  for (auto it = filenameCopy.begin() ; it < filenameCopy.end(); it++) {
+    if (illegalChars.rfind(*it) != std::string::npos) {
+      it = filenameCopy.erase(it);
+    }
+  }
 
   path.append(filenameCopy);
 

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -15,22 +15,13 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
   public:
   using AsyncMotionProfileController::AsyncMotionProfileController;
   using AsyncMotionProfileController::convertLinearToRotational;
+  using AsyncMotionProfileController::internalLoadPath;
+  using AsyncMotionProfileController::internalStorePath;
+  using AsyncMotionProfileController::makeFilePath;
 
   void executeSinglePath(const TrajectoryPair &path, std::unique_ptr<AbstractRate> rate) override {
     executeSinglePathCalled = true;
     AsyncMotionProfileController::executeSinglePath(path, std::move(rate));
-  }
-
-  static std::string makeFilePath(std::string directory, std::string filename) {
-    return AsyncMotionProfileController::makeFilePath(directory, filename);
-  }
-
-  void internalStorePath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId) {
-    AsyncMotionProfileController::internalStorePath(leftPathFile, rightPathFile, ipathId);
-  }
-
-  void internalLoadPath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId) {
-    AsyncMotionProfileController::internalLoadPath(leftPathFile, rightPathFile, ipathId);
   }
 
   TrajectoryPair getPathData(std::string ipathId) {

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -60,6 +60,8 @@ class AsyncMotionProfileControllerTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    fclose(leftPathFile);
+    fclose(rightPathFile);
     free(leftFileBuf);
     free(rightFileBuf);
     delete controller;
@@ -310,6 +312,10 @@ TEST_F(AsyncMotionProfileControllerTest, FilePathJoin) {
                "/usd/subdir/test");
   EXPECT_STREQ(MockAsyncMotionProfileController::makeFilePath("/subdir/", "test").c_str(),
                "/usd/subdir/test");
+}
+
+TEST_F(AsyncMotionProfileControllerTest, FilePathRestrict) {
+  EXPECT_STREQ(MockAsyncMotionProfileController::makeFilePath("", "t>e<s\"t\\F:i*l|e/").c_str(), "/usd/testFile");
 }
 
 TEST_F(AsyncMotionProfileControllerTest, SaveLoadPath) {

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -25,11 +25,11 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
     return AsyncMotionProfileController::makeFilePath(directory, filename);
   }
 
-  void internalStorePath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId) {
+  void internalStorePath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId) {
     AsyncMotionProfileController::internalStorePath(leftPathFile, rightPathFile, ipathId);
   }
 
-  void internalLoadPath(FILE* leftPathFile, FILE* rightPathFile, std::string ipathId) {
+  void internalLoadPath(FILE *leftPathFile, FILE *rightPathFile, std::string ipathId) {
     AsyncMotionProfileController::internalLoadPath(leftPathFile, rightPathFile, ipathId);
   }
 
@@ -72,10 +72,10 @@ class AsyncMotionProfileControllerTest : public ::testing::Test {
   SkidSteerModel *model;
   MockAsyncMotionProfileController *controller;
 
-  FILE* leftPathFile;
-  FILE* rightPathFile;
-  char* leftFileBuf;
-  char* rightFileBuf;
+  FILE *leftPathFile;
+  FILE *rightPathFile;
+  char *leftFileBuf;
+  char *rightFileBuf;
   size_t leftFileSize;
   size_t rightFileSize;
 };
@@ -315,7 +315,8 @@ TEST_F(AsyncMotionProfileControllerTest, FilePathJoin) {
 }
 
 TEST_F(AsyncMotionProfileControllerTest, FilePathRestrict) {
-  EXPECT_STREQ(MockAsyncMotionProfileController::makeFilePath("", "t>e<s\"t\\F:i*l|e/").c_str(), "/usd/testFile");
+  EXPECT_STREQ(MockAsyncMotionProfileController::makeFilePath("", "t>e<s\"t\\F:i*l|e/").c_str(),
+               "/usd/testFile");
 }
 
 TEST_F(AsyncMotionProfileControllerTest, SaveLoadPath) {

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -264,18 +264,26 @@ TEST_F(AsyncMotionProfileControllerTest, FollowPathMirrored) {
 }
 
 TEST_F(AsyncMotionProfileControllerTest, MakeFilePath) {
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/", "test").c_str(),
+               "/usd/test");
   ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/", "test").c_str(), "/usd/test");
   ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd", "test").c_str(), "/usd/test");
   ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd", "test").c_str(), "/usd/test");
   ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("", "test").c_str(), "/usd/test");
   ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/", "test").c_str(), "/usd/test");
 
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir/", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir/", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir/", "test").c_str(), "/usd/subdir/test");
-  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/subdir/", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir/", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir/", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir/", "test").c_str(),
+               "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/subdir/", "test").c_str(),
+               "/usd/subdir/test");
 }

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -21,6 +21,10 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
     AsyncMotionProfileController::executeSinglePath(path, std::move(rate));
   }
 
+  static std::string makeFilePath(std::string directory, std::string filename) {
+    return AsyncMotionProfileController::makeFilePath(directory, filename);
+  }
+
   bool executeSinglePathCalled{false};
 };
 
@@ -257,4 +261,21 @@ TEST_F(AsyncMotionProfileControllerTest, FollowPathMirrored) {
   // Disable the controller so gtest doesn't clean up the test fixture while the internal thread is
   // still running
   controller->flipDisable(true);
+}
+
+TEST_F(AsyncMotionProfileControllerTest, MakeFilePath) {
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("", "test").c_str(), "/usd/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/", "test").c_str(), "/usd/test");
+
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/usd/subdir/", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("usd/subdir/", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("subdir/", "test").c_str(), "/usd/subdir/test");
+  ASSERT_STREQ(MockAsyncMotionProfileController::makeFilePath("/subdir/", "test").c_str(), "/usd/subdir/test");
 }


### PR DESCRIPTION
Create methods in asyncMotionProfileController.
Needs testing, error checking and sanitization should be implemented.

### Description of the Change
Implements Pathfinder serialize/deserialize methods in asyncMotionProfileController

### Motivation
Paths are memory-heavy, and the v5 brain is limited. This would allow many more paths to be used as they would not have to be generated on the fly or a more limited number generated on initialize.

### Possible Drawbacks
Completely optional feature, no drawbacks foreseen.

### Verification Process
Testing WIP

### Applicable Issues

<!-- Enter any applicable Issues here -->
