### PR TITLE
Remove moveDistance and turnAngle non-units overloads

### DIFF
--- a/docs/tutorials/walkthrough/basicAutonomousMovement.md
+++ b/docs/tutorials/walkthrough/basicAutonomousMovement.md
@@ -40,11 +40,11 @@ auto chassis = ChassisControllerBuilder()
 
 void autonomous() {
     // Move to first goal in motor degrees
-    chassis->moveDistance(1000);
+    chassis->moveRaw(1000);
     // Turn to face second goal in motor degrees
-    chassis->turnAngle(100);
+    chassis->turnRaw(100);
     // Drive toward second goal in motor degrees
-    chassis->moveDistance(1500);
+    chassis->moveRaw(1500);
 }
 ```
 

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -41,7 +41,7 @@ class ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  virtual void moveDistance(double itarget) = 0;
+  virtual void moveRaw(double itarget) = 0;
 
   /**
    * Sets the target distance for the robot to drive straight (using closed-loop control).
@@ -55,7 +55,7 @@ class ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  virtual void moveDistanceAsync(double itarget) = 0;
+  virtual void moveRawAsync(double itarget) = 0;
 
   /**
    * Turns the robot clockwise in place (using closed-loop control).
@@ -69,7 +69,7 @@ class ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  virtual void turnAngle(double idegTarget) = 0;
+  virtual void turnRaw(double idegTarget) = 0;
 
   /**
    * Sets the target angle for the robot to turn clockwise in place (using closed-loop control).
@@ -83,7 +83,7 @@ class ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  virtual void turnAngleAsync(double idegTarget) = 0;
+  virtual void turnRawAsync(double idegTarget) = 0;
 
   /**
    * Sets whether turns should be mirrored.

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -62,7 +62,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  void moveDistance(double itarget) override;
+  void moveRaw(double itarget) override;
 
   /**
    * Sets the target distance for the robot to drive straight (using closed-loop control).
@@ -76,7 +76,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  void moveDistanceAsync(double itarget) override;
+  void moveRawAsync(double itarget) override;
 
   /**
    * Turns the robot clockwise in place (using closed-loop control).
@@ -100,7 +100,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  void turnAngle(double idegTarget) override;
+  void turnRaw(double idegTarget) override;
 
   /**
    * Sets the target angle for the robot to turn clockwise in place (using closed-loop control).
@@ -114,7 +114,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  void turnAngleAsync(double idegTarget) override;
+  void turnRawAsync(double idegTarget) override;
 
   /**
    * Sets whether turns should be mirrored.

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -75,7 +75,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  void moveDistance(double itarget) override;
+  void moveRaw(double itarget) override;
 
   /**
    * Sets the target distance for the robot to drive straight (using closed-loop control).
@@ -89,7 +89,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * @param itarget distance to travel in motor degrees
    */
-  void moveDistanceAsync(double itarget) override;
+  void moveRawAsync(double itarget) override;
 
   /**
    * Turns the robot clockwise in place (using closed-loop control).
@@ -113,7 +113,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  void turnAngle(double idegTarget) override;
+  void turnRaw(double idegTarget) override;
 
   /**
    * Sets the target angle for the robot to turn clockwise in place (using closed-loop control).
@@ -127,7 +127,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * @param idegTarget angle to turn for in motor degrees
    */
-  void turnAngleAsync(double idegTarget) override;
+  void turnRawAsync(double idegTarget) override;
 
   /**
    * Sets whether turns should be mirrored.

--- a/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
@@ -88,7 +88,7 @@ class DefaultOdomChassisController : public OdomChassisController {
   /**
    * This delegates to the input ChassisController.
    */
-  void moveDistance(double itarget) override;
+  void moveRaw(double itarget) override;
 
   /**
    * This delegates to the input ChassisController.
@@ -98,7 +98,7 @@ class DefaultOdomChassisController : public OdomChassisController {
   /**
    * This delegates to the input ChassisController.
    */
-  void moveDistanceAsync(double itarget) override;
+  void moveRawAsync(double itarget) override;
 
   /**
    * This delegates to the input ChassisController.
@@ -108,7 +108,7 @@ class DefaultOdomChassisController : public OdomChassisController {
   /**
    * This delegates to the input ChassisController.
    */
-  void turnAngle(double idegTarget) override;
+  void turnRaw(double idegTarget) override;
 
   /**
    * This delegates to the input ChassisController.
@@ -118,7 +118,7 @@ class DefaultOdomChassisController : public OdomChassisController {
   /**
    * This delegates to the input ChassisController.
    */
-  void turnAngleAsync(double idegTarget) override;
+  void turnRawAsync(double idegTarget) override;
 
   /**
    * This delegates to the input ChassisController.

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -588,26 +588,26 @@ class MockChassisController : public ChassisController {
   void moveDistance(QLength itarget) override {
     lastMoveDistanceTargetQLength = itarget;
   }
-  void moveDistance(double itarget) override {
+  void moveRaw(double itarget) override {
     lastMoveDistanceTargetDouble = itarget;
   }
   void moveDistanceAsync(QLength itarget) override {
     moveDistance(itarget);
   }
-  void moveDistanceAsync(double itarget) override {
-    moveDistance(itarget);
+  void moveRawAsync(double itarget) override {
+    moveRaw(itarget);
   }
   void turnAngle(QAngle idegTarget) override {
     lastTurnAngleTargetQAngle = idegTarget;
   }
-  void turnAngle(double idegTarget) override {
+  void turnRaw(double idegTarget) override {
     lastTurnAngleTargetDouble = idegTarget;
   }
   void turnAngleAsync(QAngle idegTarget) override {
     turnAngle(idegTarget);
   }
-  void turnAngleAsync(double idegTarget) override {
-    turnAngle(idegTarget);
+  void turnRawAsync(double idegTarget) override {
+    turnRaw(idegTarget);
   }
   void setTurnsMirrored(bool ishouldMirror) override {
     turnsMirrored = ishouldMirror;

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -43,7 +43,7 @@ void ChassisControllerIntegrated::moveDistance(const QLength itarget) {
   waitUntilSettled();
 }
 
-void ChassisControllerIntegrated::moveDistance(const double itarget) {
+void ChassisControllerIntegrated::moveRaw(const double itarget) {
   // Divide by straightScale so the final result turns back into motor ticks
   moveDistance((itarget / scales.straight) * meter);
 }
@@ -66,7 +66,7 @@ void ChassisControllerIntegrated::moveDistanceAsync(const QLength itarget) {
   rightController->setTarget(newTarget + enc[1]);
 }
 
-void ChassisControllerIntegrated::moveDistanceAsync(const double itarget) {
+void ChassisControllerIntegrated::moveRawAsync(const double itarget) {
   // Divide by straightScale so the final result turns back into motor ticks
   moveDistanceAsync((itarget / scales.straight) * meter);
 }
@@ -76,7 +76,7 @@ void ChassisControllerIntegrated::turnAngle(const QAngle idegTarget) {
   waitUntilSettled();
 }
 
-void ChassisControllerIntegrated::turnAngle(const double idegTarget) {
+void ChassisControllerIntegrated::turnRaw(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor ticks
   turnAngle((idegTarget / scales.turn) * degree);
 }
@@ -100,7 +100,7 @@ void ChassisControllerIntegrated::turnAngleAsync(const QAngle idegTarget) {
   rightController->setTarget(-1 * newTarget + enc[1]);
 }
 
-void ChassisControllerIntegrated::turnAngleAsync(const double idegTarget) {
+void ChassisControllerIntegrated::turnRawAsync(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor ticks
   turnAngleAsync((idegTarget / scales.turn) * degree);
 }

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -137,7 +137,7 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   newMovement.store(true, std::memory_order_release);
 }
 
-void ChassisControllerPID::moveDistanceAsync(const double itarget) {
+void ChassisControllerPID::moveRawAsync(const double itarget) {
   // Divide by straightScale so the final result turns back into motor ticks
   moveDistanceAsync((itarget / scales.straight) * meter);
 }
@@ -147,7 +147,7 @@ void ChassisControllerPID::moveDistance(const QLength itarget) {
   waitUntilSettled();
 }
 
-void ChassisControllerPID::moveDistance(const double itarget) {
+void ChassisControllerPID::moveRaw(const double itarget) {
   // Divide by straightScale so the final result turns back into motor ticks
   moveDistance((itarget / scales.straight) * meter);
 }
@@ -173,7 +173,7 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   newMovement.store(true, std::memory_order_release);
 }
 
-void ChassisControllerPID::turnAngleAsync(const double idegTarget) {
+void ChassisControllerPID::turnRawAsync(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor ticks
   turnAngleAsync((idegTarget / scales.turn) * degree);
 }
@@ -183,7 +183,7 @@ void ChassisControllerPID::turnAngle(const QAngle idegTarget) {
   waitUntilSettled();
 }
 
-void ChassisControllerPID::turnAngle(const double idegTarget) {
+void ChassisControllerPID::turnRaw(const double idegTarget) {
   // Divide by turnScale so the final result turns back into motor ticks
   turnAngle((idegTarget / scales.turn) * degree);
 }

--- a/src/api/chassis/controller/defaultOdomChassisController.cpp
+++ b/src/api/chassis/controller/defaultOdomChassisController.cpp
@@ -82,32 +82,32 @@ void DefaultOdomChassisController::moveDistance(QLength itarget) {
   controller->moveDistance(itarget);
 }
 
-void DefaultOdomChassisController::moveDistance(double itarget) {
-  controller->moveDistance(itarget);
+void DefaultOdomChassisController::moveRaw(double itarget) {
+  controller->moveRaw(itarget);
 }
 
 void DefaultOdomChassisController::moveDistanceAsync(QLength itarget) {
   controller->moveDistanceAsync(itarget);
 }
 
-void DefaultOdomChassisController::moveDistanceAsync(double itarget) {
-  controller->moveDistanceAsync(itarget);
+void DefaultOdomChassisController::moveRawAsync(double itarget) {
+  controller->moveRawAsync(itarget);
 }
 
 void DefaultOdomChassisController::turnAngle(QAngle idegTarget) {
   controller->turnAngle(idegTarget);
 }
 
-void DefaultOdomChassisController::turnAngle(double idegTarget) {
-  controller->turnAngle(idegTarget);
+void DefaultOdomChassisController::turnRaw(double idegTarget) {
+  controller->turnRaw(idegTarget);
 }
 
 void DefaultOdomChassisController::turnAngleAsync(QAngle idegTarget) {
   controller->turnAngleAsync(idegTarget);
 }
 
-void DefaultOdomChassisController::turnAngleAsync(double idegTarget) {
-  controller->turnAngleAsync(idegTarget);
+void DefaultOdomChassisController::turnRawAsync(double idegTarget) {
+  controller->turnRawAsync(idegTarget);
 }
 
 void DefaultOdomChassisController::setTurnsMirrored(bool ishouldMirror) {

--- a/test/chassisControllerIntegratedTests.cpp
+++ b/test/chassisControllerIntegratedTests.cpp
@@ -66,7 +66,7 @@ TEST_F(ChassisControllerIntegratedTest, GearsetIsCorrect) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceRawUnitsTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
@@ -92,7 +92,7 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceUnitsTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncRawUnitsTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
@@ -133,7 +133,7 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceAsyncUnitsTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleRawUnitsTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), -100);
@@ -159,7 +159,7 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleUnitsTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleAsyncRawUnitsTest) {
-  controller->turnAngleAsync(100);
+  controller->turnRawAsync(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), -100);
@@ -205,7 +205,7 @@ TEST_F(ChassisControllerIntegratedTest, MirrorTurnTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
@@ -213,7 +213,7 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
   EXPECT_FALSE(leftController->isDisabled());
   EXPECT_FALSE(rightController->isDisabled());
 
-  controller->turnAngleAsync(200);
+  controller->turnRawAsync(200);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 200);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), -200);
@@ -230,7 +230,7 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceThenTurnAngleAsyncTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleThenMoveDistanceAsyncTest) {
-  controller->turnAngleAsync(200);
+  controller->turnRawAsync(200);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 200);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), -200);
@@ -238,7 +238,7 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleThenMoveDistanceAsyncTest) {
   EXPECT_FALSE(leftController->isDisabled());
   EXPECT_FALSE(rightController->isDisabled());
 
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(leftController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(rightController->getTarget(), 100);
@@ -255,14 +255,14 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleThenMoveDistanceAsyncTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceAndWaitTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
   controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceGetPushedAndWaitTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
 
   // First bump
   leftMotor->encoder->value = 500;
@@ -278,14 +278,14 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceGetPushedAndWaitTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleAndWaitTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
   controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleGetPushedAndWaitTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
 
   // First bump
   leftMotor->encoder->value = 500;
@@ -301,7 +301,7 @@ TEST_F(ChassisControllerIntegratedTest, TurnAngleGetPushedAndWaitTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, MoveDistanceAndStopTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
   controller->stop();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
@@ -310,7 +310,7 @@ TEST_F(ChassisControllerIntegratedTest, MoveDistanceAndStopTest) {
 }
 
 TEST_F(ChassisControllerIntegratedTest, TurnAngleAndStopTest) {
-  controller->turnAngleAsync(100);
+  controller->turnRawAsync(100);
   controller->stop();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);

--- a/test/chassisControllerPidTest.cpp
+++ b/test/chassisControllerPidTest.cpp
@@ -71,7 +71,7 @@ TEST_F(ChassisControllerPIDTest, GearsetIsCorrect) {
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceRawUnitsTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
 
   EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
@@ -98,7 +98,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceUnitsTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncRawUnitsTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
@@ -137,7 +137,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAsyncUnitsTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleRawUnitsTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
 
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
   EXPECT_DOUBLE_EQ(turnController->getTarget(), 100);
@@ -164,7 +164,7 @@ TEST_F(ChassisControllerPIDTest, TurnAngleUnitsTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleAsyncRawUnitsTest) {
-  controller->turnAngleAsync(100);
+  controller->turnRawAsync(100);
 
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
   EXPECT_DOUBLE_EQ(turnController->getTarget(), 100);
@@ -213,7 +213,7 @@ TEST_F(ChassisControllerPIDTest, MirrorTurnTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
@@ -222,7 +222,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
   EXPECT_FALSE(angleController->isDisabled());
   EXPECT_TRUE(turnController->isDisabled());
 
-  controller->turnAngleAsync(200);
+  controller->turnRawAsync(200);
 
   EXPECT_DOUBLE_EQ(turnController->getTarget(), 200);
 
@@ -240,7 +240,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceThenTurnAngleAsyncTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
-  controller->turnAngleAsync(200);
+  controller->turnRawAsync(200);
 
   EXPECT_DOUBLE_EQ(turnController->getTarget(), 200);
 
@@ -248,7 +248,7 @@ TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
   EXPECT_TRUE(angleController->isDisabled());
   EXPECT_FALSE(turnController->isDisabled());
 
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
 
   EXPECT_DOUBLE_EQ(distanceController->getTarget(), 100);
   EXPECT_DOUBLE_EQ(angleController->getTarget(), 0);
@@ -267,14 +267,14 @@ TEST_F(ChassisControllerPIDTest, TurnAngleThenMoveDistanceAsyncTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceAndWaitTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
   controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceGetBumpedAndWaitTest) {
-  controller->moveDistance(100);
+  controller->moveRaw(100);
 
   // First bump
   leftMotor->encoder->value = 500;
@@ -290,14 +290,14 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceGetBumpedAndWaitTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleAndWaitTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
   controller->waitUntilSettled();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleGetBumpedAndWaitTest) {
-  controller->turnAngle(100);
+  controller->turnRaw(100);
 
   // First bump
   leftMotor->encoder->value = 500;
@@ -313,7 +313,7 @@ TEST_F(ChassisControllerPIDTest, TurnAngleGetBumpedAndWaitTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, MoveDistanceAndStopTest) {
-  controller->moveDistanceAsync(100);
+  controller->moveRawAsync(100);
   controller->stop();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);
@@ -322,7 +322,7 @@ TEST_F(ChassisControllerPIDTest, MoveDistanceAndStopTest) {
 }
 
 TEST_F(ChassisControllerPIDTest, TurnAngleAndStopTest) {
-  controller->turnAngleAsync(100);
+  controller->turnRawAsync(100);
   controller->stop();
 
   assertMotorsHaveBeenStopped(leftMotor, rightMotor);


### PR DESCRIPTION
### Description of the Change

This PR remove `moveDistance` and `turnAngle` overloads that use `double` instead of units.

### Motivation

These overloads have caused some confusion, so renaming them makes for a clearer API.

### Possible Drawbacks

None.

### Verification Process

Just CI.

### Applicable Issues

None.
