### PR TITLE
Abstract Odometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(OkapiLibV5
         include/okapi/api/filter/passthroughFilter.hpp
         include/okapi/api/filter/velMath.hpp
         include/okapi/api/odometry/odometry.hpp
+        include/okapi/api/odometry/twoEncoderOdometry.hpp
         include/okapi/api/odometry/odomMath.hpp
         include/okapi/api/odometry/threeEncoderOdometry.hpp
         include/okapi/api/units/QAcceleration.hpp
@@ -158,7 +159,7 @@ add_executable(OkapiLibV5
         src/api/filter/filter.cpp
         src/api/filter/passthroughFilter.cpp
         src/api/filter/velMath.cpp
-        src/api/odometry/odometry.cpp
+        src/api/odometry/twoEncoderOdometry.cpp
         src/api/odometry/odomMath.cpp
         src/api/odometry/threeEncoderOdometry.cpp
         src/api/util/abstractRate.cpp
@@ -180,7 +181,7 @@ add_executable(OkapiLibV5
         test/controlTests.cpp
         test/filterTests.cpp
         test/implMocks.cpp
-        test/odometryTests.cpp
+        test/twoEncoderOdometryTests.cpp
         test/utilTests.cpp
         test/unitTests.cpp
         test/loggerTests.cpp

--- a/include/okapi/api/chassis/controller/odomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/odomChassisController.hpp
@@ -14,6 +14,11 @@
 #include "okapi/api/odometry/point.hpp"
 #include "okapi/api/util/logging.hpp"
 #include "okapi/api/util/timeUtil.hpp"
+#include "okapi/api/units/QSpeed.hpp"
+#include "okapi/api/util/abstractRate.hpp"
+#include <atomic>
+#include <memory>
+#include <valarray>
 
 namespace okapi {
 class OdomChassisController : public ChassisController {

--- a/include/okapi/api/odometry/odometry.hpp
+++ b/include/okapi/api/odometry/odometry.hpp
@@ -49,5 +49,10 @@ class Odometry {
    */
   virtual void setState(const OdomState &istate,
                         const StateMode &imode = StateMode::FRAME_TRANSFORMATION) = 0;
+
+  /**
+   * @return The internal ChassisModel.
+   */
+  virtual std::shared_ptr<ReadOnlyChassisModel> getModel() = 0;
 };
 } // namespace okapi

--- a/include/okapi/api/odometry/odometry.hpp
+++ b/include/okapi/api/odometry/odometry.hpp
@@ -11,13 +11,6 @@
 #include "okapi/api/chassis/model/readOnlyChassisModel.hpp"
 #include "okapi/api/odometry/odomState.hpp"
 #include "okapi/api/odometry/stateMode.hpp"
-#include "okapi/api/units/QSpeed.hpp"
-#include "okapi/api/util/abstractRate.hpp"
-#include "okapi/api/util/logging.hpp"
-#include "okapi/api/util/timeUtil.hpp"
-#include <atomic>
-#include <memory>
-#include <valarray>
 
 namespace okapi {
 class Odometry {
@@ -25,31 +18,20 @@ class Odometry {
   /**
    * Odometry. Tracks the movement of the robot and estimates its position in coordinates
    * relative to the start (assumed to be (0, 0, 0)).
-   *
-   * @param itimeUtil The TimeUtil.
-   * @param imodel The chassis model for reading sensors.
-   * @param ichassisScales The chassis dimensions.
-   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
-   * driving straight.
-   * @param ilogger The logger this instance will log to.
    */
-  Odometry(const TimeUtil &itimeUtil,
-           const std::shared_ptr<ReadOnlyChassisModel> &imodel,
-           const ChassisScales &ichassisScales,
-           const QSpeed &iwheelVelDelta = 0.0001_mps,
-           const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
+  explicit Odometry() = default;
 
   virtual ~Odometry() = default;
 
   /**
    * Sets the drive and turn scales.
    */
-  virtual void setScales(const ChassisScales &ichassisScales);
+  virtual void setScales(const ChassisScales &ichassisScales) = 0;
 
   /**
    * Do one odometry step.
    */
-  virtual void step();
+  virtual void step() = 0;
 
   /**
    * Returns the current state.
@@ -57,7 +39,7 @@ class Odometry {
    * @param imode The mode to return the state in.
    * @return The current state in the given format.
    */
-  virtual OdomState getState(const StateMode &imode = StateMode::FRAME_TRANSFORMATION) const;
+  virtual OdomState getState(const StateMode &imode = StateMode::FRAME_TRANSFORMATION) const = 0;
 
   /**
    * Sets a new state to be the current state.
@@ -66,26 +48,6 @@ class Odometry {
    * @param imode The mode to treat the input state as.
    */
   virtual void setState(const OdomState &istate,
-                        const StateMode &imode = StateMode::FRAME_TRANSFORMATION);
-
-  protected:
-  std::shared_ptr<Logger> logger;
-  std::unique_ptr<AbstractRate> rate;
-  std::unique_ptr<AbstractTimer> timer;
-  std::shared_ptr<ReadOnlyChassisModel> model;
-  ChassisScales chassisScales;
-  QSpeed wheelVelDelta;
-  OdomState state;
-  std::valarray<std::int32_t> newTicks{0, 0, 0}, tickDiff{0, 0, 0}, lastTicks{0, 0, 0};
-
-  /**
-   * Does the math, side-effect free, for one odom step.
-   *
-   * @param itickDiff The tick difference from the previous step to this step.
-   * @param ideltaT The time difference from the previous step to this step.
-   * @return The newly computed OdomState.
-   */
-  virtual OdomState odomMathStep(const std::valarray<std::int32_t> &itickDiff,
-                                 const QTime &ideltaT);
+                        const StateMode &imode = StateMode::FRAME_TRANSFORMATION) = 0;
 };
 } // namespace okapi

--- a/include/okapi/api/odometry/threeEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/threeEncoderOdometry.hpp
@@ -32,6 +32,11 @@ class ThreeEncoderOdometry : public TwoEncoderOdometry {
                        const QSpeed &iwheelVelDelta = 0.0001_mps,
                        const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
+  /**
+   * @return The internal ChassisModel.
+   */
+  std::shared_ptr<ReadOnlyChassisModel> getModel() override;
+
   protected:
   std::shared_ptr<ReadOnlyChassisModel> model;
 

--- a/include/okapi/api/odometry/threeEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/threeEncoderOdometry.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 #include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
-#include "okapi/api/odometry/odometry.hpp"
+#include "okapi/api/odometry/twoEncoderOdometry.hpp"
 #include "okapi/api/util/timeUtil.hpp"
 #include <functional>
 
 namespace okapi {
-class ThreeEncoderOdometry : public Odometry {
+class ThreeEncoderOdometry : public TwoEncoderOdometry {
   public:
   /**
    * Odometry. Tracks the movement of the robot and estimates its position in coordinates

--- a/include/okapi/api/odometry/twoEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/twoEncoderOdometry.hpp
@@ -1,0 +1,88 @@
+/*
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include "okapi/api/odometry/odometry.hpp"
+#include "okapi/api/units/QSpeed.hpp"
+#include "okapi/api/util/abstractRate.hpp"
+#include "okapi/api/util/logging.hpp"
+#include "okapi/api/util/timeUtil.hpp"
+#include <atomic>
+#include <memory>
+#include <valarray>
+
+namespace okapi {
+class TwoEncoderOdometry : public Odometry {
+  public:
+  /**
+   * TwoEncoderOdometry. Tracks the movement of the robot and estimates its position in coordinates
+   * relative to the start (assumed to be (0, 0, 0)).
+   *
+   * @param itimeUtil The TimeUtil.
+   * @param imodel The chassis model for reading sensors.
+   * @param ichassisScales The chassis dimensions.
+   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
+   * driving straight.
+   * @param ilogger The logger this instance will log to.
+   */
+  TwoEncoderOdometry(const TimeUtil &itimeUtil,
+                     const std::shared_ptr<ReadOnlyChassisModel> &imodel,
+                     const ChassisScales &ichassisScales,
+                     const QSpeed &iwheelVelDelta = 0.0001_mps,
+                     const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
+
+  virtual ~TwoEncoderOdometry() = default;
+
+  /**
+   * Sets the drive and turn scales.
+   */
+  void setScales(const ChassisScales &ichassisScales) override;
+
+  /**
+   * Do one odometry step.
+   */
+  void step() override;
+
+  /**
+   * Returns the current state.
+   *
+   * @param imode The mode to return the state in.
+   * @return The current state in the given format.
+   */
+  OdomState getState(const StateMode &imode = StateMode::FRAME_TRANSFORMATION) const override;
+
+  /**
+   * Sets a new state to be the current state.
+   *
+   * @param istate The new state in the given format.
+   * @param imode The mode to treat the input state as.
+   */
+  void setState(const OdomState &istate,
+                const StateMode &imode = StateMode::FRAME_TRANSFORMATION) override;
+
+  protected:
+  std::shared_ptr<Logger> logger;
+  std::unique_ptr<AbstractRate> rate;
+  std::unique_ptr<AbstractTimer> timer;
+  std::shared_ptr<ReadOnlyChassisModel> model;
+  ChassisScales chassisScales;
+  QSpeed wheelVelDelta;
+  OdomState state;
+  std::valarray<std::int32_t> newTicks{0, 0, 0}, tickDiff{0, 0, 0}, lastTicks{0, 0, 0};
+
+  /**
+   * Does the math, side-effect free, for one odom step.
+   *
+   * @param itickDiff The tick difference from the previous step to this step.
+   * @param ideltaT The time difference from the previous step to this step.
+   * @return The newly computed OdomState.
+   */
+  virtual OdomState odomMathStep(const std::valarray<std::int32_t> &itickDiff,
+                                 const QTime &ideltaT);
+};
+} // namespace okapi

--- a/include/okapi/api/odometry/twoEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/twoEncoderOdometry.hpp
@@ -65,6 +65,11 @@ class TwoEncoderOdometry : public Odometry {
   void setState(const OdomState &istate,
                 const StateMode &imode = StateMode::FRAME_TRANSFORMATION) override;
 
+  /**
+   * @return The internal ChassisModel.
+   */
+  std::shared_ptr<ReadOnlyChassisModel> getModel() override;
+
   protected:
   std::shared_ptr<Logger> logger;
   std::unique_ptr<AbstractRate> rate;

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -15,7 +15,7 @@ ThreeEncoderOdometry::ThreeEncoderOdometry(const TimeUtil &itimeUtil,
                                            const ChassisScales &ichassisScales,
                                            const QSpeed &iwheelVelDelta,
                                            const std::shared_ptr<Logger> &logger)
-  : Odometry(itimeUtil, imodel, ichassisScales, iwheelVelDelta, logger), model(imodel) {
+  : TwoEncoderOdometry(itimeUtil, imodel, ichassisScales, iwheelVelDelta, logger), model(imodel) {
   if (ichassisScales.middle == 0) {
     std::string msg = "ThreeEncoderOdometry: Middle scale cannot be zero.";
     LOG_ERROR(msg);

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -73,4 +73,8 @@ OdomState ThreeEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &
 
   return OdomState{dX * meter, dY * meter, deltaTheta * radian};
 }
+
+std::shared_ptr<ReadOnlyChassisModel> ThreeEncoderOdometry::getModel() {
+  return model;
+}
 } // namespace okapi

--- a/src/api/odometry/twoEncoderOdometry.cpp
+++ b/src/api/odometry/twoEncoderOdometry.cpp
@@ -100,4 +100,8 @@ void TwoEncoderOdometry::setState(const OdomState &istate, const StateMode &imod
     state = OdomState{istate.y, istate.x, istate.theta};
   }
 }
+
+std::shared_ptr<ReadOnlyChassisModel> TwoEncoderOdometry::getModel() {
+  return model;
+}
 } // namespace okapi

--- a/src/api/odometry/twoEncoderOdometry.cpp
+++ b/src/api/odometry/twoEncoderOdometry.cpp
@@ -5,17 +5,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-#include "okapi/api/odometry/odometry.hpp"
+#include "okapi/api/odometry/twoEncoderOdometry.hpp"
 #include "okapi/api/units/QAngularSpeed.hpp"
 #include "okapi/api/util/mathUtil.hpp"
 #include <cmath>
 
 namespace okapi {
-Odometry::Odometry(const TimeUtil &itimeUtil,
-                   const std::shared_ptr<ReadOnlyChassisModel> &imodel,
-                   const ChassisScales &ichassisScales,
-                   const QSpeed &iwheelVelDelta,
-                   const std::shared_ptr<Logger> &ilogger)
+TwoEncoderOdometry::TwoEncoderOdometry(const TimeUtil &itimeUtil,
+                                       const std::shared_ptr<ReadOnlyChassisModel> &imodel,
+                                       const ChassisScales &ichassisScales,
+                                       const QSpeed &iwheelVelDelta,
+                                       const std::shared_ptr<Logger> &ilogger)
   : logger(ilogger),
     rate(itimeUtil.getRate()),
     timer(itimeUtil.getTimer()),
@@ -24,11 +24,11 @@ Odometry::Odometry(const TimeUtil &itimeUtil,
     wheelVelDelta(iwheelVelDelta) {
 }
 
-void Odometry::setScales(const ChassisScales &ichassisScales) {
+void TwoEncoderOdometry::setScales(const ChassisScales &ichassisScales) {
   chassisScales = ichassisScales;
 }
 
-void Odometry::step() {
+void TwoEncoderOdometry::step() {
   const auto deltaT = timer->getDt();
 
   if (deltaT.getValue() != 0) {
@@ -44,7 +44,8 @@ void Odometry::step() {
   }
 }
 
-OdomState Odometry::odomMathStep(const std::valarray<std::int32_t> &itickDiff, const QTime &) {
+OdomState TwoEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &itickDiff,
+                                           const QTime &) {
   const double deltaL = itickDiff[0] / chassisScales.straight;
   const double deltaR = itickDiff[1] / chassisScales.straight;
 
@@ -83,7 +84,7 @@ OdomState Odometry::odomMathStep(const std::valarray<std::int32_t> &itickDiff, c
   return OdomState{dX * meter, dY * meter, deltaTheta * radian};
 }
 
-OdomState Odometry::getState(const StateMode &imode) const {
+OdomState TwoEncoderOdometry::getState(const StateMode &imode) const {
   if (imode == StateMode::FRAME_TRANSFORMATION) {
     return state;
   } else {
@@ -91,7 +92,7 @@ OdomState Odometry::getState(const StateMode &imode) const {
   }
 }
 
-void Odometry::setState(const OdomState &istate, const StateMode &imode) {
+void TwoEncoderOdometry::setState(const OdomState &istate, const StateMode &imode) {
   LOG_DEBUG("State set to: " + istate.str());
   if (imode == StateMode::FRAME_TRANSFORMATION) {
     state = istate;

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -326,7 +326,7 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
   if (isSkidSteer) {
     if (odometry == nullptr) {
       if (middleSensor == nullptr) {
-        odometry = std::make_unique<Odometry>(odometryTimeUtilFactory.create(),
+        odometry = std::make_unique<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
                                               chassisController->getModel(),
                                               chassisController->getChassisScales(),
                                               wheelVelDelta,

--- a/test/defaultOdomChassisControllerTest.cpp
+++ b/test/defaultOdomChassisControllerTest.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/chassis/controller/defaultOdomChassisController.hpp"
+#include "okapi/api/odometry/twoEncoderOdometry.hpp"
 #include "test/tests/api/implMocks.hpp"
 #include <gtest/gtest.h>
 
@@ -14,7 +15,7 @@ using namespace okapi;
 class DefaultOdomChassisControllerTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    odom = new Odometry(createTimeUtil(), std::make_shared<MockReadOnlyChassisModel>(), scales);
+    odom = new TwoEncoderOdometry(createTimeUtil(), std::make_shared<MockReadOnlyChassisModel>(), scales);
     controller = std::make_shared<MockChassisController>();
 
     drive = new DefaultOdomChassisController(
@@ -27,7 +28,7 @@ class DefaultOdomChassisControllerTest : public ::testing::Test {
 
   ChassisScales scales{{4.125_in, 10_in}, imev5GreenTPR};
   SkidSteerModel *model;
-  Odometry *odom;
+  TwoEncoderOdometry *odom;
   DefaultOdomChassisController *drive;
   std::shared_ptr<MockChassisController> controller;
 };

--- a/test/twoEncoderOdometryTests.cpp
+++ b/test/twoEncoderOdometryTests.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
-#include "okapi/api/odometry/odometry.hpp"
+#include "okapi/api/odometry/twoEncoderOdometry.hpp"
 #include "okapi/api/odometry/threeEncoderOdometry.hpp"
 #include "okapi/api/util/mathUtil.hpp"
 #include "test/tests/api/implMocks.hpp"
@@ -19,7 +19,7 @@ class OdometryTest : public ::testing::Test {
   protected:
   void SetUp() override {
     model = new MockSkidSteerModel();
-    odom = new Odometry(createConstantTimeUtil(10_ms),
+    odom = new TwoEncoderOdometry(createConstantTimeUtil(10_ms),
                         std::shared_ptr<MockSkidSteerModel>(model),
                         ChassisScales({{wheelDiam, wheelbaseWidth}, 360}));
   }
@@ -35,7 +35,7 @@ class OdometryTest : public ::testing::Test {
   QLength wheelDiam = 4_in;
   QLength wheelbaseWidth = 10_in;
   MockSkidSteerModel *model;
-  Odometry *odom;
+  TwoEncoderOdometry *odom;
 };
 
 TEST_F(OdometryTest, NoSensorMovementDoesNotAffectState) {


### PR DESCRIPTION
### Description of the Change

This PR defines an abstract `Odometry` class, which has interface methods such as `getState`, `setState` and `step`. 

The former `Odometry` class has been renamed to `TwoEncoderOdometry`, and all the necessary tests and builders updated.

As a separate change, all odometry classes now have `getModel` as a method, to allow people to do things such as read sensor values of the odometry object. 

### Motivation

There are two motivations for this:

- Extend `Odometry` to implement custom odometry that does not build on the math or protected objects contained in `TwoEncoderOdometry`
- Implement an odometry reader that can observe the state of the sensors within the odometry

Currently, it is impossible to implement an odometry class that extends `Odometry` with a different constructor/member interface, as `Odometry` is not empty-constructable.

My personal use-case is this:
I want to implement my own odometry that extends `Odometry`, but that uses completely different members and constructors. I also want to make an LVGL odometry display that can accept any `Odometry` and display the state of the robot, along with the sensor values of the robot. Currently, I am unable to inherit my custom odometry from `Odometry`, so therefore I can't have my GUI accept an `Odometry`.

### Verification Process

While this is more of a structural change, I have not tested it on a real robot. I hope I didn't miss something important.
