### PR TITLE
Fix unsafe frees in AMPC and ALMPC dtors

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -236,8 +236,11 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   void forceRemovePath(const std::string &ipathId);
 
   protected:
+  using TrajectoryPtr = std::unique_ptr<TrajectoryCandidate, void (*)(TrajectoryCandidate *)>;
+  using SegmentPtr = std::unique_ptr<Segment, void (*)(void *)>;
+
   struct TrajectoryPair {
-    Segment *segment;
+    SegmentPtr segment;
     int length;
   };
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -252,9 +252,12 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   void forceRemovePath(const std::string &ipathId);
 
   protected:
+  using TrajectoryPtr = std::unique_ptr<TrajectoryCandidate, void(*)(TrajectoryCandidate*)>;
+  using SegmentPtr = std::unique_ptr<Segment, void (*)(void *)>;
+
   struct TrajectoryPair {
-    Segment *left;
-    Segment *right;
+    SegmentPtr left;
+    SegmentPtr right;
     int length;
   };
 

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -252,7 +252,7 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   void forceRemovePath(const std::string &ipathId);
 
   protected:
-  using TrajectoryPtr = std::unique_ptr<TrajectoryCandidate, void(*)(TrajectoryCandidate*)>;
+  using TrajectoryPtr = std::unique_ptr<TrajectoryCandidate, void (*)(TrajectoryCandidate *)>;
   using SegmentPtr = std::unique_ptr<Segment, void (*)(void *)>;
 
   struct TrajectoryPair {

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -28,10 +28,11 @@ AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
 
 AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
+  isDisabled();
 
-  for (auto path : paths) {
-    free(path.second.segment);
-  }
+  // Free paths before deleting the task
+  std::scoped_lock lock(currentPathMutex);
+  paths.clear();
 
   delete task;
 }
@@ -59,7 +60,18 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
 
   LOG_INFO(std::string("AsyncLinearMotionProfileController: Preparing trajectory"));
 
-  TrajectoryCandidate candidate;
+  TrajectoryPtr candidate(new TrajectoryCandidate, [](TrajectoryCandidate *c) {
+    if (c->laptr) {
+      free(c->laptr);
+    }
+
+    if (c->saptr) {
+      free(c->saptr);
+    }
+
+    delete c;
+  });
+
   pathfinder_prepare(points.data(),
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
@@ -68,39 +80,23 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
                      ilimits.maxVel,
                      ilimits.maxAccel,
                      ilimits.maxJerk,
-                     &candidate);
+                     candidate.get());
 
-  const int length = candidate.length;
+  const int length = candidate->length;
 
   if (length < 0) {
     std::string message = "AsyncLinearMotionProfileController: Length was negative. " +
                           getPathErrorMessage(points, ipathId, length);
 
-    if (candidate.laptr) {
-      free(candidate.laptr);
-    }
-
-    if (candidate.saptr) {
-      free(candidate.saptr);
-    }
-
     LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
-  auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
+  SegmentPtr trajectory(static_cast<Segment *>(malloc(length * sizeof(Segment))), free);
 
   if (trajectory == nullptr) {
     std::string message = "AsyncLinearMotionProfileController: Could not allocate trajectory. " +
                           getPathErrorMessage(points, ipathId, length);
-
-    if (candidate.laptr) {
-      free(candidate.laptr);
-    }
-
-    if (candidate.saptr) {
-      free(candidate.saptr);
-    }
 
     LOG_ERROR(message);
     throw std::runtime_error(message);
@@ -108,12 +104,12 @@ void AsyncLinearMotionProfileController::generatePath(std::initializer_list<QLen
 
   LOG_INFO(std::string("AsyncLinearMotionProfileController: Generating path"));
 
-  pathfinder_generate(&candidate, trajectory);
+  pathfinder_generate(candidate.get(), trajectory.get());
 
   // Free the old path before overwriting it
   forceRemovePath(ipathId);
 
-  paths.emplace(ipathId, TrajectoryPair{trajectory, length});
+  paths.emplace(ipathId, TrajectoryPair{std::move(trajectory), length});
 
   LOG_INFO("AsyncLinearMotionProfileController: Completely done generating path " + ipathId);
   LOG_DEBUG("AsyncLinearMotionProfileController: Path length: " + std::to_string(length));
@@ -147,7 +143,6 @@ bool AsyncLinearMotionProfileController::removePath(const std::string &ipathId) 
 
   auto oldPath = paths.find(ipathId);
   if (oldPath != paths.end()) {
-    free(oldPath->second.segment);
     paths.erase(ipathId);
   }
 
@@ -234,10 +229,11 @@ void AsyncLinearMotionProfileController::executeSinglePath(const TrajectoryPair 
     // if a running path is asked to be removed at the moment this loop is executing
     std::scoped_lock lock(currentPathMutex);
 
-    const auto segDT = path.segment[i].dt * second;
-    currentProfilePosition = path.segment[i].position;
+    const auto segDT = path.segment.get()[i].dt * second;
+    currentProfilePosition = path.segment.get()[i].position;
 
-    const auto motorRPM = convertLinearToRotational(path.segment[i].velocity * mps).convert(rpm);
+    const auto motorRPM =
+      convertLinearToRotational(path.segment.get()[i].velocity * mps).convert(rpm);
     output->controllerSet(motorRPM / toUnderlyingType(pair.internalGearset) * reversed);
 
     // Unlock before the delay to be nice to other tasks
@@ -299,7 +295,7 @@ double AsyncLinearMotionProfileController::getError() const {
     return 0;
   } else {
     // The last position in the path is the target position
-    return path->second.segment[path->second.length - 1].position - currentProfilePosition;
+    return path->second.segment.get()[path->second.length - 1].position - currentProfilePosition;
   }
 }
 

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -36,11 +36,11 @@ AsyncMotionProfileController::AsyncMotionProfileController(
 
 AsyncMotionProfileController::~AsyncMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
+  isDisabled();
 
-  for (auto &path : paths) {
-    free(path.second.left);
-    free(path.second.right);
-  }
+  // Free paths before deleting the task
+  std::scoped_lock lock(currentPathMutex);
+  paths.clear();
 
   delete task;
 }
@@ -69,7 +69,18 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
 
   LOG_INFO(std::string("AsyncMotionProfileController: Preparing trajectory"));
 
-  TrajectoryCandidate candidate;
+  TrajectoryPtr candidate(new TrajectoryCandidate, [](TrajectoryCandidate *c) {
+    if (c->laptr) {
+      free(c->laptr);
+    }
+
+    if (c->saptr) {
+      free(c->saptr);
+    }
+
+    delete c;
+  });
+
   pathfinder_prepare(points.data(),
                      static_cast<int>(points.size()),
                      FIT_HERMITE_CUBIC,
@@ -78,39 +89,23 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
                      ilimits.maxVel,
                      ilimits.maxAccel,
                      ilimits.maxJerk,
-                     &candidate);
+                     candidate.get());
 
-  const int length = candidate.length;
+  const int length = candidate->length;
 
   if (length < 0) {
     std::string message = "AsyncMotionProfileController: Length was negative. " +
                           getPathErrorMessage(points, ipathId, length);
 
-    if (candidate.laptr) {
-      free(candidate.laptr);
-    }
-
-    if (candidate.saptr) {
-      free(candidate.saptr);
-    }
-
     LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
-  auto *trajectory = static_cast<Segment *>(malloc(length * sizeof(Segment)));
+  SegmentPtr trajectory(static_cast<Segment *>(malloc(length * sizeof(Segment))), free);
 
   if (trajectory == nullptr) {
     std::string message = "AsyncMotionProfileController: Could not allocate trajectory. " +
                           getPathErrorMessage(points, ipathId, length);
-
-    if (candidate.laptr) {
-      free(candidate.laptr);
-    }
-
-    if (candidate.saptr) {
-      free(candidate.saptr);
-    }
 
     LOG_ERROR(message);
     throw std::runtime_error(message);
@@ -118,42 +113,32 @@ void AsyncMotionProfileController::generatePath(std::initializer_list<Point> iwa
 
   LOG_INFO(std::string("AsyncMotionProfileController: Generating path"));
 
-  pathfinder_generate(&candidate, trajectory);
+  pathfinder_generate(candidate.get(), trajectory.get());
 
-  auto *leftTrajectory = (Segment *)malloc(sizeof(Segment) * length);
-  auto *rightTrajectory = (Segment *)malloc(sizeof(Segment) * length);
+  SegmentPtr leftTrajectory((Segment *)malloc(sizeof(Segment) * length), free);
+  SegmentPtr rightTrajectory((Segment *)malloc(sizeof(Segment) * length), free);
 
   if (leftTrajectory == nullptr || rightTrajectory == nullptr) {
     std::string message = "AsyncMotionProfileController: Could not allocate left and/or right "
                           "trajectories. " +
                           getPathErrorMessage(points, ipathId, length);
 
-    if (leftTrajectory) {
-      free(leftTrajectory);
-    }
-
-    if (rightTrajectory) {
-      free(rightTrajectory);
-    }
-
-    if (trajectory) {
-      free(trajectory);
-    }
-
     LOG_ERROR(message);
     throw std::runtime_error(message);
   }
 
   LOG_INFO(std::string("AsyncMotionProfileController: Modifying for tank drive"));
-  pathfinder_modify_tank(
-    trajectory, length, leftTrajectory, rightTrajectory, scales.wheelTrack.convert(meter));
-
-  free(trajectory);
+  pathfinder_modify_tank(trajectory.get(),
+                         length,
+                         leftTrajectory.get(),
+                         rightTrajectory.get(),
+                         scales.wheelTrack.convert(meter));
 
   // Free the old path before overwriting it
   forceRemovePath(ipathId);
 
-  paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, length});
+  paths.emplace(ipathId,
+                TrajectoryPair{std::move(leftTrajectory), std::move(rightTrajectory), length});
 
   LOG_INFO("AsyncMotionProfileController: Completely done generating path " + ipathId);
   LOG_DEBUG("AsyncMotionProfileController: Path length: " + std::to_string(length));
@@ -185,8 +170,6 @@ bool AsyncMotionProfileController::removePath(const std::string &ipathId) {
 
   auto oldPath = paths.find(ipathId);
   if (oldPath != paths.end()) {
-    free(oldPath->second.left);
-    free(oldPath->second.right);
     paths.erase(ipathId);
   }
 
@@ -268,9 +251,10 @@ void AsyncMotionProfileController::executeSinglePath(const TrajectoryPair &path,
     // if a running path is asked to be removed at the moment this loop is executing
     std::scoped_lock lock(currentPathMutex);
 
-    const auto segDT = path.left[i].dt * second;
-    const auto leftRPM = convertLinearToRotational(path.left[i].velocity * mps).convert(rpm);
-    const auto rightRPM = convertLinearToRotational(path.right[i].velocity * mps).convert(rpm);
+    const auto segDT = path.left.get()[i].dt * second;
+    const auto leftRPM = convertLinearToRotational(path.left.get()[i].velocity * mps).convert(rpm);
+    const auto rightRPM =
+      convertLinearToRotational(path.right.get()[i].velocity * mps).convert(rpm);
 
     const double rightSpeed = rightRPM / toUnderlyingType(pair.internalGearset) * reversed;
     const double leftSpeed = leftRPM / toUnderlyingType(pair.internalGearset) * reversed;
@@ -451,8 +435,8 @@ void AsyncMotionProfileController::internalStorePath(FILE *leftPathFile,
     int len = pathData->second.length;
 
     // Serialize paths
-    pathfinder_serialize_csv(leftPathFile, pathData->second.left, len);
-    pathfinder_serialize_csv(rightPathFile, pathData->second.right, len);
+    pathfinder_serialize_csv(leftPathFile, pathData->second.left.get(), len);
+    pathfinder_serialize_csv(rightPathFile, pathData->second.right.get(), len);
   }
 }
 
@@ -470,15 +454,16 @@ void AsyncMotionProfileController::internalLoadPath(FILE *leftPathFile,
   rewind(leftPathFile);
 
   // Allocate memory
-  auto *leftTrajectory = (Segment *)malloc(sizeof(Segment) * count);
-  auto *rightTrajectory = (Segment *)malloc(sizeof(Segment) * count);
+  SegmentPtr leftTrajectory((Segment *)malloc(sizeof(Segment) * count), free);
+  SegmentPtr rightTrajectory((Segment *)malloc(sizeof(Segment) * count), free);
 
-  pathfinder_deserialize_csv(leftPathFile, leftTrajectory);
-  pathfinder_deserialize_csv(rightPathFile, rightTrajectory);
+  pathfinder_deserialize_csv(leftPathFile, leftTrajectory.get());
+  pathfinder_deserialize_csv(rightPathFile, rightTrajectory.get());
 
   // Remove the old path if it exists
   forceRemovePath(ipathId);
-  paths.emplace(ipathId, TrajectoryPair{leftTrajectory, rightTrajectory, count});
+  paths.emplace(ipathId,
+                TrajectoryPair{std::move(leftTrajectory), std::move(rightTrajectory), count});
 }
 
 std::string AsyncMotionProfileController::makeFilePath(const std::string &directory,

--- a/src/pathfinder/generator.c
+++ b/src/pathfinder/generator.c
@@ -78,8 +78,5 @@ int pathfinder_generate(TrajectoryCandidate *c, Segment *segments) {
         }
     }
     
-    free(c->saptr);
-    free(c->laptr);
-    
     return trajectory_length;
 }

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -24,7 +24,7 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
     AsyncMotionProfileController::executeSinglePath(path, std::move(rate));
   }
 
-  TrajectoryPair getPathData(std::string ipathId) {
+  TrajectoryPair& getPathData(std::string ipathId) {
     return paths.at(ipathId);
   }
 


### PR DESCRIPTION
### Description of the Change

This PR fixes the unsafe frees in the AMPC and ALMPC dtors when freeing paths.

### Verification Process

The tests still pass, there are no memory leaks, and it works on a real robot.

### Applicable Issues

Closes #377.
