### PR TITLE
Add odometry for all chassis models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(OkapiLibV5
         include/okapi/api/chassis/model/readOnlyChassisModel.hpp
         include/okapi/api/chassis/model/skidSteerModel.hpp
         include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+        include/okapi/api/chassis/model/threeEncoderXDriveModel.hpp
         include/okapi/api/chassis/model/xDriveModel.hpp
         include/okapi/api/control/async/asyncController.hpp
         include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -136,6 +137,7 @@ add_executable(OkapiLibV5
         src/api/chassis/model/hDriveModel.cpp
         src/api/chassis/model/skidSteerModel.cpp
         src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+        src/api/chassis/model/threeEncoderXDriveModel.cpp
         src/api/chassis/model/xDriveModel.cpp
         src/api/control/async/asyncLinearMotionProfileController.cpp
         src/api/control/async/asyncMotionProfileController.cpp
@@ -210,7 +212,8 @@ add_executable(OkapiLibV5
         test/odomMathTests.cpp
         include/okapi/api/odometry/stateMode.hpp
         include/okapi/api/odometry/odomState.hpp
-        src/api/odometry/odomState.cpp)
+        src/api/odometry/odomState.cpp
+        test/threeEncoderXDriveModelTests.cpp)
 
 # Link against gtest
 target_link_libraries(OkapiLibV5 gtest_main)

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -37,6 +37,7 @@
 #include "okapi/api/chassis/model/readOnlyChassisModel.hpp"
 #include "okapi/api/chassis/model/skidSteerModel.hpp"
 #include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
+#include "okapi/api/chassis/model/threeEncoderXDriveModel.hpp"
 #include "okapi/api/chassis/model/xDriveModel.hpp"
 #include "okapi/impl/chassis/controller/chassisControllerBuilder.hpp"
 

--- a/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp
@@ -25,8 +25,8 @@ class ThreeEncoderSkidSteerModel : public SkidSteerModel {
   ThreeEncoderSkidSteerModel(std::shared_ptr<AbstractMotor> ileftSideMotor,
                              std::shared_ptr<AbstractMotor> irightSideMotor,
                              std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-                             std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
                              std::shared_ptr<ContinuousRotarySensor> irightEnc,
+                             std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
                              double imaxVelocity,
                              double imaxVoltage);
 

--- a/include/okapi/api/chassis/model/threeEncoderXDriveModel.hpp
+++ b/include/okapi/api/chassis/model/threeEncoderXDriveModel.hpp
@@ -1,0 +1,52 @@
+/*
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include "okapi/api/chassis/model/xDriveModel.hpp"
+
+namespace okapi {
+class ThreeEncoderXDriveModel : public XDriveModel {
+  public:
+  /**
+   * Model for an x drive (wheels at 45 deg from a skid steer drive). When all motors are powered
+   * +100%, the robot should move forward in a straight line.
+   *
+   * @param itopLeftMotor The top left motor.
+   * @param itopRightMotor The top right motor.
+   * @param ibottomRightMotor The bottom right motor.
+   * @param ibottomLeftMotor The bottom left motor.
+   * @param ileftEnc The left side encoder.
+   * @param irightEnc The right side encoder.
+   * @param imiddleEnc The middle encoder.
+   */
+  ThreeEncoderXDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
+                          std::shared_ptr<AbstractMotor> itopRightMotor,
+                          std::shared_ptr<AbstractMotor> ibottomRightMotor,
+                          std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+                          std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+                          std::shared_ptr<ContinuousRotarySensor> irightEnc,
+                          std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
+                          double imaxVelocity,
+                          double imaxVoltage);
+
+  /**
+   * Read the sensors.
+   *
+   * @return sensor readings in the format {left, right, middle}
+   */
+  std::valarray<std::int32_t> getSensorVals() const override;
+
+  /**
+   * Reset the sensors to their zero point.
+   */
+  void resetSensors() override;
+
+  protected:
+  std::shared_ptr<ContinuousRotarySensor> middleSensor;
+};
+} // namespace okapi

--- a/include/okapi/api/util/mathUtil.hpp
+++ b/include/okapi/api/util/mathUtil.hpp
@@ -60,7 +60,7 @@ static constexpr double ime269TPR = 240.448;
 static constexpr std::int32_t imev5RedTPR = 1800;
 
 /**
- * The ticks per rotation of the V5 motor with a hreen gearset.
+ * The ticks per rotation of the V5 motor with a green gearset.
  */
 static constexpr std::int32_t imev5GreenTPR = 900;
 

--- a/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
+++ b/src/api/chassis/model/threeEncoderSkidSteerModel.cpp
@@ -12,8 +12,8 @@ ThreeEncoderSkidSteerModel::ThreeEncoderSkidSteerModel(
   std::shared_ptr<AbstractMotor> ileftSideMotor,
   std::shared_ptr<AbstractMotor> irightSideMotor,
   std::shared_ptr<ContinuousRotarySensor> ileftEnc,
-  std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
   std::shared_ptr<ContinuousRotarySensor> irightEnc,
+  std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
   const double imaxVelocity,
   const double imaxVoltage)
   : SkidSteerModel(std::move(ileftSideMotor),

--- a/src/api/chassis/model/threeEncoderXDriveModel.cpp
+++ b/src/api/chassis/model/threeEncoderXDriveModel.cpp
@@ -1,0 +1,42 @@
+/*
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/chassis/model/threeEncoderXDriveModel.hpp"
+
+namespace okapi {
+ThreeEncoderXDriveModel::ThreeEncoderXDriveModel(std::shared_ptr<AbstractMotor> itopLeftMotor,
+                                                 std::shared_ptr<AbstractMotor> itopRightMotor,
+                                                 std::shared_ptr<AbstractMotor> ibottomRightMotor,
+                                                 std::shared_ptr<AbstractMotor> ibottomLeftMotor,
+                                                 std::shared_ptr<ContinuousRotarySensor> ileftEnc,
+                                                 std::shared_ptr<ContinuousRotarySensor> irightEnc,
+                                                 std::shared_ptr<ContinuousRotarySensor> imiddleEnc,
+                                                 const double imaxVelocity,
+                                                 const double imaxVoltage)
+  : XDriveModel(std::move(itopLeftMotor),
+                std::move(itopRightMotor),
+                std::move(ibottomRightMotor),
+                std::move(ibottomLeftMotor),
+                std::move(ileftEnc),
+                std::move(irightEnc),
+                imaxVelocity,
+                imaxVoltage),
+    middleSensor(std::move(imiddleEnc)) {
+}
+
+std::valarray<std::int32_t> ThreeEncoderXDriveModel::getSensorVals() const {
+  // Return the middle sensor last so this is compatible with XDriveModel::getSensorVals()
+  return std::valarray<std::int32_t>{static_cast<std::int32_t>(leftSensor->get()),
+                                     static_cast<std::int32_t>(rightSensor->get()),
+                                     static_cast<std::int32_t>(middleSensor->get())};
+}
+
+void ThreeEncoderXDriveModel::resetSensors() {
+  XDriveModel::resetSensors();
+  middleSensor->reset();
+}
+} // namespace okapi

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -21,12 +21,6 @@ ThreeEncoderOdometry::ThreeEncoderOdometry(const TimeUtil &itimeUtil,
     LOG_ERROR(msg);
     throw std::invalid_argument(msg);
   }
-
-  if (ichassisScales.middleWheelDistance == 0_m) {
-    std::string msg = "ThreeEncoderOdometry: Middle wheel distance cannot be zero.";
-    LOG_ERROR(msg);
-    throw std::invalid_argument(msg);
-  }
 }
 
 OdomState ThreeEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &itickDiff,

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -505,8 +505,8 @@ std::shared_ptr<SkidSteerModel> ChassisControllerBuilder::makeSkidSteerModel() {
     return std::make_shared<ThreeEncoderSkidSteerModel>(skidSteerMotors.left,
                                                         skidSteerMotors.right,
                                                         leftSensor,
-                                                        middleSensor,
                                                         rightSensor,
+                                                        middleSensor,
                                                         maxVelocity,
                                                         maxVoltage);
   } else {

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -7,6 +7,7 @@
  */
 #include "okapi/impl/chassis/controller/chassisControllerBuilder.hpp"
 #include "okapi/api/chassis/model/threeEncoderSkidSteerModel.hpp"
+#include "okapi/api/chassis/model/threeEncoderXDriveModel.hpp"
 #include "okapi/api/odometry/threeEncoderOdometry.hpp"
 #include "okapi/impl/util/configurableTimeUtilFactory.hpp"
 #include "okapi/impl/util/rate.hpp"
@@ -372,44 +373,38 @@ std::shared_ptr<OdomChassisController> ChassisControllerBuilder::buildOdometry()
 
 std::shared_ptr<DefaultOdomChassisController>
 ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisController) {
-  if (driveMode == DriveMode::SkidSteer) {
-    if (odometry == nullptr) {
-      if (middleSensor == nullptr) {
-        odometry = std::make_unique<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
+  if (odometry == nullptr) {
+    if (middleSensor == nullptr) {
+      odometry = std::make_unique<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
+                                                      chassisController->getModel(),
+                                                      chassisController->getChassisScales(),
+                                                      wheelVelDelta,
+                                                      controllerLogger);
+    } else {
+      odometry = std::make_unique<ThreeEncoderOdometry>(odometryTimeUtilFactory.create(),
                                                         chassisController->getModel(),
                                                         chassisController->getChassisScales(),
                                                         wheelVelDelta,
                                                         controllerLogger);
-      } else {
-        odometry = std::make_unique<ThreeEncoderOdometry>(odometryTimeUtilFactory.create(),
-                                                          chassisController->getModel(),
-                                                          chassisController->getChassisScales(),
-                                                          wheelVelDelta,
-                                                          controllerLogger);
-      }
     }
-
-    auto out =
-      std::make_shared<DefaultOdomChassisController>(chassisControllerTimeUtilFactory.create(),
-                                                     std::move(odometry),
-                                                     chassisController,
-                                                     stateMode,
-                                                     moveThreshold,
-                                                     turnThreshold,
-                                                     controllerLogger);
-
-    out->startOdomThread();
-
-    if (isParentedToCurrentTask && NOT_INITIALIZE_TASK && NOT_COMP_INITIALIZE_TASK) {
-      out->getOdomThread()->notifyWhenDeletingRaw(pros::c::task_get_current());
-    }
-
-    return out;
-  } else {
-    std::string msg("ChassisControllerBuilder: Odometry is only supported with skid-steer layout.");
-    LOG_ERROR(msg);
-    throw std::runtime_error(msg);
   }
+
+  auto out =
+    std::make_shared<DefaultOdomChassisController>(chassisControllerTimeUtilFactory.create(),
+                                                   std::move(odometry),
+                                                   chassisController,
+                                                   stateMode,
+                                                   moveThreshold,
+                                                   turnThreshold,
+                                                   controllerLogger);
+
+  out->startOdomThread();
+
+  if (isParentedToCurrentTask && NOT_INITIALIZE_TASK && NOT_COMP_INITIALIZE_TASK) {
+    out->getOdomThread()->notifyWhenDeletingRaw(pros::c::task_get_current());
+  }
+
+  return out;
 }
 
 std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
@@ -483,6 +478,7 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
 }
 
 std::shared_ptr<ChassisModel> ChassisControllerBuilder::makeChassisModel() {
+  // These implementations should handle a null middleSensor
   switch (driveMode) {
   case DriveMode::SkidSteer:
     return makeSkidSteerModel();
@@ -494,7 +490,8 @@ std::shared_ptr<ChassisModel> ChassisControllerBuilder::makeChassisModel() {
     return makeHDriveModel();
 
   default:
-    std::string msg = "ChassisControllerBuilder: Unhandled DriveMode case in makeChassisModel.";
+    std::string msg =
+      "ChassisControllerBuilder: BUG: Unhandled DriveMode case in makeChassisModel.";
     LOG_ERROR(msg);
     throw std::runtime_error(msg);
   }
@@ -520,17 +517,30 @@ std::shared_ptr<SkidSteerModel> ChassisControllerBuilder::makeSkidSteerModel() {
 }
 
 std::shared_ptr<XDriveModel> ChassisControllerBuilder::makeXDriveModel() {
-  return std::make_shared<XDriveModel>(xDriveMotors.topLeft,
-                                       xDriveMotors.topRight,
-                                       xDriveMotors.bottomRight,
-                                       xDriveMotors.bottomLeft,
-                                       leftSensor,
-                                       rightSensor,
-                                       maxVelocity,
-                                       maxVoltage);
+  if (middleSensor != nullptr) {
+    return std::make_shared<ThreeEncoderXDriveModel>(xDriveMotors.topLeft,
+                                                     xDriveMotors.topRight,
+                                                     xDriveMotors.bottomRight,
+                                                     xDriveMotors.bottomLeft,
+                                                     leftSensor,
+                                                     rightSensor,
+                                                     middleSensor,
+                                                     maxVelocity,
+                                                     maxVoltage);
+  } else {
+    return std::make_shared<XDriveModel>(xDriveMotors.topLeft,
+                                         xDriveMotors.topRight,
+                                         xDriveMotors.bottomRight,
+                                         xDriveMotors.bottomLeft,
+                                         leftSensor,
+                                         rightSensor,
+                                         maxVelocity,
+                                         maxVoltage);
+  }
 }
 
 std::shared_ptr<HDriveModel> ChassisControllerBuilder::makeHDriveModel() {
+  // HDriveModel already has three encoders
   return std::make_shared<HDriveModel>(hDriveMotors.left,
                                        hDriveMotors.right,
                                        hDriveMotors.middle,

--- a/test/threeEncoderOdometryTests.cpp
+++ b/test/threeEncoderOdometryTests.cpp
@@ -139,3 +139,23 @@ TEST_F(ThreeEncoderOdometryTest, SmallSwingTurnOnRightWheels) {
   odom.step();
   assertOdomStateEquals(&odom, -0.024_in, 0_in, 0.2131_deg);
 }
+
+TEST_F(ThreeEncoderOdometryTest, MiddleEncoderDistanceOfZero) {
+  auto model = std::make_shared<MockThreeEncoderModel>();
+  ThreeEncoderOdometry odom(
+    createConstantTimeUtil(10_ms),
+    model,
+    ChassisScales{{wheelDiam, wheelbaseWidth, 0_in, wheelDiam}, quadEncoderTPR});
+
+  model->setSensorVals(0, 0, 10);
+  odom.step();
+  assertOdomStateEquals(&odom, 0_in, calculateDistanceTraveled(10), 0_deg);
+
+  model->setSensorVals(0, 0, 0);
+  odom.step();
+  assertOdomStateEquals(&odom, 0_in, 0_in, 0_deg);
+
+  model->setSensorVals(10, 10, 10);
+  odom.step();
+  assertOdomStateEquals(&odom, calculateDistanceTraveled(10), calculateDistanceTraveled(10), 0_deg);
+}

--- a/test/threeEncoderSkidSteerModelTests.cpp
+++ b/test/threeEncoderSkidSteerModelTests.cpp
@@ -21,7 +21,7 @@ class ThreeEncoderSkidSteerModelTest : public ::testing::Test {
     rightSensor = std::make_shared<MockContinuousRotarySensor>();
     middleSensor = std::make_shared<MockContinuousRotarySensor>();
     model = new ThreeEncoderSkidSteerModel(
-      leftMotor, rightMotor, leftSensor, middleSensor, rightSensor, 100, v5MotorMaxVoltage);
+      leftMotor, rightMotor, leftSensor, rightSensor, middleSensor, 100, v5MotorMaxVoltage);
   }
 
   void TearDown() override {

--- a/test/threeEncoderXDriveModelTests.cpp
+++ b/test/threeEncoderXDriveModelTests.cpp
@@ -1,0 +1,80 @@
+/*
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/chassis/model/threeEncoderXDriveModel.hpp"
+#include "okapi/api/chassis/model/xDriveModel.hpp"
+#include "test/tests/api/implMocks.hpp"
+#include <gtest/gtest.h>
+
+using namespace okapi;
+
+class ThreeEncoderXDriveModelTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    topLeftMotor = std::make_shared<MockMotor>();
+    topRightMotor = std::make_shared<MockMotor>();
+    bottomRightMotor = std::make_shared<MockMotor>();
+    bottomLeftMotor = std::make_shared<MockMotor>();
+    leftSensor = std::make_shared<MockContinuousRotarySensor>();
+    rightSensor = std::make_shared<MockContinuousRotarySensor>();
+    middleSensor = std::make_shared<MockContinuousRotarySensor>();
+    model = new ThreeEncoderXDriveModel(topLeftMotor,
+                                        topRightMotor,
+                                        bottomRightMotor,
+                                        bottomLeftMotor,
+                                        leftSensor,
+                                        rightSensor,
+                                        middleSensor,
+                                        100,
+                                        v5MotorMaxVoltage);
+  }
+
+  void TearDown() override {
+    delete model;
+  }
+
+  std::shared_ptr<MockMotor> topLeftMotor;
+  std::shared_ptr<MockMotor> topRightMotor;
+  std::shared_ptr<MockMotor> bottomRightMotor;
+  std::shared_ptr<MockMotor> bottomLeftMotor;
+  std::shared_ptr<MockContinuousRotarySensor> leftSensor;
+  std::shared_ptr<MockContinuousRotarySensor> rightSensor;
+  std::shared_ptr<MockContinuousRotarySensor> middleSensor;
+  ThreeEncoderXDriveModel *model;
+};
+
+TEST_F(ThreeEncoderXDriveModelTest, GetSensorValsIsCompatibleWithXDriveModel) {
+  leftSensor->value = 1;
+  rightSensor->value = 2;
+  middleSensor->value = 3;
+
+  auto xDriveModelVals = XDriveModel(topLeftMotor,
+                                     topRightMotor,
+                                     bottomRightMotor,
+                                     bottomLeftMotor,
+                                     leftSensor,
+                                     rightSensor,
+                                     100,
+                                     v5MotorMaxVoltage)
+                           .getSensorVals();
+  auto threeEncoderXDriveModelVals = model->getSensorVals();
+
+  EXPECT_EQ(xDriveModelVals[0], threeEncoderXDriveModelVals[0]);
+  EXPECT_EQ(xDriveModelVals[1], threeEncoderXDriveModelVals[1]);
+}
+
+TEST_F(ThreeEncoderXDriveModelTest, Reset) {
+  leftSensor->value = 1;
+  rightSensor->value = 1;
+  middleSensor->value = 1;
+
+  model->resetSensors();
+
+  EXPECT_EQ(leftSensor->get(), 0);
+  EXPECT_EQ(rightSensor->get(), 0);
+  EXPECT_EQ(middleSensor->get(), 0);
+}


### PR DESCRIPTION
### Description of the Change

This PR adds odometry support for all chassis models. This PR also adds `ThreeEncoderXDriveModel`.

### Motivation

This is a good feature to have.

### Possible Drawbacks

None.

### Verification Process

I have not verified this on real hardware.

### Applicable Issues

None.
