### PR TITLE
Separate drive and odometry scales

### DIFF
--- a/docs/tutorials/concepts/twodmotionprofiling.md
+++ b/docs/tutorials/concepts/twodmotionprofiling.md
@@ -41,17 +41,14 @@ using namespace okapi;
 
 auto myChassis = ChassisControllerBuilder()
                    .withMotors({1, 2}, {-3, -4})
-                   .withGearset(AbstractMotor::gearset::green)
-                   .withDimensions({{4_in, 11.5_in}, imev5GreenTPR})
+                   // Green gearset, 4 in wheel diam, 11.5 in wheel track
+                   .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
                    .build();
 
 auto profileController = AsyncMotionProfileControllerBuilder()
                            .withLimits({1.0, 2.0, 10.0})
                            .withOutput(myChassis)
                            .buildMotionProfileController();
-
-void opcontrol() {
-}
 ```
 
 Next, let's create a motion profile. A profile is created with a list of points
@@ -102,8 +99,8 @@ using namespace okapi;
 
 auto myChassis = ChassisControllerBuilder()
                    .withMotors({1, 2}, {-3, -4})
-                   .withGearset(AbstractMotor::gearset::green)
-                   .withDimensions({{4_in, 11.5_in}, imev5GreenTPR})
+                   // Green gearset, 4 in wheel diam, 11.5 in wheel track
+                   .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
                    .build();
 
 auto profileController = AsyncMotionProfileControllerBuilder()

--- a/docs/tutorials/walkthrough/asyncAutonomousMovement.md
+++ b/docs/tutorials/walkthrough/asyncAutonomousMovement.md
@@ -12,32 +12,22 @@ using namespace okapi;
 
 auto driveController = ChassisControllerBuilder()
                         .withMotors(1, -2)
+                        // Green gearset, 4 in wheel diam, 13.5 in wheel track
+                        .withDimensions(AbstractMotor::gearset::green, {4_in, 13.5_in})
                         .build();
-
-void autonomous() {
-}
 ```
 
 And then we'll add a lift subsystem as an Async Controller:
 
 ```cpp
-using namespace okapi;
-
 const double liftkP = 0.001;
 const double liftkI = 0.0001;
 const double liftkD = 0.0001;
-
-auto driveController = ChassisControllerBuilder()
-                        .withMotors(1, -2)
-                        .build();
 
 auto liftController = AsyncPosControllerBuilder()
                         .withMotor(3) // lift motor port 3
                         .withGains({liftkP, liftkI, liftkD})
                         .build();
-
-void autonomous() {
-}
 ```
 
 Now that we have two subsystems to run, let's execute a few different movements.
@@ -48,31 +38,12 @@ lift's status), we'll run
 the drive controller.
 
 ```cpp
-using namespace okapi;
+// Begin movements
+driveController->moveDistanceAsync(10_in); // Move 10 inches forward
+liftController->setTarget(200); // Move 200 motor degrees upward
+driveController->waitUntilSettled();
 
-const double liftkP = 0.001;
-const double liftkI = 0.0001;
-const double liftkD = 0.0001;
-
-auto driveController = ChassisControllerBuilder()
-                        .withMotors(1, -2)
-                        // 4 inch wheel diameter, 13 inch wheelbase, green cartridge
-                        .withDimensions({{4_in, 13_in}, imev5GreenTPR})
-                        .build();
-
-auto liftController = AsyncPosControllerBuilder()
-                        .withMotor(3) // lift motor port 3
-                        .withGains({liftkP, liftkI, liftkD})
-                        .build();
-
-void autonomous() {
-    // Begin movements
-    driveController->moveDistanceAsync(10_in); // Move 10 inches forward
-    liftController->setTarget(200); // Move 200 motor degrees upward
-    driveController->waitUntilSettled();
-
-    // Then the next movement will execute after the drive movement finishes
-}
+// Then the next movement will execute after the drive movement finishes
 ```
 
 If blocking the next movement with regard only to the lift is desired, swap
@@ -82,30 +53,11 @@ to finish before executing the next movement, then call
 controllers.
 
 ```cpp
-using namespace okapi;
+// Begin movements
+driveController->moveDistanceAsync(10_in); // Move 10 inches forward
+liftController->setTarget(200); // Move 200 motor degrees upward
+driveController->waitUntilSettled();
+liftController->waitUntilSettled();
 
-const double liftkP = 0.001;
-const double liftkI = 0.0001;
-const double liftkD = 0.0001;
-
-auto driveController = ChassisControllerBuilder()
-                        .withMotors(1, -2)
-                        // 4 inch wheel diameter, 13 inch wheelbase, green cartridge
-                        .withDimensions({{4_in, 13_in}, imev5GreenTPR})
-                        .build();
-
-auto liftController = AsyncPosControllerBuilder()
-                        .withMotor(3) // lift motor port 3
-                        .withGains({liftkP, liftkI, liftkD})
-                        .build();
-
-void autonomous() {
-    // Begin movements
-    driveController->moveDistanceAsync(10_in); // Move 10 inches forward
-    liftController->setTarget(200); // Move 200 motor degrees upward
-    driveController->waitUntilSettled();
-    liftController->waitUntilSettled();
-
-    // Then the next movement will execute after both movements finish
-}
+// Then the next movement will execute after both movements finish
 ```

--- a/docs/tutorials/walkthrough/basicAutonomousMovement.md
+++ b/docs/tutorials/walkthrough/basicAutonomousMovement.md
@@ -22,6 +22,8 @@ using namespace okapi;
 
 auto chassis = ChassisControllerBuilder()
                 .withMotors(1, -2)
+                // Green gearset, 4 in wheel diam, 13.5 in wheel track
+                .withDimensions(AbstractMotor::gearset::green, {4_in, 13.5_in})
                 .build();
 ```
 
@@ -32,44 +34,10 @@ two fundamental movement types:
 forward/backward and turning on a point.
 
 ```cpp
-using namespace okapi;
-
-auto chassis = ChassisControllerBuilder()
-                .withMotors(1, -2)
-                .build();
-
-void autonomous() {
-    // Move to first goal in motor degrees
-    chassis->moveRaw(1000);
-    // Turn to face second goal in motor degrees
-    chassis->turnRaw(100);
-    // Drive toward second goal in motor degrees
-    chassis->moveRaw(1500);
-}
-```
-
-If you'd like to set movements in real life units, that's possible as well. Just
-pass in the drive's gearset and dimensions, and then use the appropriate suffix
-for the units that you would like the movement to occur in.
-
-```cpp
-using namespace okapi;
-
-const auto WHEEL_DIAMETER = 4_in;
-const auto CHASSIS_WIDTH = 13.5_in;
-
-auto chassis = ChassisControllerBuilder()
-                .withMotors(1, -2)
-                .withGearset(AbstractMotor::gearset::green)
-                .withDimensions({{WHEEL_DIAMETER, CHASSIS_WIDTH}, imev5GreenTPR})
-                .build();
-
-void autonomous() {
-    // Move 1 meter to the first goal
-    chassis->moveDistance(1_m);
-    // Turn 90 degrees to face second goal
-    chassis->turnAngle(90_deg);
-    // Drive 1 and a half feet toward second goal
-    chassis->moveDistance(1.5_ft);
-}
+// Move 1 meter to the first goal
+chassis->moveDistance(1_m);
+// Turn 90 degrees to face second goal
+chassis->turnAngle(90_deg);
+// Drive 1 and a half feet toward second goal
+chassis->moveDistance(1.5_ft);
 ```

--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -10,73 +10,58 @@ Please read the preface on where to use builders:
 
 ## Configuring motors
 
-The only required parameter is the motor configuration. Both skid-steer and
-x-drive layouts are supported.
+You must configure the motors. Skid-steer, x-drive, and h-drive configurations are supported.
 
-### Two motors by ports:
+### Two motor skid-steer:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .build();
-}
+ChassisControllerBuilder()
+    .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
 ```
 
-### Two motors:
+### Four motor skid-steer:
+
+You may also use [MotorGroups](@ref okapi::MotorGroup). You are not required to have an equal
+number of motors per side. There is no limit on the number of motors per side.
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-Motor leftMotor(1);
-Motor rightMotor(-2);
-
-auto drive = ChassisControllerBuilder()
-                .withMotors(leftMotor, rightMotor)
-                .build();
-}
+ChassisControllerBuilder()
+    .withMotors(
+        {-1, -2}, // Left motors are 1 & 2 (reversed)
+        {3, 4}    // Right motors are 3 & 4
+    )
 ```
 
-### More than two motors by ports:
+### X-Drive:
+
+You may also use [MotorGroups](@ref okapi::MotorGroup).
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(
-                    {-1, -2}, // Left motors are 1 & 2 (reversed)
-                    {3, 4}    // Right motors are 3 & 4
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withMotors(
+        1,  // Top left
+        -2, // Top right (reversed)
+        -3, // Bottom right (reversed)
+        4   // Bottom left
+    )
 ```
 
-### More than two motors by objects:
+### H-Drive:
+
+You may also use [MotorGroups](@ref okapi::MotorGroup).
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-MotorGroup leftMotors({1, 2});
-MotorGroup rightMotors({-3, -4});
-
-auto drive = ChassisControllerBuilder()
-                .withMotors(leftMotors, rightMotors)
-                .build();
-}
+ChassisControllerBuilder()
+    .withMotors(
+        1,  // Left side
+        -2, // Right side (reversed)
+        3   // Middle
+    )
 ```
 
 ## Configuring your gearset and robot dimensions
 
-You should also configure the gearset and chassis dimensions to ensure that the gearsets in the
+You must configure the gearset and chassis dimensions to ensure that the gearsets in the
 motors are correct and to enable commanding the robot in real-life units (inches, degrees, etc.).
 
 ### Gearset and dimensions:
@@ -97,31 +82,17 @@ auto drive = ChassisControllerBuilder()
 ### Gearset with an external ratio and dimensions:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                // Green gearset, external ratio of (2.0 / 3.0), 4 inch wheel diameter, 11.5 inch wheelbase
-                .withDimensions(AbstractMotor::gearset::green * (2.0 / 3.0), {4_in, 11.5_in})
-                .build();
-}
+ChassisControllerBuilder()
+    // Green gearset, external ratio of (2.0 / 3.0), 4 inch wheel diameter, 11.5 inch wheelbase
+    .withDimensions(AbstractMotor::gearset::green * (2.0 / 3.0), {4_in, 11.5_in})
 ```
 
 ### Gearset and raw scales:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                // Green gearset, straight scale of 1127.8696, turn scale of 2.875
-                .withDimensions(AbstractMotor::gearset::green, {1127.8696, 2.875})
-                .build();
-}
+ChassisControllerBuilder()
+    // Green gearset, straight scale of 1127.8696, turn scale of 2.875
+    .withDimensions(AbstractMotor::gearset::green, {1127.8696, 2.875})
 ```
 
 ## Configuring your sensors
@@ -132,18 +103,11 @@ encoders), then you will need to pass those in as well.
 ### Encoders:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withSensors(
-                    {'A', 'B'}, // Left encoder in ADI ports A & B
-                    {'C', 'D', true}  // Right encoder in ADI ports C & D (reversed)
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withSensors(
+        {'A', 'B'}, // Left encoder in ADI ports A & B
+        {'C', 'D', true}  // Right encoder in ADI ports C & D (reversed)
+    )
 ```
 
 ## Configuring PID gains
@@ -154,36 +118,22 @@ need to pass in two or three sets of PID gains.
 ### Two sets:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGains(
-                    {0.001, 0, 0.0001}, // Distance controller gains
-                    {0.001, 0, 0.0001}  // Turn controller gains
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withGains(
+        {0.001, 0, 0.0001}, // Distance controller gains
+        {0.001, 0, 0.0001}  // Turn controller gains
+    )
 ```
 
 ### Three sets:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGains(
-                    {0.001, 0, 0.0001}, // Distance controller gains
-                    {0.001, 0, 0.0001}, // Turn controller gains
-                    {0.001, 0, 0.0001}  // Angle controller gains (helps drive straight)
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withGains(
+        {0.001, 0, 0.0001}, // Distance controller gains
+        {0.001, 0, 0.0001}, // Turn controller gains
+        {0.001, 0, 0.0001}  // Angle controller gains (helps drive straight)
+    )
 ```
 
 ## Configuring derivative filters
@@ -197,65 +147,31 @@ specify any derivative filters, the default filter is a
 ### One filter:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGains(
-                    {0.001, 0, 0.0001}, // Distance controller gains
-                    {0.001, 0, 0.0001}  // Turn controller gains
-                )
-                .withDerivativeFilters(
-                    std::make_unique<AverageFilter<3>>() // Distance controller filter
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withDerivativeFilters(
+        std::make_unique<AverageFilter<3>>() // Distance controller filter
+    )
 ```
 
 ### Two filters:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGains(
-                    {0.001, 0, 0.0001}, // Distance controller gains
-                    {0.001, 0, 0.0001}  // Turn controller gains
-                )
-                .withDerivativeFilters(
-                    std::make_unique<AverageFilter<3>>(), // Distance controller filter
-                    std::make_unique<AverageFilter<3>>()  // Turn controller filter
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withDerivativeFilters(
+        std::make_unique<AverageFilter<3>>(), // Distance controller filter
+        std::make_unique<AverageFilter<3>>()  // Turn controller filter
+    )
 ```
 
 ### Three filters:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGains(
-                    {0.001, 0, 0.0001}, // Distance controller gains
-                    {0.001, 0, 0.0001}, // Turn controller gains
-                    {0.001, 0, 0.0001}  // Angle controller gains (helps drive straight)
-                )
-                .withDerivativeFilters(
-                    std::make_unique<AverageFilter<3>>(), // Distance controller filter
-                    std::make_unique<AverageFilter<3>>(), // Turn controller filter
-                    std::make_unique<AverageFilter<3>>()  // Angle controller filter
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withDerivativeFilters(
+        std::make_unique<AverageFilter<3>>(), // Distance controller filter
+        std::make_unique<AverageFilter<3>>(), // Turn controller filter
+        std::make_unique<AverageFilter<3>>()  // Angle controller filter
+    )
 ```
 
 ## Configuring maximum velocity and voltage
@@ -265,29 +181,15 @@ You can change the default maximum velocity or voltage.
 ### Max velocity:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withMaxVelocity(100)
-                .build();
-}
+ChassisControllerBuilder()
+    .withMaxVelocity(100)
 ```
 
 ### Max voltage:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withMaxVoltage(10000)
-                .build();
-}
+ChassisControllerBuilder()
+    .withMaxVoltage(10000)
 ```
 
 ## Configuring the controller settling behavior
@@ -297,59 +199,39 @@ You can change the [SettledUtil](@ref okapi::SettledUtil) that a
 in order to change the settling behavior of the chassis.
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withClosedLoopControllerTimeUtil(50, 5, 250_ms)
-                .build();
-}
+ChassisControllerBuilder()
+    .withClosedLoopControllerTimeUtil(50, 5, 250_ms)
 ```
 
 ## Configuring the Logger
 
-If you want the [ChassisController](@ref okapi::ChassisController) and the
-classes it creates to log what they are doing, either for debugging or other
-purposes, you can supply a [Logger](@ref okapi::Logger).
+If you want the [ChassisController](@ref okapi::ChassisController) and the classes it creates to log
+what they are doing, either for debugging or other purposes, you can supply a
+[Logger](@ref okapi::Logger). You can also
+[enable logging globally](docs/tutorials/concepts/logging.md).
 
 ### Log to the PROS terminal:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withLogger(
-                    std::make_shared<Logger>(
-                        TimeUtilFactory::createDefault().getTimer(), // It needs a Timer
-                        "/ser/sout", // Output to the PROS terminal
-                        Logger::LogLevel::debug // Most verbose log level
-                    )
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withLogger(
+        std::make_shared<Logger>(
+            TimeUtilFactory::createDefault().getTimer(), // It needs a Timer
+            "/ser/sout", // Output to the PROS terminal
+            Logger::LogLevel::debug // Most verbose log level
+        )
+    )
 ```
 
 ### Log to the SD card:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withLogger(
-                    std::make_shared<Logger>(
-                        TimeUtilFactory::createDefault().getTimer(), // It needs a Timer
-                        "/usd/test_logging.txt", // Output to a file on the SD card
-                        Logger::LogLevel::debug  // Most verbose log level
-                    )
-                )
-                .build();
-}
+ChassisControllerBuilder()
+    .withLogger(
+        std::make_shared<Logger>(
+            TimeUtilFactory::createDefault().getTimer(), // It needs a Timer
+            "/usd/test_logging.txt", // Output to a file on the SD card
+            Logger::LogLevel::debug  // Most verbose log level
+        )
+    )
 ```

--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -97,10 +97,10 @@ ChassisControllerBuilder()
 
 ## Configuring your sensors
 
-If you do not use the motors' built-in encoders (e.g., you might use ADI
-encoders), then you will need to pass those in as well.
-
-### Encoders:
+If you do not use the motors' built-in encoders (e.g., you might use ADI encoders), then you will
+need to pass those in as well. These sensor will not affect the
+[ChassisControllerIntegrated](@ref okapi::ChassisControllerIntegrated) controls because it uses the
+integrated control (and therefore, the encoders built-in to the motors).
 
 ```cpp
 ChassisControllerBuilder()
@@ -108,6 +108,49 @@ ChassisControllerBuilder()
         {'A', 'B'}, // Left encoder in ADI ports A & B
         {'C', 'D', true}  // Right encoder in ADI ports C & D (reversed)
     )
+```
+
+## Configuring odometry
+
+OkapiLib supports odometry for all chassis configurations.
+
+### Odometry using integrated encoders:
+
+If you don't have external sensors, don't pass an extra [ChassisScales](@ref okapi::ChassisScales)
+to [withOdometry](@ref okapi::ChassisControllerBuilder::withOdometry).
+
+```cpp
+ChassisControllerBuilder()
+    .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
+    .withOdometry() // Use the same scales as the chassis (above)
+    .buildOdometry()
+```
+
+### Odometry using external encoders:
+
+If you have external sensors, you need to pass an extra [ChassisScales](@ref okapi::ChassisScales)
+to [withOdometry](@ref okapi::ChassisControllerBuilder::withOdometry) to specify the dimensions
+for the tracking wheels. If you are using a
+[ChassisControllerPID](@ref okapi::ChassisControllerPID), these dimensions will be the same as
+the ones given to [withDimensions](@ref okapi::ChassisControllerBuilder::withDimensions). If you are
+using a [ChassisControllerIntegrated](@ref okapi::ChassisControllerIntegrated), these dimensions
+will be different than the ones given to
+[withDimensions](@ref okapi::ChassisControllerBuilder::withDimensions).
+
+```cpp
+ChassisControllerBuilder()
+    .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
+    .withSensors(
+        {'A', 'B'}, // Left encoder in ADI ports A & B
+        {'C', 'D', true}  // Right encoder in ADI ports C & D (reversed)
+    )
+    // Specify the tracking wheels diam (3 in), track (7 in), and TPR (360)
+    .withOdometry({{3_in, 7_in}, quadEncoderTPR})
+    .buildOdometry()
 ```
 
 ## Configuring PID gains

--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -74,11 +74,12 @@ auto drive = ChassisControllerBuilder()
 }
 ```
 
-## Configuring a gearset
+## Configuring your gearset and robot dimensions
 
-You can pass in a gearset and external gear ratio directly.
+You should also configure the gearset and chassis dimensions to ensure that the gearsets in the
+motors are correct and to enable commanding the robot in real-life units (inches, degrees, etc.).
 
-### No external ratio:
+### Gearset and dimensions:
 
 ```cpp
 #include "okapi/api.hpp"
@@ -87,12 +88,13 @@ using namespace okapi;
 void opcontrol() {
 auto drive = ChassisControllerBuilder()
                 .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGearset(AbstractMotor::gearset::green) // Green gearset
+                // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+                .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
                 .build();
 }
 ```
 
-### With external ratio:
+### Gearset with an external ratio and dimensions:
 
 ```cpp
 #include "okapi/api.hpp"
@@ -101,20 +103,13 @@ using namespace okapi;
 void opcontrol() {
 auto drive = ChassisControllerBuilder()
                 .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGearset(AbstractMotor::gearset::green * 1.5) // Green gearset, external ratio of 1.5
+                // Green gearset, external ratio of (2.0 / 3.0), 4 inch wheel diameter, 11.5 inch wheelbase
+                .withDimensions(AbstractMotor::gearset::green * (2.0 / 3.0), {4_in, 11.5_in})
                 .build();
 }
 ```
 
-## Configuring your robot dimensions
-
-If you want to command your robot in real-life units (inches, degrees, etc.)
-then you need to pass in your robot's dimensions. Alternatively, if you want to
-fine-tune the scales, you could calculate them by hand and pass them in
-directly. See the [ChassisScales](@ref okapi::ChassisScales) docs for the math
-to do this.
-
-### Dimensions:
+### Gearset and raw scales:
 
 ```cpp
 #include "okapi/api.hpp"
@@ -123,23 +118,8 @@ using namespace okapi;
 void opcontrol() {
 auto drive = ChassisControllerBuilder()
                 .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGearset(AbstractMotor::gearset::green) // Green gearset
-                .withDimensions({{4_in, 11.5_in}, imev5GreenTPR}) // 4 inch wheel diameter, 11.5 inch wheelbase
-                .build();
-}
-```
-
-### Scales:
-
-```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withGearset(AbstractMotor::gearset::green * 1.5) // Green gearset, external ratio of 1.5
-                .withDimensions({{1127.8696, 2.875}, imev5GreenTPR}) // Straight scale, turn scale
+                // Green gearset, straight scale of 1127.8696, turn scale of 2.875
+                .withDimensions(AbstractMotor::gearset::green, {1127.8696, 2.875})
                 .build();
 }
 ```
@@ -310,13 +290,11 @@ auto drive = ChassisControllerBuilder()
 }
 ```
 
-## Configuring the TimeUtil
+## Configuring the controller settling behavior
 
-You can also change the [TimeUtil](@ref okapi::TimeUtil) used for the
-controllers. This is how you can change the settling behavior of the
-[ChassisController](@ref okapi::ChassisController).
-
-### Change SettledUtil:
+You can change the [SettledUtil](@ref okapi::SettledUtil) that a
+[ClosedLoopController](@ref okapi::ClosedLoopController) gets when it is created by the builder,
+in order to change the settling behavior of the chassis.
 
 ```cpp
 #include "okapi/api.hpp"
@@ -325,7 +303,7 @@ using namespace okapi;
 void opcontrol() {
 auto drive = ChassisControllerBuilder()
                 .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                .withTimeUtil(TimeUtilFactory::withSettledUtilParams(50, 5, 250_ms))
+                .withClosedLoopControllerTimeUtil(50, 5, 250_ms)
                 .build();
 }
 ```

--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -67,16 +67,9 @@ motors are correct and to enable commanding the robot in real-life units (inches
 ### Gearset and dimensions:
 
 ```cpp
-#include "okapi/api.hpp"
-using namespace okapi;
-
-void opcontrol() {
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-                // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
-                .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
-                .build();
-}
+ChassisControllerBuilder()
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
 ```
 
 ### Gearset with an external ratio and dimensions:

--- a/docs/tutorials/walkthrough/clawbot.md
+++ b/docs/tutorials/walkthrough/clawbot.md
@@ -90,11 +90,16 @@ tuning the PID controllers.
 We will be using
 [ChassisControllerIntegrated](@ref okapi::ChassisControllerIntegrated) for this
 tutorial. Let's initialize it now with our two motors in ports ``1`` and ``10``.
-The motor in port ``10`` is negative because it is reversed.
+The motor in port ``10`` is negative because it is reversed. We should also specify the gearset
+in the drive motors and the chassis dimensions.
 
 ```cpp
 // Chassis Controller - lets us drive the robot around with open- or closed-loop control
-auto drive = ChassisControllerBuilder().withMotors(1, -10).build();
+auto drive = ChassisControllerBuilder()
+                 .withMotors(1, -10)
+                 // Green gearset, 4 in wheel diam, 11.5 in wheel track
+                 .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
+                 .build();
 ```
 
 Next, let's setup tank or arcade control.
@@ -216,31 +221,15 @@ if (armLimitSwitch.isPressed()) {
 
 ## Autonomous Routine
 
-To illustrate the closed-loop control method that
+To illustrate the closed-loop control methods that
 [ChassisController](@ref okapi::ChassisController) has, let's make a simple
 autonomous routine to drive in a square.
 
 Writing an autonomous routine is much easier when distances and turns can be
-done with physical units, so let's configure the
-[ChassisController](@ref okapi::ChassisController) with the clawbot chassis's
-dimensions. This will require that we specify two additional parameters. The
-first is the gearset of the motors on the chassis, in this example we will use
-the standard green cartridges. The second is a
-[list](http://www.cplusplus.com/reference/initializer_list/initializer_list/)
-containing the wheel diameter (`4` inches) and the width of the chassis (`11.5`
-inches).
-
-```cpp
-// Chassis Controller - lets us drive the robot around with open- or closed-loop control
-auto drive = ChassisControllerBuilder()
-                .withMotors(1, -10)
-                .withGearset(AbstractMotor::gearset::green)
-                .withDimensions({{4_in, 11.5_in}, imev5GreenTPR})
-                .build();
-```
-
-After this, you can move the chassis in physical units, such as inches and
-degrees:
+done with physical units, but because we have already configured the gearset and chassis
+dimensions for our [ChassisController](@ref okapi::ChassisController), we don't need to do any
+extra work to use this feature. Let's make the robot move along the first quarter of the square
+pattern:
 
 ```cpp
 drive->moveDistance(12_in); // Drive forward 12 inches
@@ -260,10 +249,10 @@ using namespace okapi;
 void opcontrol() {
     // Chassis Controller - lets us drive the robot around with open- or closed-loop control
     auto drive = ChassisControllerBuilder()
-                    .withMotors(1, -10)
-                    .withGearset(AbstractMotor::gearset::green)
-                    .withDimensions({{4_in, 11.5_in}, imev5GreenTPR})
-                    .build();
+                     .withMotors(1, -10)
+                     // Green gearset, 4 in wheel diam, 11.5 in wheel track
+                     .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
+                     .build();
 
     // Joystick to read analog values for tank or arcade control
     // Master controller by default
@@ -322,10 +311,10 @@ using namespace okapi;
 void opcontrol() {
     // Chassis Controller - lets us drive the robot around with open- or closed-loop control
     auto drive = ChassisControllerBuilder()
-                    .withMotors(1, -10)
-                    .withGearset(AbstractMotor::gearset::green)
-                    .withDimensions({{4_in, 11.5_in}, imev5GreenTPR})
-                    .build();
+                     .withMotors(1, -10)
+                     // Green gearset, 4 in wheel diam, 11.5 in wheel track
+                     .withDimensions(AbstractMotor::gearset::green, {4_in, 11.5_in})
+                     .build();
 
     // Joystick to read analog values for tank or arcade control
     // Master controller by default

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -57,7 +57,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * ```cpp
    * // Drive forward by spinning the motors 400 degrees
-   * chassis->moveDistance(400);
+   * chassis->moveRaw(400);
    * ```
    *
    * @param itarget distance to travel in motor degrees
@@ -95,7 +95,7 @@ class ChassisControllerIntegrated : public ChassisController {
    *
    * ```cpp
    * // Turn clockwise by spinning the motors 200 degrees
-   * chassis->turnAngle(200);
+   * chassis->turnRaw(200);
    * ```
    *
    * @param idegTarget angle to turn for in motor degrees

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -70,7 +70,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * ```cpp
    * // Drive forward by spinning the motors 400 degrees
-   * chassis->moveDistance(400);
+   * chassis->moveRaw(400);
    * ```
    *
    * @param itarget distance to travel in motor degrees
@@ -108,7 +108,7 @@ class ChassisControllerPID : public ChassisController {
    *
    * ```cpp
    * // Turn clockwise by spinning the motors 200 degrees
-   * chassis->turnAngle(200);
+   * chassis->turnRaw(200);
    * ```
    *
    * @param idegTarget angle to turn for in motor degrees

--- a/include/okapi/api/odometry/threeEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/threeEncoderOdometry.hpp
@@ -29,7 +29,6 @@ class ThreeEncoderOdometry : public TwoEncoderOdometry {
   ThreeEncoderOdometry(const TimeUtil &itimeUtil,
                        const std::shared_ptr<ReadOnlyChassisModel> &imodel,
                        const ChassisScales &ichassisScales,
-                       const QSpeed &iwheelVelDelta = 0.0001_mps,
                        const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
   /**

--- a/include/okapi/api/odometry/twoEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/twoEncoderOdometry.hpp
@@ -26,14 +26,11 @@ class TwoEncoderOdometry : public Odometry {
    * @param itimeUtil The TimeUtil.
    * @param imodel The chassis model for reading sensors.
    * @param ichassisScales The chassis dimensions.
-   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
-   * driving straight.
    * @param ilogger The logger this instance will log to.
    */
   TwoEncoderOdometry(const TimeUtil &itimeUtil,
                      const std::shared_ptr<ReadOnlyChassisModel> &imodel,
                      const ChassisScales &ichassisScales,
-                     const QSpeed &iwheelVelDelta = 0.0001_mps,
                      const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
   virtual ~TwoEncoderOdometry() = default;
@@ -76,7 +73,6 @@ class TwoEncoderOdometry : public Odometry {
   std::unique_ptr<AbstractTimer> timer;
   std::shared_ptr<ReadOnlyChassisModel> model;
   ChassisScales chassisScales;
-  QSpeed wheelVelDelta;
   OdomState state;
   std::valarray<std::int32_t> newTicks{0, 0, 0}, tickDiff{0, 0, 0}, lastTicks{0, 0, 0};
 

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -404,15 +404,16 @@ class ChassisControllerBuilder {
   ChassisControllerBuilder &notParentedToCurrentTask();
 
   /**
-   * Builds the ChassisController. Throws a std::runtime_exception if no motors were set.
+   * Builds the ChassisController. Throws a std::runtime_exception if no motors were set or if no
+   * dimensions were set.
    *
    * @return A fully built ChassisController.
    */
   std::shared_ptr<ChassisController> build();
 
   /**
-   * Builds the OdomChassisController. Throws a std::runtime_exception if no motors were set or if
-   * no odometry information was passed.
+   * Builds the OdomChassisController. Throws a std::runtime_exception if no motors were set, if no
+   * dimensions were set, or if no odometry information was passed.
    *
    * @return A fully built OdomChassisController.
    */
@@ -463,7 +464,6 @@ class ChassisControllerBuilder {
   TimeUtilFactory closedLoopControllerTimeUtilFactory = TimeUtilFactory();
   TimeUtilFactory odometryTimeUtilFactory = TimeUtilFactory();
 
-  bool gearsetSetByUser{false}; // Used so motors don't overwrite gearset set manually
   AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid};
   ChassisScales driveScales{{1, 1}, imev5GreenTPR};
   bool differentOdomScales{false};

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -253,6 +253,25 @@ class ChassisControllerBuilder {
   /**
    * Sets the odometry information, causing the builder to generate an Odometry variant.
    *
+   * @param iodomScales The ChassisScales used just for odometry (if they are different than those
+   * for the drive).
+   * @param imode The new default StateMode used to interpret target points and query the Odometry
+   * state.
+   * @param imoveThreshold The minimum length movement.
+   * @param iturnThreshold The minimum angle turn.
+   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
+   * driving straight.
+   * @return An ongoing builder.
+   */
+  ChassisControllerBuilder &withOdometry(const ChassisScales &iodomScales,
+                                         const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
+                                         const QLength &imoveThreshold = 0_mm,
+                                         const QAngle &iturnThreshold = 0_deg,
+                                         const QSpeed &iwheelVelDelta = 0.0001_mps);
+
+  /**
+   * Sets the odometry information, causing the builder to generate an Odometry variant.
+   *
    * @param iodometry The odometry object.
    * @param imode The new default StateMode used to interpret target points and query the Odometry
    * state.
@@ -279,20 +298,24 @@ class ChassisControllerBuilder {
     std::unique_ptr<Filter> iangleFilter = std::make_unique<PassthroughFilter>());
 
   /**
-   * Sets the gearset. The default gearset is derived from the motor's.
-   *
-   * @param igearset The gearset.
-   * @return An ongoing builder.
-   */
-  ChassisControllerBuilder &withGearset(const AbstractMotor::GearsetRatioPair &igearset);
-
-  /**
    * Sets the chassis dimensions.
    *
-   * @param iscales The dimensions.
+   * @param igearset The gearset.
+   * @param idimensions The dimensions in the same order as in ChassisScales.
    * @return An ongoing builder.
    */
-  ChassisControllerBuilder &withDimensions(const ChassisScales &iscales);
+  ChassisControllerBuilder &withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
+                                           const std::initializer_list<QLength> &idimensions);
+
+  /**
+   * Sets the chassis dimensions by setting the raw scales.
+   *
+   * @param igearset The gearset.
+   * @param iscales The raw scales in the same order as in ChassisScales.
+   * @return An ongoing builder.
+   */
+  ChassisControllerBuilder &withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
+                                           const std::initializer_list<double> &iscales);
 
   /**
    * Sets the max velocity. Overrides the max velocity of the gearset.
@@ -448,7 +471,9 @@ class ChassisControllerBuilder {
 
   bool gearsetSetByUser{false}; // Used so motors don't overwrite gearset set manually
   AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid};
-  ChassisScales scales{{1, 1}, imev5GreenTPR};
+  ChassisScales driveScales{{1, 1}, imev5GreenTPR};
+  bool differentOdomScales{false};
+  ChassisScales odomScales{{1, 1}, imev5GreenTPR};
   std::shared_ptr<Logger> controllerLogger = Logger::getDefaultLogger();
 
   bool hasOdom{false}; // Whether odometry was passed

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -300,7 +300,7 @@ class ChassisControllerBuilder {
   /**
    * Sets the chassis dimensions.
    *
-   * @param igearset The gearset.
+   * @param igearset The gearset in the drive motors.
    * @param idimensions The dimensions in the same order as in ChassisScales.
    * @return An ongoing builder.
    */
@@ -310,7 +310,7 @@ class ChassisControllerBuilder {
   /**
    * Sets the chassis dimensions by setting the raw scales.
    *
-   * @param igearset The gearset.
+   * @param igearset The gearset in the drive motors.
    * @param iscales The raw scales in the same order as in ChassisScales.
    * @return An ongoing builder.
    */

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -241,14 +241,11 @@ class ChassisControllerBuilder {
    * state.
    * @param imoveThreshold The minimum length movement.
    * @param iturnThreshold The minimum angle turn.
-   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
-   * driving straight.
    * @return An ongoing builder.
    */
   ChassisControllerBuilder &withOdometry(const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
                                          const QLength &imoveThreshold = 0_mm,
-                                         const QAngle &iturnThreshold = 0_deg,
-                                         const QSpeed &iwheelVelDelta = 0.0001_mps);
+                                         const QAngle &iturnThreshold = 0_deg);
 
   /**
    * Sets the odometry information, causing the builder to generate an Odometry variant.
@@ -259,15 +256,12 @@ class ChassisControllerBuilder {
    * state.
    * @param imoveThreshold The minimum length movement.
    * @param iturnThreshold The minimum angle turn.
-   * @param iwheelVelDelta The maximum delta between wheel velocities to consider the robot as
-   * driving straight.
    * @return An ongoing builder.
    */
   ChassisControllerBuilder &withOdometry(const ChassisScales &iodomScales,
                                          const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
                                          const QLength &imoveThreshold = 0_mm,
-                                         const QAngle &iturnThreshold = 0_deg,
-                                         const QSpeed &iwheelVelDelta = 0.0001_mps);
+                                         const QAngle &iturnThreshold = 0_deg);
 
   /**
    * Sets the odometry information, causing the builder to generate an Odometry variant.
@@ -478,7 +472,6 @@ class ChassisControllerBuilder {
 
   bool hasOdom{false}; // Whether odometry was passed
   std::unique_ptr<Odometry> odometry;
-  QSpeed wheelVelDelta;
   StateMode stateMode;
   QLength moveThreshold;
   QAngle turnThreshold;

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -13,9 +13,8 @@ namespace okapi {
 ThreeEncoderOdometry::ThreeEncoderOdometry(const TimeUtil &itimeUtil,
                                            const std::shared_ptr<ReadOnlyChassisModel> &imodel,
                                            const ChassisScales &ichassisScales,
-                                           const QSpeed &iwheelVelDelta,
                                            const std::shared_ptr<Logger> &logger)
-  : TwoEncoderOdometry(itimeUtil, imodel, ichassisScales, iwheelVelDelta, logger), model(imodel) {
+  : TwoEncoderOdometry(itimeUtil, imodel, ichassisScales, logger), model(imodel) {
   if (ichassisScales.middle == 0) {
     std::string msg = "ThreeEncoderOdometry: Middle scale cannot be zero.";
     LOG_ERROR(msg);

--- a/src/api/odometry/twoEncoderOdometry.cpp
+++ b/src/api/odometry/twoEncoderOdometry.cpp
@@ -14,14 +14,12 @@ namespace okapi {
 TwoEncoderOdometry::TwoEncoderOdometry(const TimeUtil &itimeUtil,
                                        const std::shared_ptr<ReadOnlyChassisModel> &imodel,
                                        const ChassisScales &ichassisScales,
-                                       const QSpeed &iwheelVelDelta,
                                        const std::shared_ptr<Logger> &ilogger)
   : logger(ilogger),
     rate(itimeUtil.getRate()),
     timer(itimeUtil.getTimer()),
     model(imodel),
-    chassisScales(ichassisScales),
-    wheelVelDelta(iwheelVelDelta) {
+    chassisScales(ichassisScales) {
 }
 
 void TwoEncoderOdometry::setScales(const ChassisScales &ichassisScales) {

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -223,22 +223,19 @@ ChassisControllerBuilder::withDerivativeFilters(std::unique_ptr<Filter> idistanc
 
 ChassisControllerBuilder &ChassisControllerBuilder::withOdometry(const StateMode &imode,
                                                                  const QLength &imoveThreshold,
-                                                                 const QAngle &iturnThreshold,
-                                                                 const QSpeed &iwheelVelDelta) {
+                                                                 const QAngle &iturnThreshold) {
   hasOdom = true;
   odometry = nullptr;
   stateMode = imode;
   moveThreshold = imoveThreshold;
   turnThreshold = iturnThreshold;
-  wheelVelDelta = iwheelVelDelta;
   return *this;
 }
 
 ChassisControllerBuilder &ChassisControllerBuilder::withOdometry(const ChassisScales &iodomScales,
                                                                  const StateMode &imode,
                                                                  const QLength &imoveThreshold,
-                                                                 const QAngle &iturnThreshold,
-                                                                 const QSpeed &iwheelVelDelta) {
+                                                                 const QAngle &iturnThreshold) {
   hasOdom = true;
   differentOdomScales = true;
   odomScales = iodomScales;
@@ -246,7 +243,6 @@ ChassisControllerBuilder &ChassisControllerBuilder::withOdometry(const ChassisSc
   stateMode = imode;
   moveThreshold = imoveThreshold;
   turnThreshold = iturnThreshold;
-  wheelVelDelta = iwheelVelDelta;
   return *this;
 }
 
@@ -414,13 +410,11 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
       odometry = std::make_unique<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
                                                       chassisController->getModel(),
                                                       odomScales,
-                                                      wheelVelDelta,
                                                       controllerLogger);
     } else {
       odometry = std::make_unique<ThreeEncoderOdometry>(odometryTimeUtilFactory.create(),
                                                         chassisController->getModel(),
                                                         odomScales,
-                                                        wheelVelDelta,
                                                         controllerLogger);
     }
   }

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -45,10 +45,6 @@ ChassisControllerBuilder::withMotors(const std::shared_ptr<AbstractMotor> &ileft
     maxVelocity = toUnderlyingType(ileft->getGearing());
   }
 
-  if (!gearsetSetByUser) {
-    gearset = ileft->getGearing();
-  }
-
   return *this;
 }
 
@@ -88,10 +84,6 @@ ChassisControllerBuilder::withMotors(const std::shared_ptr<AbstractMotor> &itopL
 
   if (!maxVelSetByUser) {
     maxVelocity = toUnderlyingType(itopLeft->getGearing());
-  }
-
-  if (!gearsetSetByUser) {
-    gearset = itopLeft->getGearing();
   }
 
   return *this;
@@ -137,10 +129,6 @@ ChassisControllerBuilder::withMotors(const std::shared_ptr<AbstractMotor> &ileft
 
   if (!maxVelSetByUser) {
     maxVelocity = toUnderlyingType(ileft->getGearing());
-  }
-
-  if (!gearsetSetByUser) {
-    gearset = ileft->getGearing();
   }
 
   return *this;
@@ -268,7 +256,6 @@ ChassisControllerBuilder::withOdometry(std::unique_ptr<Odometry> iodometry,
 ChassisControllerBuilder &
 ChassisControllerBuilder::withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
                                          const std::initializer_list<QLength> &idimensions) {
-  gearsetSetByUser = true;
   gearset = igearset;
 
   if (!maxVelSetByUser) {
@@ -285,7 +272,6 @@ ChassisControllerBuilder::withDimensions(const AbstractMotor::GearsetRatioPair &
 ChassisControllerBuilder &
 ChassisControllerBuilder::withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
                                          const std::initializer_list<double> &iscales) {
-  gearsetSetByUser = true;
   gearset = igearset;
 
   if (!maxVelSetByUser) {
@@ -360,17 +346,9 @@ std::shared_ptr<ChassisController> ChassisControllerBuilder::build() {
     throw std::runtime_error(msg);
   }
 
-  if (!gearsetSetByUser) {
-    LOG_WARN_S(
-      "ChassisControllerBuilder: The default gearset is selected. This is probably a bug.");
-  }
-
-  std::int32_t calculatedTPR = gearsetToTPR(gearset.internalGearset) * gearset.ratio;
-  if (calculatedTPR != driveScales.tpr) {
-    std::string msg(
-      "ChassisControllerBuilder: BUG: The calculated TPR from the given gearset and ratio (" +
-      std::to_string(calculatedTPR) + ") does not equal the TPR given in the ChassisScales (" +
-      std::to_string(driveScales.tpr) + ").");
+  if (gearset.internalGearset == AbstractMotor::gearset::invalid) {
+    // Invalid by default. The user must provide one.
+    std::string msg("ChassisControllerBuilder: A gearset was not provided.");
     LOG_ERROR(msg);
     throw std::runtime_error(msg);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,7 @@ void opcontrol() {
 
   drive = ChassisControllerBuilder()
             .withMotors(-1, 2)
-            .withDimensions({{4_in, 11_in}, imev5GreenTPR})
-            .withGearset(AbstractMotor::gearset::green)
+            .withDimensions(AbstractMotor::gearset::green, {4_in, 11_in})
             .withMaxVelocity(60)
             .withOdometry(StateMode::FRAME_TRANSFORMATION)
             .buildOdometry();

--- a/src/test/asyncMotionProfileControllerBuilderIntegrationTests.cpp
+++ b/src/test/asyncMotionProfileControllerBuilderIntegrationTests.cpp
@@ -20,8 +20,7 @@ static void testMotionProfileController() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
-                 .withDimensions({{imaginaryDiameter, 10_in}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {imaginaryDiameter, 10_in})
                  .build();
 
   auto controller = AsyncMotionProfileControllerBuilder()

--- a/src/test/chassisControllerBuilderIntegrationTests.cpp
+++ b/src/test/chassisControllerBuilderIntegrationTests.cpp
@@ -18,7 +18,7 @@ static void testForwardUsesCorrectMaximumVelocityForAGearset() {
   const double power = 0.3;
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
+                 .withDimensions(MOTOR_GEARSET, {1_in, 10_in})
                  .build();
 
   drive->model().forward(power);
@@ -42,7 +42,7 @@ static void testMaxVelWorksOutOfOrder() {
   auto drive = ChassisControllerBuilder()
                  .withMaxVelocity(maxVel)
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
+                 .withDimensions(MOTOR_GEARSET, {1_in, 10_in})
                  .build();
 
   drive->model().forward(1);
@@ -65,7 +65,7 @@ static void testSensorsWork() {
   auto drive = ChassisControllerBuilder()
                  .withSensors({MOTOR_1_PORT}, {MOTOR_2_PORT})
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
+                 .withDimensions(MOTOR_GEARSET, {1_in, 10_in})
                  .build();
 
   Motor leftMtr(MOTOR_1_PORT);
@@ -108,7 +108,7 @@ static void testMotorGearsetsAreNotOverwritten() {
   auto drive = ChassisControllerBuilder()
                  .withSensors({MOTOR_1_PORT}, {MOTOR_2_PORT})
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(AbstractMotor::gearset::blue)
+                 .withDimensions(AbstractMotor::gearset::blue, {1_in, 10_in})
                  .build();
 
   test("Left motor gearset should equal blue",
@@ -128,9 +128,8 @@ static void testOCCI() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
                  .withOdometry()
-                 .withDimensions({{4_in, 10_in}, toUnderlyingType(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4_in, 10_in})
                  .buildOdometry();
 
   const auto stateBefore = drive->getState();
@@ -166,9 +165,8 @@ static void testOCCPID() {
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
                  .withGains({0.01, 0, 0}, {0, 0, 0})
-                 .withGearset(MOTOR_GEARSET)
                  .withOdometry()
-                 .withDimensions({{4_in, 10_in}, toUnderlyingType(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4_in, 10_in})
                  .buildOdometry();
 
   const auto stateBefore = drive->getState();

--- a/src/test/chassisControllerIntegratedTests.cpp
+++ b/src/test/chassisControllerIntegratedTests.cpp
@@ -19,8 +19,7 @@ static void testMoveDistanceGoesTheRightDistance() {
   QLength wheelDiam = 4.125_in;
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
-                 .withDimensions({{wheelDiam, 11.375_in}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {wheelDiam, 11.375_in})
                  .build();
 
   // Move one wheel rotation
@@ -47,8 +46,7 @@ static void testTurnAngleGoesTheRightDistance() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
-                 .withDimensions({{4.125_in, 11.375_in}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4.125_in, 11.375_in})
                  .build();
 
   // Turn one wheel rotation

--- a/src/test/chassisControllerPidTests.cpp
+++ b/src/test/chassisControllerPidTests.cpp
@@ -18,9 +18,8 @@ static void testWaitUntilSettledExitsProperly() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
                  .withGains({}, {0.003})
-                 .withDimensions({{4_in, 10_in}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4_in, 10_in})
                  .build();
 
   for (int i = 0; i < 10; ++i) {
@@ -54,9 +53,8 @@ static void testMoveDistanceGoesTheRightDistance() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
                  .withGains({0.003, 0.0001, 0.00015}, {})
-                 .withDimensions({{4_in, 10_in}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4_in, 10_in})
                  .build();
 
   // Move one wheel rotation
@@ -83,9 +81,8 @@ static void testTurnAngleGoesTheRightDistance() {
 
   auto drive = ChassisControllerBuilder()
                  .withMotors(MOTOR_1_PORT, MOTOR_2_PORT)
-                 .withGearset(MOTOR_GEARSET)
                  .withGains({}, {0.003, 0.0001, 0.00015})
-                 .withDimensions({{4_in, 365_mm}, gearsetToTPR(MOTOR_GEARSET)})
+                 .withDimensions(MOTOR_GEARSET, {4_in, 365_mm})
                  .build();
 
   // Turn one wheel rotation


### PR DESCRIPTION
### Description of the Change

This PR separates the drive and odom scales, and forces the user to at least supply the drive scales (because the method to specify them has been combined with `withGearset`).

### Motivation

These two usages for the scales were conflated before, which introduced a bug when using CCI and odom with tracking wheels. This PR also eliminates a bug where the gearset and TPR in the scales could be mismatched.

### Possible Drawbacks

The user will be forced to supply scales now.

### Verification Process

This has not been verified.

### Applicable Issues

None.
