### PR TITLE
Fix unsafe reads from path.length

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -249,7 +249,9 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   AbstractMotor::GearsetRatioPair pair;
   double currentProfilePosition{0};
   TimeUtil timeUtil;
-  CrossplatformMutex pathRemoveMutex;
+
+  // This must be locked when accessing the current path
+  CrossplatformMutex currentPathMutex;
 
   std::string currentPath{""};
   std::atomic_bool isRunning{false};
@@ -276,5 +278,13 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
 
   std::string
   getPathErrorMessage(const std::vector<Waypoint> &points, const std::string &ipathId, int length);
+
+  /**
+   * Reads the length of the path in a thread-safe manner.
+   *
+   * @param path The path to read from.
+   * @return The length of the path.
+   */
+  int getPathLength(const TrajectoryPair &path);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -265,7 +265,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   ChassisScales scales;
   AbstractMotor::GearsetRatioPair pair;
   TimeUtil timeUtil;
-  CrossplatformMutex pathRemoveMutex;
+
+  // This must be locked when accessing the current path
+  CrossplatformMutex currentPathMutex;
 
   std::string currentPath{""};
   std::atomic_bool isRunning{false};
@@ -306,5 +308,13 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
 
   void internalStorePath(FILE *leftPathFile, FILE *rightPathFile, const std::string &ipathId);
   void internalLoadPath(FILE *leftPathFile, FILE *rightPathFile, const std::string &ipathId);
+
+  /**
+   * Reads the length of the path in a thread-safe manner.
+   *
+   * @param path The path to read from.
+   * @return The length of the path.
+   */
+  int getPathLength(const TrajectoryPair &path);
 };
 } // namespace okapi

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -240,7 +240,9 @@ void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair 
     const auto motorRPM = convertLinearToRotational(path.segment[i].velocity * mps).convert(rpm);
     output->controllerSet(motorRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
+    // Unlock before the delay to be nice to other tasks
     currentPathMutex.unlock();
+
     rate->delayUntil(segDT);
   }
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes an unsafe read from `path.length` in AMPC and ALMPC.

### Verification Process

We can't really test for this change.

### Applicable Issues
Closes #376.
