### PR TITLE
Odometry getScales

### DIFF
--- a/include/okapi/api/odometry/odometry.hpp
+++ b/include/okapi/api/odometry/odometry.hpp
@@ -54,5 +54,10 @@ class Odometry {
    * @return The internal ChassisModel.
    */
   virtual std::shared_ptr<ReadOnlyChassisModel> getModel() = 0;
+
+  /**
+   * @return The internal ChassisScales.
+   */
+  virtual ChassisScales getScales() = 0;
 };
 } // namespace okapi

--- a/include/okapi/api/odometry/threeEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/threeEncoderOdometry.hpp
@@ -31,14 +31,7 @@ class ThreeEncoderOdometry : public TwoEncoderOdometry {
                        const ChassisScales &ichassisScales,
                        const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
-  /**
-   * @return The internal ChassisModel.
-   */
-  std::shared_ptr<ReadOnlyChassisModel> getModel() override;
-
   protected:
-  std::shared_ptr<ReadOnlyChassisModel> model;
-
   /**
    * Does the math, side-effect free, for one odom step.
    *

--- a/include/okapi/api/odometry/twoEncoderOdometry.hpp
+++ b/include/okapi/api/odometry/twoEncoderOdometry.hpp
@@ -67,6 +67,11 @@ class TwoEncoderOdometry : public Odometry {
    */
   std::shared_ptr<ReadOnlyChassisModel> getModel() override;
 
+  /**
+   * @return The internal ChassisScales.
+   */
+  ChassisScales getScales() override;
+
   protected:
   std::shared_ptr<Logger> logger;
   std::unique_ptr<AbstractRate> rate;

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -14,7 +14,7 @@ ThreeEncoderOdometry::ThreeEncoderOdometry(const TimeUtil &itimeUtil,
                                            const std::shared_ptr<ReadOnlyChassisModel> &imodel,
                                            const ChassisScales &ichassisScales,
                                            const std::shared_ptr<Logger> &logger)
-  : TwoEncoderOdometry(itimeUtil, imodel, ichassisScales, logger), model(imodel) {
+  : TwoEncoderOdometry(itimeUtil, imodel, ichassisScales, logger) {
   if (ichassisScales.middle == 0) {
     std::string msg = "ThreeEncoderOdometry: Middle scale cannot be zero.";
     LOG_ERROR(msg);
@@ -70,9 +70,5 @@ OdomState ThreeEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &
   }
 
   return OdomState{dX * meter, dY * meter, deltaTheta * radian};
-}
-
-std::shared_ptr<ReadOnlyChassisModel> ThreeEncoderOdometry::getModel() {
-  return model;
 }
 } // namespace okapi

--- a/src/api/odometry/twoEncoderOdometry.cpp
+++ b/src/api/odometry/twoEncoderOdometry.cpp
@@ -107,4 +107,8 @@ void TwoEncoderOdometry::setState(const OdomState &istate, const StateMode &imod
 std::shared_ptr<ReadOnlyChassisModel> TwoEncoderOdometry::getModel() {
   return model;
 }
+
+ChassisScales TwoEncoderOdometry::getScales() {
+  return chassisScales;
+}
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR adds a `getScales` method to `Odometry` and `TwoEncoderOdometry`.
This PR also removes the `model` member from `ThreeEncoderOdometry`, which unnecessarily shadows `TwoEncoderOdometry`.

### Motivation

I need to be able to read the chassis scales from Odometry for a library I am working on. 

### Possible Drawbacks

None that I can think of.

### Verification Process

It compiles.
