### PR TITLE
Add isSettled to ChassisController

### DIFF
--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -24,7 +24,8 @@
  *
  * <a href="annotated.html">OkapiLib Classes</a>
  *
- * Not sure where to go? Take a look at the [Getting Started tutorial](docs/tutorials/walkthrough/gettingStarted.md).
+ * Not sure where to go? Take a look at the
+ * [Getting Started tutorial](docs/tutorials/walkthrough/gettingStarted.md).
  */
 
 #include "okapi/api/chassis/controller/chassisControllerIntegrated.hpp"

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -93,6 +93,13 @@ class ChassisController {
   virtual void setTurnsMirrored(bool ishouldMirror) = 0;
 
   /**
+   * Checks whether the internal controllers are currently settled.
+   *
+   * @return Whether this ChassisController is settled.
+   */
+  virtual bool isSettled() = 0;
+
+  /**
    * Delays until the currently executing movement completes.
    */
   virtual void waitUntilSettled() = 0;

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -124,6 +124,13 @@ class ChassisControllerIntegrated : public ChassisController {
   void setTurnsMirrored(bool ishouldMirror) override;
 
   /**
+   * Checks whether the internal controllers are currently settled.
+   *
+   * @return Whether this ChassisController is settled.
+   */
+  bool isSettled() override;
+
+  /**
    * Delays until the currently executing movement completes.
    */
   void waitUntilSettled() override;

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -137,6 +137,13 @@ class ChassisControllerPID : public ChassisController {
   void setTurnsMirrored(bool ishouldMirror) override;
 
   /**
+   * Checks whether the internal controllers are currently settled.
+   *
+   * @return Whether this ChassisController is settled.
+   */
+  bool isSettled() override;
+
+  /**
    * Delays until the currently executing movement completes.
    */
   void waitUntilSettled() override;

--- a/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
@@ -128,6 +128,11 @@ class DefaultOdomChassisController : public OdomChassisController {
   /**
    * This delegates to the input ChassisController.
    */
+  bool isSettled() override;
+
+  /**
+   * This delegates to the input ChassisController.
+   */
   void waitUntilSettled() override;
 
   /**

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -352,6 +352,8 @@ class SimulatedSystem : public ControllerInput<double>, public ControllerOutput<
   std::thread thread;
 };
 
+enum class IsSettledOverride { none, alwaysSettled, neverSettled };
+
 class MockAsyncPosIntegratedController : public AsyncPosIntegratedController {
   public:
   MockAsyncPosIntegratedController();
@@ -360,7 +362,7 @@ class MockAsyncPosIntegratedController : public AsyncPosIntegratedController {
 
   bool isSettled() override;
 
-  bool isSettledOverride{true};
+  IsSettledOverride isSettledOverride{IsSettledOverride::none};
   using AsyncPosIntegratedController::maxVelocity;
 };
 
@@ -374,7 +376,7 @@ class MockAsyncVelIntegratedController : public AsyncVelIntegratedController {
 
   void controllerSet(double ivalue) override;
 
-  bool isSettledOverride{true};
+  IsSettledOverride isSettledOverride{IsSettledOverride::none};
 
   double lastTarget{0};
   double maxTarget{0};
@@ -391,7 +393,7 @@ class MockIterativeController : public IterativePosPIDController {
 
   bool isSettled() override;
 
-  bool isSettledOverride{true};
+  IsSettledOverride isSettledOverride{IsSettledOverride::none};
 };
 
 void assertMotorsHaveBeenStopped(MockMotor *leftMotor, MockMotor *rightMotor);
@@ -610,6 +612,9 @@ class MockChassisController : public ChassisController {
   void setTurnsMirrored(bool ishouldMirror) override {
     turnsMirrored = ishouldMirror;
   }
+  bool isSettled() override {
+    return settled;
+  }
   void waitUntilSettled() override {
     waitUntilSettledCalled++;
   }
@@ -634,6 +639,7 @@ class MockChassisController : public ChassisController {
   QAngle lastTurnAngleTargetQAngle;
   double lastTurnAngleTargetDouble;
   bool turnsMirrored{false};
+  bool settled{true};
   int waitUntilSettledCalled{0};
   int stopCalled{0};
   ChassisScales scales{{4.125_in, 10_in}, imev5GreenTPR};

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -109,11 +109,15 @@ void ChassisControllerIntegrated::setTurnsMirrored(const bool ishouldMirror) {
   normalTurns = !ishouldMirror;
 }
 
+bool ChassisControllerIntegrated::isSettled() {
+  return leftController->isSettled() && rightController->isSettled();
+}
+
 void ChassisControllerIntegrated::waitUntilSettled() {
   LOG_INFO(std::string("ChassisControllerIntegrated: Waiting to settle"));
 
   auto rate = timeUtil.getRate();
-  while (!(leftController->isSettled() && rightController->isSettled())) {
+  while (!isSettled()) {
     rate->delayUntil(10_ms);
   }
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -188,6 +188,19 @@ void ChassisControllerPID::setTurnsMirrored(const bool ishouldMirror) {
   normalTurns = !ishouldMirror;
 }
 
+bool ChassisControllerPID::isSettled() {
+  switch (mode) {
+  case distance:
+    return distancePid->isSettled() && anglePid->isSettled();
+
+  case angle:
+    return turnPid->isSettled();
+
+  default:
+    return true;
+  }
+}
+
 void ChassisControllerPID::waitUntilSettled() {
   LOG_INFO(std::string("ChassisControllerPID: Waiting to settle"));
 

--- a/src/api/chassis/controller/defaultOdomChassisController.cpp
+++ b/src/api/chassis/controller/defaultOdomChassisController.cpp
@@ -114,6 +114,10 @@ void DefaultOdomChassisController::setTurnsMirrored(bool ishouldMirror) {
   controller->setTurnsMirrored(ishouldMirror);
 }
 
+bool DefaultOdomChassisController::isSettled() {
+  return controller->isSettled();
+}
+
 void DefaultOdomChassisController::waitUntilSettled() {
   controller->waitUntilSettled();
 }

--- a/test/chassisControllerIntegratedTests.cpp
+++ b/test/chassisControllerIntegratedTests.cpp
@@ -12,13 +12,16 @@
 
 using namespace okapi;
 
-class ChassisControllerIntegratedTest : public ::testing::Test {
+class ChassisControllerIntegratedTest : public ::testing::Test { // NOLINT(hicpp-member-init)
   protected:
   void SetUp() override {
     scales = new ChassisScales({wheelDiam, wheelTrack}, gearsetToTPR(gearset));
 
     leftController = new MockAsyncPosIntegratedController();
     rightController = new MockAsyncPosIntegratedController();
+
+    leftController->isSettledOverride = IsSettledOverride::alwaysSettled;
+    rightController->isSettledOverride = IsSettledOverride::alwaysSettled;
 
     model = new MockSkidSteerModel();
     model->setMaxVelocity(101);
@@ -320,4 +323,22 @@ TEST_F(ChassisControllerIntegratedTest, SetMaxVelocityTest) {
   EXPECT_EQ(leftController->maxVelocity, 42);
   EXPECT_EQ(rightController->maxVelocity, 42);
   EXPECT_EQ(model->getMaxVelocity(), 42);
+}
+
+TEST_F(ChassisControllerIntegratedTest, isNotSettledWhenLeftControllerIsNotSettled) {
+  leftController->isSettledOverride = IsSettledOverride::neverSettled;
+  rightController->isSettledOverride = IsSettledOverride::alwaysSettled;
+  EXPECT_FALSE(controller->isSettled());
+}
+
+TEST_F(ChassisControllerIntegratedTest, isNotSettledWhenRightControllerIsNotSettled) {
+  leftController->isSettledOverride = IsSettledOverride::alwaysSettled;
+  rightController->isSettledOverride = IsSettledOverride::neverSettled;
+  EXPECT_FALSE(controller->isSettled());
+}
+
+TEST_F(ChassisControllerIntegratedTest, isSettledWhenLeftAndRightControllersAreSettled) {
+  leftController->isSettledOverride = IsSettledOverride::alwaysSettled;
+  rightController->isSettledOverride = IsSettledOverride::alwaysSettled;
+  EXPECT_TRUE(controller->isSettled());
 }

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -358,7 +358,14 @@ MockAsyncPosIntegratedController::MockAsyncPosIntegratedController(const TimeUti
 }
 
 bool MockAsyncPosIntegratedController::isSettled() {
-  return isSettledOverride || AsyncPosIntegratedController::isSettled();
+  switch (isSettledOverride) {
+  case IsSettledOverride::none:
+    return AsyncPosIntegratedController::isSettled();
+  case IsSettledOverride::alwaysSettled:
+    return true;
+  case IsSettledOverride::neverSettled:
+    return false;
+  }
 }
 
 MockAsyncVelIntegratedController::MockAsyncVelIntegratedController()
@@ -369,7 +376,14 @@ MockAsyncVelIntegratedController::MockAsyncVelIntegratedController()
 }
 
 bool MockAsyncVelIntegratedController::isSettled() {
-  return isSettledOverride || AsyncVelIntegratedController::isSettled();
+  switch (isSettledOverride) {
+  case IsSettledOverride::none:
+    return AsyncVelIntegratedController::isSettled();
+  case IsSettledOverride::alwaysSettled:
+    return true;
+  case IsSettledOverride::neverSettled:
+    return false;
+  }
 }
 
 void MockAsyncVelIntegratedController::setTarget(const double itarget) {
@@ -401,7 +415,14 @@ MockIterativeController::MockIterativeController(const double ikP)
 }
 
 bool MockIterativeController::isSettled() {
-  return isSettledOverride || IterativePosPIDController::isSettled();
+  switch (isSettledOverride) {
+  case IsSettledOverride::none:
+    return IterativePosPIDController::isSettled();
+  case IsSettledOverride::alwaysSettled:
+    return true;
+  case IsSettledOverride::neverSettled:
+    return false;
+  }
 }
 
 void assertMotorsHaveBeenStopped(MockMotor *leftMotor, MockMotor *rightMotor) {


### PR DESCRIPTION
### Description of the Change

This PR adds `ChassisController::isSettled`.

### Motivation

Some users asked for this.

### Possible Drawbacks

Some of the logic in `ChassisControllerPID` has been duplicated, but it's not much and I don't want to touch that class more than necessary.

### Verification Process

New unit tests.

### Applicable Issues

Closes #386.
