### PR TITLE
Add unitless RQuantity unit

### DIFF
--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -80,6 +80,7 @@ class RQuantity {
 
 // Unitless
 QUANTITY_TYPE(0, 0, 0, 0, Number)
+constexpr Number number(1.0);
 
 // Standard arithmetic operators:
 // ------------------------------


### PR DESCRIPTION
### Description of the Change

This PR adds the definition of a a unitless 'Number' unit.
The dimension was there, but a unit was not defined using that dimension.

