### PR TITLE
Remove AbstractRate::delay(int)

### DIFF
--- a/include/okapi/api/control/util/controllerRunner.hpp
+++ b/include/okapi/api/control/util/controllerRunner.hpp
@@ -42,7 +42,7 @@ template <typename Input, typename Output> class ControllerRunner {
     icontroller.setTarget(itarget);
 
     while (!icontroller.isSettled()) {
-      rate->delay(10);
+      rate->delayUntil(10_ms);
     }
 
     LOG_INFO("ControllerRunner: runUntilSettled(AsyncController): Done waiting to settle");
@@ -66,7 +66,7 @@ template <typename Input, typename Output> class ControllerRunner {
 
     while (!icontroller.isSettled()) {
       ioutput.controllerSet(icontroller.getOutput());
-      rate->delay(10);
+      rate->delayUntil(10_ms);
     }
 
     LOG_INFO("ControllerRunner: runUntilSettled(IterativeController): Done waiting to settle");
@@ -90,7 +90,7 @@ template <typename Input, typename Output> class ControllerRunner {
     double lastError = error;
     while (error != 0 && std::copysign(1.0, error) == std::copysign(1.0, lastError)) {
       lastError = error;
-      rate->delay(10);
+      rate->delayUntil(10_ms);
       error = icontroller.getError();
     }
 
@@ -118,7 +118,7 @@ template <typename Input, typename Output> class ControllerRunner {
     while (error != 0 && std::copysign(1.0, error) == std::copysign(1.0, lastError)) {
       ioutput.controllerSet(icontroller.getOutput());
       lastError = error;
-      rate->delay(10);
+      rate->delayUntil(10_ms);
       error = icontroller.getError();
     }
 

--- a/include/okapi/api/util/abstractRate.hpp
+++ b/include/okapi/api/util/abstractRate.hpp
@@ -25,14 +25,6 @@ class AbstractRate {
   virtual void delay(QFrequency ihz) = 0;
 
   /**
-   * Delay the current task such that it runs every ihz ms. The first delay will run for
-   * 1000/(ihz). Subsequent delays will adjust according to the previous runtime of the task.
-   *
-   * @param ihz the frequency in ms
-   */
-  virtual void delay(int ihz) = 0;
-
-  /**
    * Delay the current task until itime has passed. This method can be used by periodic tasks to
    * ensure a consistent execution frequency.
    *

--- a/include/okapi/impl/util/rate.hpp
+++ b/include/okapi/impl/util/rate.hpp
@@ -23,14 +23,6 @@ class Rate : public AbstractRate {
   void delay(QFrequency ihz) override;
 
   /**
-   * Delay the current task such that it runs every ihz ms. The first delay will run for
-   * 1000/(ihz). Subsequent delays will adjust according to the previous runtime of the task.
-   *
-   * @param ihz the frequency in ms
-   */
-  void delay(int ihz) override;
-
-  /**
    * Delay the current task until itime has passed. This method can be used by periodic tasks to
    * ensure a consistent execution frequency.
    *

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -298,8 +298,6 @@ class MockRate : public AbstractRate {
 
   void delay(QFrequency ihz) override;
 
-  void delay(int ihz) override;
-
   void delayUntil(QTime itime) override;
 
   void delayUntil(uint32_t ims) override;

--- a/src/impl/util/rate.cpp
+++ b/src/impl/util/rate.cpp
@@ -15,10 +15,6 @@ void Rate::delay(const QFrequency ihz) {
   delayUntil(1000 / ihz.convert(Hz));
 }
 
-void Rate::delay(const int ihz) {
-  delayUntil(1000 / ihz);
-}
-
 void Rate::delayUntil(const QTime itime) {
   delayUntil(itime.convert(millisecond));
 }

--- a/src/test/utilTests.cpp
+++ b/src/test/utilTests.cpp
@@ -44,7 +44,7 @@ static void testUtils() {
       uint32_t lastTime = pros::millis();
 
       for (int i = 0; i < 10; i++) {
-        rate.delay(10);
+        rate.delayUntil(10_ms);
 
         // Static cast so the compiler doesn't complain about comparing signed and unsigned values
         test("Rate " + std::to_string(i),

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -255,11 +255,7 @@ QTime ConstantMockTimer::clearMark() {
 MockRate::MockRate() = default;
 
 void MockRate::delay(QFrequency ihz) {
-  delay(static_cast<int>(ihz.convert(Hz)));
-}
-
-void MockRate::delay(int ihz) {
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000 / ihz));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000 / static_cast<int>(ihz.convert(Hz))));
 }
 
 void MockRate::delayUntil(QTime itime) {


### PR DESCRIPTION
### Description of the Change

This PR removes `AbstractRate::delay(int)`.

### Motivation

This method is confusing and unused.

### Possible Drawbacks

Some people may have been using it, but they can use one of the other two `delay` overloads instead.

### Verification Process

N/A

### Applicable Issues

Closes #401.
