### PR TITLE
Fix issue #387 controllerSet() on reversed Motors

### DIFF
--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -280,7 +280,7 @@ std::shared_ptr<ContinuousRotarySensor> Motor::getEncoder() {
 }
 
 void Motor::controllerSet(const double ivalue) {
-  //Reversing is done by moveVelocity, no need to add * reversed.
+  // Reversing is done by moveVelocity, no need to reverse here
   moveVelocity(ivalue * toUnderlyingType(getGearing()));
 }
 

--- a/src/impl/device/motor/motor.cpp
+++ b/src/impl/device/motor/motor.cpp
@@ -280,7 +280,8 @@ std::shared_ptr<ContinuousRotarySensor> Motor::getEncoder() {
 }
 
 void Motor::controllerSet(const double ivalue) {
-  moveVelocity(ivalue * toUnderlyingType(getGearing()) * reversed);
+  //Reversing is done by moveVelocity, no need to add * reversed.
+  moveVelocity(ivalue * toUnderlyingType(getGearing()));
 }
 
 std::uint8_t Motor::getPort() const {


### PR DESCRIPTION
### Description of the Change

Remove the reference to `reversed` in Motor's `controllerSet`, as the `moveVelocity` function it calls already uses it.

### Motivation

Doing this allows for controllers to behave as expected on a reversed motor.

### Possible Drawbacks

Anyone working around this issue will have their motors again doubly-reversed, though it should be fine as not many people have the RC2 version of OkapiLib.

### Applicable Issues

Closes #387.
