### PR TITLE
Change motion profile DT to 10 milliseconds

### DIFF
--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -213,13 +213,13 @@ void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair 
   const auto reversed = direction.load(std::memory_order_acquire);
 
   for (int i = 0; i < path.length && !isDisabled(); ++i) {
-    float segDT = path.segment[i].dt;
+    const auto segDT = path.segment[i].dt * second;
     currentProfilePosition = path.segment[i].position;
 
     const auto motorRPM = convertLinearToRotational(path.segment[i].velocity * mps).convert(rpm);
     output->controllerSet(motorRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-    rate->delayUntil(segDT * second);
+    rate->delayUntil(segDT);
   }
 }
 

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -63,7 +63,7 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
                      PATHFINDER_SAMPLES_FAST,
-                     0.001,
+                     0.010,
                      ilimits.maxVel,
                      ilimits.maxAccel,
                      ilimits.maxJerk,
@@ -213,12 +213,13 @@ void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair 
   const auto reversed = direction.load(std::memory_order_acquire);
 
   for (int i = 0; i < path.length && !isDisabled(); ++i) {
+    float segDT = path.segment[i].dt;
     currentProfilePosition = path.segment[i].position;
 
     const auto motorRPM = convertLinearToRotational(path.segment[i].velocity * mps).convert(rpm);
     output->controllerSet(motorRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-    rate->delayUntil(1_ms);
+    rate->delayUntil(segDT * second);
   }
 }
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -253,25 +253,25 @@ void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
 
   if (followMirrored) {
     for (int i = 0; i < path.length && !isDisabled(); ++i) {
-      float segDT = path.left[i].dt;
+      const auto segDT = path.left[i].dt * second;
       const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
       const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
 
       model->left(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
       model->right(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-      rate->delayUntil(segDT * second);
+      rate->delayUntil(segDT);
     }
   } else {
     for (int i = 0; i < path.length && !isDisabled(); ++i) {
-      float segDT = path.left[i].dt;
+      const auto segDT = path.left[i].dt * second;
       const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
       const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
 
       model->left(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
       model->right(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-      rate->delayUntil(segDT * second);
+      rate->delayUntil(segDT);
     }
   }
 }

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -74,7 +74,7 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
                      PATHFINDER_SAMPLES_FAST,
-                     0.001,
+                     0.010,
                      ilimits.maxVel,
                      ilimits.maxAccel,
                      ilimits.maxJerk,
@@ -253,23 +253,25 @@ void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
 
   if (followMirrored) {
     for (int i = 0; i < path.length && !isDisabled(); ++i) {
+      float segDT = path.left[i].dt;
       const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
       const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
 
       model->left(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
       model->right(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-      rate->delayUntil(1_ms);
+      rate->delayUntil(segDT * second);
     }
   } else {
     for (int i = 0; i < path.length && !isDisabled(); ++i) {
+      float segDT = path.left[i].dt;
       const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
       const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
 
       model->left(leftRPM / toUnderlyingType(pair.internalGearset) * reversed);
       model->right(rightRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
-      rate->delayUntil(1_ms);
+      rate->delayUntil(segDT * second);
     }
   }
 }


### PR DESCRIPTION
### Description of the Change
Changes the default motion profile delta-time to 10 milliseconds, and changes the follower to read the delta-time from the path instead of assuming it's the default.

### Motivation
10 ms is the fastest the motors can update, it bogs down memory and path generation speed to do a shorter delta-time.

### Possible Drawbacks
This code is 100% backwards-compatible. No reduced performance in path following should exist.

### Verification Process
Tests pass. I also made this change before Worlds and ran it (the AMPC change) on one of our robots.

### Applicable Issues

Closes #362
