### PR TITLE
Update errno docs

### DIFF
--- a/include/okapi/impl/device/motor/motor.hpp
+++ b/include/okapi/impl/device/motor/motor.hpp
@@ -53,9 +53,6 @@ class Motor : public AbstractMotor {
    * @note This function simply sets the target for the motor, it does not block program execution
    * until the movement finishes.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param iposition The absolute position to move to in the motor's encoder units
    * @param ivelocity The maximum allowable velocity for the movement in RPM
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -72,9 +69,6 @@ class Motor : public AbstractMotor {
    * @note This function simply sets the target for the motor, it does not block program execution
    * until the movement finishes.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param iposition The relative position to move to in the motor's encoder units
    * @param ivelocity The maximum allowable velocity for the movement in RPM
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -90,9 +84,6 @@ class Motor : public AbstractMotor {
    * is held with PID to ensure consistent speed, as opposed to setting the motor's
    * voltage.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param ivelocity The new motor velocity from -+-100, +-200, or +-600 depending on the motor's
    * gearset
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -102,9 +93,6 @@ class Motor : public AbstractMotor {
   /**
    * Sets the voltage for the motor from -12000 to 12000.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param ivoltage The new voltage value from -12000 to 12000.
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
@@ -113,9 +101,6 @@ class Motor : public AbstractMotor {
   /**
    * Changes the output velocity for a profiled movement (moveAbsolute or moveRelative). This will
    * have no effect if the motor is not following a profiled movement.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @param ivelocity The new motor velocity from -+-100, +-200, or +-600 depending on the motor's
    * gearset
@@ -132,9 +117,6 @@ class Motor : public AbstractMotor {
   /**
    * Gets the target position set for the motor by the user.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The target position in its encoder units or PROS_ERR_F if the operation failed,
    * setting errno.
    */
@@ -142,9 +124,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Gets the absolute position of the motor in its encoder units.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's absolute position in its encoder units or PROS_ERR_F if the operation
    * failed, setting errno.
@@ -154,18 +133,12 @@ class Motor : public AbstractMotor {
   /**
    * Sets the "absolute" zero position of the motor to its current position.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   std::int32_t tarePosition() override;
 
   /**
    * Gets the velocity commanded to the motor by the user.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The commanded motor velocity from +-100, +-200, or +-600, or PROS_ERR if the operation
    * failed, setting errno.
@@ -175,9 +148,6 @@ class Motor : public AbstractMotor {
   /**
    * Gets the actual velocity of the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's actual velocity in RPM or PROS_ERR_F if the operation failed, setting
    * errno.
    */
@@ -186,20 +156,12 @@ class Motor : public AbstractMotor {
   /**
    * Gets the current drawn by the motor in mA.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's current in mA or PROS_ERR if the operation failed, setting errno.
    */
   std::int32_t getCurrentDraw() override;
 
   /**
    * Gets the direction of movement for the motor.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return 1 for moving in the positive direction, -1 for moving in the negative direction, and
    * PROS_ERR if the operation failed, setting errno.
@@ -213,20 +175,12 @@ class Motor : public AbstractMotor {
    * drawing no electrical power, and an efficiency of 0% means that the motor
    * is drawing power but not moving.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's efficiency in percent or PROS_ERR_F if the operation failed, setting errno.
    */
   double getEfficiency() override;
 
   /**
    * Checks if the motor is drawing over its current limit.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return 1 if the motor's current limit is being exceeded and 0 if the current limit is not
    * exceeded, or PROS_ERR if the operation failed, setting errno.
@@ -235,10 +189,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Checks if the motor's temperature is above its limit.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return 1 if the temperature limit is exceeded and 0 if the the temperature is below the limit,
    * or PROS_ERR if the operation failed, setting errno.
@@ -250,6 +200,7 @@ class Motor : public AbstractMotor {
    *
    * Although this function forwards data from the motor, the motor presently does not provide any
    * value. This function returns PROS_ERR with errno set to ENOSYS.
+   *
    * @return 1 if the motor is not moving, 0 if the motor is moving, or PROS_ERR if the operation
    * failed, setting errno
    */
@@ -270,10 +221,6 @@ class Motor : public AbstractMotor {
    * Gets the faults experienced by the motor. Compare this bitfield to the bitmasks in
    * pros::motor_fault_e_t.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return A currently unknown bitfield containing the motor's faults. 0b00000100 = Current Limit
    * Hit
    */
@@ -283,10 +230,6 @@ class Motor : public AbstractMotor {
    * Gets the flags set by the motor's operation. Compare this bitfield to the bitmasks in
    * pros::motor_flag_e_t.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return A currently unknown bitfield containing the motor's flags. These seem to be unrelated
    * to the individual get_specific_flag functions
    */
@@ -294,10 +237,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Gets the raw encoder count of the motor at a given timestamp.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @param timestamp A pointer to a time in milliseconds for which the encoder count will be
    * returned. If NULL, the timestamp at which the encoder count was read will not be supplied
@@ -309,20 +248,12 @@ class Motor : public AbstractMotor {
   /**
    * Gets the power drawn by the motor in Watts.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's power draw in Watts or PROS_ERR_F if the operation failed, setting errno.
    */
   double getPower() override;
 
   /**
    * Gets the temperature of the motor in degrees Celsius.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's temperature in degrees Celsius or PROS_ERR_F if the operation failed,
    * setting errno.
@@ -332,20 +263,12 @@ class Motor : public AbstractMotor {
   /**
    * Gets the torque generated by the motor in Newton Metres (Nm).
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's torque in NM or PROS_ERR_F if the operation failed, setting errno.
    */
   double getTorque() override;
 
   /**
    * Gets the voltage delivered to the motor in millivolts.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's voltage in V or PROS_ERR_F if the operation failed, setting errno.
    */
@@ -360,9 +283,6 @@ class Motor : public AbstractMotor {
   /**
    * Sets one of AbstractMotor::brakeMode to the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param imode The new motor brake mode to set for the motor
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
@@ -370,9 +290,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Gets the brake mode that was set for the motor.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return One of brakeMode, according to what was set for the motor, or brakeMode::invalid if the
    * operation failed, setting errno.
@@ -382,21 +299,13 @@ class Motor : public AbstractMotor {
   /**
    * Sets the current limit for the motor in mA.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param ilimit The new current limit in mA
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
    */
   std::int32_t setCurrentLimit(std::int32_t ilimit) override;
 
   /**
-   * Gets the current limit for the motor in mA.
-   *
-   * The default value is 2500 mA.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
+   * Gets the current limit for the motor in mA. The default value is 2500 mA.
    *
    * @return The motor's current limit in mA or PROS_ERR if the operation failed, setting errno.
    */
@@ -404,9 +313,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Sets one of AbstractMotor::encoderUnits for the motor encoder.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @param iunits The new motor encoder units
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -416,9 +322,6 @@ class Motor : public AbstractMotor {
   /**
    * Gets the encoder units that were set for the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return One of encoderUnits according to what is set for the motor or encoderUnits::invalid if
    * the operation failed.
    */
@@ -426,9 +329,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Sets one of AbstractMotor::gearset for the motor.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @param igearset The new motor gearset
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -438,21 +338,14 @@ class Motor : public AbstractMotor {
   /**
    * Gets the gearset that was set for the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return One of gearset according to what is set for the motor, or gearset::invalid if the
    * operation failed.
    */
   gearset getGearing() override;
 
   /**
-   * Sets the reverse flag for the motor.
-   *
-   * This will invert its movements and the values returned for its position.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
+   * Sets the reverse flag for the motor. This will invert its movements and the values returned for
+   * its position.
    *
    * @param ireverse True reverses the motor, false is default
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -461,9 +354,6 @@ class Motor : public AbstractMotor {
 
   /**
    * Sets the voltage limit for the motor in Volts.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @param ilimit The new voltage limit in Volts
    * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
@@ -510,7 +400,8 @@ class Motor : public AbstractMotor {
    * @param ikP the proportional constant
    * @param ikI the integral constant
    * @param ikD the derivative constant
-   * @return 1 if the operation was successful or PROS_ERR if the operation failed, setting errno.
+   * @return `1` if the operation was successful or `PROS_ERR` if the operation failed, setting
+   * errno.
    */
   virtual std::int32_t setVelPID(double ikF, double ikP, double ikI, double ikD);
 
@@ -539,15 +430,15 @@ class Motor : public AbstractMotor {
   /**
    * Get the encoder associated with this motor.
    *
-   * @return encoder for this motor
+   * @return The encoder for this motor.
    */
   std::shared_ptr<ContinuousRotarySensor> getEncoder() override;
 
   /**
    * Writes the value of the controller output. This method might be automatically called in another
-   * thread by the controller. The range of input values is expected to be [-1, 1].
+   * thread by the controller. The range of input values is expected to be `[-1, 1]`.
    *
-   * @param ivalue the controller's output in the range [-1, 1]
+   * @param ivalue The controller's output in the range `[-1, 1]`.
    */
   void controllerSet(double ivalue) override;
 

--- a/include/okapi/impl/device/motor/motorGroup.hpp
+++ b/include/okapi/impl/device/motor/motorGroup.hpp
@@ -53,9 +53,6 @@ class MotorGroup : public AbstractMotor {
    * @note This function simply sets the target for the motor, it does not block program execution
    * until the movement finishes.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param iposition The absolute position to move to in the motor's encoder units
    * @param ivelocity The maximum allowable velocity for the movement in RPM
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
@@ -72,9 +69,6 @@ class MotorGroup : public AbstractMotor {
    * @note This function simply sets the target for the motor, it does not block program execution
    * until the movement finishes.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param iposition The relative position to move to in the motor's encoder units
    * @param ivelocity The maximum allowable velocity for the movement in RPM
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
@@ -90,9 +84,6 @@ class MotorGroup : public AbstractMotor {
    * is held with PID to ensure consistent speed, as opposed to setting the motor's
    * voltage.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param ivelocity The new motor velocity from -+-100, +-200, or +-600 depending on the motor's
    * gearset
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
@@ -100,12 +91,9 @@ class MotorGroup : public AbstractMotor {
   std::int32_t moveVelocity(std::int16_t ivelocity) override;
 
   /**
-   * Sets the voltage for the motor from -12000 to 12000.
+   * Sets the voltage for the motor from `-12000` to `12000`.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param ivoltage The new voltage value from -12000 to 12000.
+   * @param ivoltage The new voltage value from `-12000` to `12000`.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t moveVoltage(std::int16_t ivoltage) override;
@@ -114,11 +102,8 @@ class MotorGroup : public AbstractMotor {
    * Changes the output velocity for a profiled movement (moveAbsolute or moveRelative). This will
    * have no effect if the motor is not following a profiled movement.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param ivelocity The new motor velocity from -+-100, +-200, or +-600 depending on the motor's
-   * gearset
+   * @param ivelocity The new motor velocity from `+-100`, `+-200`, or `+-600` depending on the
+   * motor's gearset.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t modifyProfiledVelocity(std::int32_t ivelocity) override;
@@ -132,9 +117,6 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the target position set for the motor by the user.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The target position in its encoder units or `PROS_ERR_F` if the operation failed,
    * setting errno.
    */
@@ -142,9 +124,6 @@ class MotorGroup : public AbstractMotor {
 
   /**
    * Gets the absolute position of the motor in its encoder units.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's absolute position in its encoder units or `PROS_ERR_F` if the operation
    * failed, setting errno.
@@ -154,18 +133,12 @@ class MotorGroup : public AbstractMotor {
   /**
    * Sets the "absolute" zero position of the motor to its current position.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t tarePosition() override;
 
   /**
    * Gets the velocity commanded to the motor by the user.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The commanded motor velocity from +-100, +-200, or +-600, or `PROS_ERR` if the
    * operation failed, setting errno.
@@ -175,9 +148,6 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the actual velocity of the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's actual velocity in RPM or `PROS_ERR_F` if the operation failed, setting
    * errno.
    */
@@ -186,20 +156,12 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the current drawn by the motor in mA.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's current in mA or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t getCurrentDraw() override;
 
   /**
    * Gets the direction of movement for the motor.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return 1 for moving in the positive direction, -1 for moving in the negative direction, and
    * `PROS_ERR` if the operation failed, setting errno.
@@ -213,10 +175,6 @@ class MotorGroup : public AbstractMotor {
    * drawing no electrical power, and an efficiency of 0% means that the motor
    * is drawing power but not moving.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's efficiency in percent or `PROS_ERR_F` if the operation failed, setting
    * errno.
    */
@@ -224,10 +182,6 @@ class MotorGroup : public AbstractMotor {
 
   /**
    * Checks if the motor is drawing over its current limit.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return 1 if the motor's current limit is being exceeded and 0 if the current limit is not
    * exceeded, or `PROS_ERR` if the operation failed, setting errno.
@@ -237,10 +191,6 @@ class MotorGroup : public AbstractMotor {
   /**
    * Checks if the motor's temperature is above its limit.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return 1 if the temperature limit is exceeded and 0 if the the temperature is below the limit,
    * or `PROS_ERR` if the operation failed, setting errno.
    */
@@ -249,10 +199,8 @@ class MotorGroup : public AbstractMotor {
   /**
    * Checks if the motor is stopped.
    *
-   * \note Although this function forwards data from the motor, the motor
-   * presently
-   * does not provide any value. This function returns `PROS_ERR` with errno set to
-   * ENOSYS.
+   * Although this function forwards data from the motor, the motor presently does not provide any
+   * value. This function returns `PROS_ERR` with errno set to `ENOSYS`.
    *
    * @return 1 if the motor is not moving, 0 if the motor is moving, or `PROS_ERR` if the operation
    * failed, setting errno
@@ -262,13 +210,11 @@ class MotorGroup : public AbstractMotor {
   /**
    * Checks if the motor is at its zero position.
    *
-   * Although this function forwards data from the motor, the motor
-   * presently
-   * does not provide any value. This function returns `PROS_ERR` with errno set to
-   * ENOSYS.
+   * Although this function forwards data from the motor, the motor presently does not provide any
+   * value. This function returns `PROS_ERR` with errno set to `ENOSYS`.
    *
-   * @return 1 if the motor is at zero absolute position, 0 if the motor has moved from its absolute
-   * zero, or `PROS_ERR` if the operation failed, setting errno
+   * @return 1 if the motor is at zero absolute position, `0` if the motor has moved from its
+   * absolute zero, or `PROS_ERR` if the operation failed, setting errno
    */
   std::int32_t getZeroPositionFlag() override;
 
@@ -276,22 +222,14 @@ class MotorGroup : public AbstractMotor {
    * Gets the faults experienced by the motor. Compare this bitfield to the bitmasks in
    * pros::motor_fault_e_t.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @return A currently unknown bitfield containing the motor's faults. 0b00000100 = Current Limit
-   * Hit
+   * @return A currently unknown bitfield containing the motor's faults. `0b00000100` = Current
+   * Limit Hit
    */
   uint32_t getFaults() override;
 
   /**
    * Gets the flags set by the motor's operation. Compare this bitfield to the bitmasks in
    * pros::motor_flag_e_t.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return A currently unknown bitfield containing the motor's flags. These seem to be unrelated
    * to the individual get_specific_flag functions
@@ -301,13 +239,8 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the raw encoder count of the motor at a given timestamp.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @param timestamp A pointer to a time in milliseconds for which the encoder count will be
-   * returned. If NULL, the timestamp at which the encoder count was read will not be supplied
-   *
+   * returned. If `NULL`, the timestamp at which the encoder count was read will not be supplied.
    * @return The raw encoder count at the given timestamp or `PROS_ERR` if the operation failed.
    */
   std::int32_t getRawPosition(std::uint32_t *timestamp) override;
@@ -315,20 +248,12 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the power drawn by the motor in Watts.
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's power draw in Watts or `PROS_ERR_F` if the operation failed, setting errno.
    */
   double getPower() override;
 
   /**
    * Gets the temperature of the motor in degrees Celsius.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's temperature in degrees Celsius or `PROS_ERR_F` if the operation failed,
    * setting errno.
@@ -338,20 +263,12 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the torque generated by the motor in Newton Metres (Nm).
    *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return The motor's torque in NM or `PROS_ERR_F` if the operation failed, setting errno.
    */
   double getTorque() override;
 
   /**
    * Gets the voltage delivered to the motor in millivolts.
-   *
-   * This function uses the following values of errno when an error state is
-   * reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return The motor's voltage in V or `PROS_ERR_F` if the operation failed, setting errno.
    */
@@ -369,16 +286,13 @@ class MotorGroup : public AbstractMotor {
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param imode The new motor brake mode to set for the motor
+   * @param imode The new motor brake mode to set for the motor.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setBrakeMode(AbstractMotor::brakeMode imode) override;
 
   /**
    * Gets the brake mode that was set for the motor.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return One of brakeMode, according to what was set for the motor, or brakeMode::invalid if the
    * operation failed, setting errno.
@@ -391,18 +305,13 @@ class MotorGroup : public AbstractMotor {
    * This function uses the following values of errno when an error state is reached:
    * EACCES - Another resource is currently trying to access the port.
    *
-   * @param ilimit The new current limit in mA
+   * @param ilimit The new current limit in mA.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setCurrentLimit(std::int32_t ilimit) override;
 
   /**
-   * Gets the current limit for the motor in mA.
-   *
-   * The default value is 2500 mA.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
+   * Gets the current limit for the motor in mA. The default value is `2500` mA.
    *
    * @return The motor's current limit in mA or `PROS_ERR` if the operation failed, setting errno.
    */
@@ -411,19 +320,13 @@ class MotorGroup : public AbstractMotor {
   /**
    * Sets one of AbstractMotor::encoderUnits for the motor encoder.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param iunits The new motor encoder units
+   * @param iunits The new motor encoder units.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setEncoderUnits(AbstractMotor::encoderUnits iunits) override;
 
   /**
    * Gets the encoder units that were set for the motor.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
    *
    * @return One of encoderUnits according to what is set for the motor or encoderUnits::invalid if
    * the operation failed.
@@ -433,10 +336,7 @@ class MotorGroup : public AbstractMotor {
   /**
    * Sets one of AbstractMotor::gearset for the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param igearset The new motor gearset
+   * @param igearset The new motor gearset.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setGearing(AbstractMotor::gearset igearset) override;
@@ -444,23 +344,16 @@ class MotorGroup : public AbstractMotor {
   /**
    * Gets the gearset that was set for the motor.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
    * @return One of gearset according to what is set for the motor, or `gearset::invalid` if the
    * operation failed.
    */
   gearset getGearing() override;
 
   /**
-   * Sets the reverse flag for the motor.
+   * Sets the reverse flag for the motor. This will invert its movements and the values returned for
+   * its position.
    *
-   * This will invert its movements and the values returned for its position.
-   *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param ireverse True reverses the motor, false is default
+   * @param ireverse True reverses the motor, false is default.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setReversed(bool ireverse) override;
@@ -468,10 +361,7 @@ class MotorGroup : public AbstractMotor {
   /**
    * Sets the voltage limit for the motor in Volts.
    *
-   * This function uses the following values of errno when an error state is reached:
-   * EACCES - Another resource is currently trying to access the port.
-   *
-   * @param ilimit The new voltage limit in Volts
+   * @param ilimit The new voltage limit in Volts.
    * @return 1 if the operation was successful or `PROS_ERR` if the operation failed, setting errno.
    */
   std::int32_t setVoltageLimit(std::int32_t ilimit) override;


### PR DESCRIPTION
### Description of the Change

This PR removes the errno documentation.

### Motivation

Duplicating the errno docs is brittle; users can just check the PROS docs if they need to know.

### Possible Drawbacks

Users will also have to check the PROS docs for errno meanings, which is an extra step compared to before.

### Verification Process

N/A

### Applicable Issues

Closes #356
