### PR TITLE
#357: Fix partner controller stepping on master controller buttonArray

### DIFF
--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -124,6 +124,7 @@ class Controller {
   protected:
   ControllerId m_id;
   pros::Controller controller;
-  static std::array<ControllerButton *, 12> buttonArray;
+  static std::array<ControllerButton *, 12> masterButtonArray;
+  static std::array<ControllerButton *, 12> partnerButtonArray;
 };
 } // namespace okapi

--- a/include/test/testRunner.hpp
+++ b/include/test/testRunner.hpp
@@ -43,7 +43,7 @@ void resetHardware();
 void test_printf(const std::string &istring);
 
 /**
- * Run a test. The lambda can have any body, or it can be a sinlge function call. In that case, use
+ * Run a test. The lambda can have any body, or it can be a single function call. In that case, use
  * TEST_BODY for a more succinct way of writing the test.
  *
  * @param iname test name (describe what it does)

--- a/src/impl/device/button/controllerButton.cpp
+++ b/src/impl/device/button/controllerButton.cpp
@@ -9,9 +9,7 @@
 
 namespace okapi {
 ControllerButton::ControllerButton(const ControllerDigital ibtn, const bool iinverted)
-  : ButtonBase(iinverted),
-    controller(ControllerUtil::idToProsEnum(ControllerId::master)),
-    btn(ibtn) {
+  : ControllerButton(ControllerId::master, ibtn, iinverted) {
 }
 
 ControllerButton::ControllerButton(const ControllerId icontroller,
@@ -22,6 +20,6 @@ ControllerButton::ControllerButton(const ControllerId icontroller,
 
 bool ControllerButton::currentlyPressed() {
   const bool pressed = controller.get_digital(ControllerUtil::digitalToProsEnum(btn)) != 0;
-  return inverted ? !pressed : pressed;
+  return inverted == !pressed;
 }
 } // namespace okapi

--- a/src/impl/device/controller.cpp
+++ b/src/impl/device/controller.cpp
@@ -10,11 +10,11 @@
 #include "okapi/impl/device/controllerUtil.hpp"
 
 namespace okapi {
-std::array<ControllerButton *, 12> Controller::buttonArray;
+std::array<ControllerButton *, 12> Controller::masterButtonArray{nullptr};
+std::array<ControllerButton *, 12> Controller::partnerButtonArray{nullptr};
 
 Controller::Controller(const ControllerId iid)
   : m_id(iid), controller(ControllerUtil::idToProsEnum(iid)) {
-  std::fill(buttonArray.begin(), buttonArray.end(), nullptr);
 }
 
 Controller::~Controller() = default;
@@ -44,6 +44,8 @@ bool Controller::getDigital(const ControllerDigital ibutton) {
 
 ControllerButton &Controller::operator[](const ControllerDigital ibtn) {
   const auto index = toUnderlyingType(ibtn) - toUnderlyingType(ControllerDigital::L1);
+
+  auto &buttonArray = m_id == ControllerId::master ? masterButtonArray : partnerButtonArray;
 
   if (buttonArray[index] == nullptr) {
     buttonArray[index] = new ControllerButton(m_id, ibtn);

--- a/src/test/controllerTests.cpp
+++ b/src/test/controllerTests.cpp
@@ -11,8 +11,9 @@
 using namespace snowhouse;
 using namespace okapi;
 
-static void testBtnOperatorOverloadReturnsTheSameInstance() {
-  printf("Testing Controller operator[] overload returns the same ControllerButton instance\n");
+static void testBtnOperatorOverloadReturnsTheSameInstanceOnMaster() {
+  printf("Testing Controller operator[] overload returns the same ControllerButton instance on the "
+         "master controller\n");
   resetHardware();
 
   Controller c;
@@ -25,7 +26,41 @@ static void testBtnOperatorOverloadReturnsTheSameInstance() {
   resetHardware();
 }
 
+static void testBtnOperatorOverloadReturnsTheSameInstanceOnPartner() {
+  printf("Testing Controller operator[] overload returns the same ControllerButton instance on the "
+         "partner controller\n");
+  resetHardware();
+
+  Controller c(ControllerId::partner);
+  auto btnAddr1 = &c[ControllerDigital::X];
+  auto btnAddr2 = &c[ControllerDigital::X];
+
+  test("First button is not null", TEST_BODY(AssertThat, btnAddr1, Is().Not().Null()));
+  test("Two calls should give the same address",
+       TEST_BODY(AssertThat, btnAddr1 == btnAddr2, IsTrue()));
+  resetHardware();
+}
+
+static void testBtnOperatorOverloadWorksWithMasterAndPartnerSimultaneously() {
+  printf("Testing Controller operator[] overload works for master and partner simultaneously\n");
+  resetHardware();
+
+  Controller master;
+  Controller partner(ControllerId::partner);
+  auto btnAddrMaster = &master[ControllerDigital::X];
+  auto btnAddrPartner = &partner[ControllerDigital::X];
+
+  test("The master button is not null", TEST_BODY(AssertThat, btnAddrMaster, Is().Not().Null()));
+  test("The partner button is not null", TEST_BODY(AssertThat, btnAddrPartner, Is().Not().Null()));
+  test("The two buttons have different addresses",
+       TEST_BODY(AssertThat, btnAddrMaster != btnAddrPartner, IsTrue()));
+
+  resetHardware();
+}
+
 void runControllerTests() {
   test_printf("Testing Controller");
-  testBtnOperatorOverloadReturnsTheSameInstance();
+  testBtnOperatorOverloadReturnsTheSameInstanceOnMaster();
+  testBtnOperatorOverloadReturnsTheSameInstanceOnPartner();
+  testBtnOperatorOverloadWorksWithMasterAndPartnerSimultaneously();
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes subsequent `Controller` instances stepping on prior instances' `buttonArray` values. Users typically found this bug by declaring a partner controller and observing its buttons were actually the master controller's buttons.

### Motivation

This is a bug.

### Possible Drawbacks

None.

### Verification Process

Some new unit tests were added.

### Applicable Issues

Closes #357.
