### PR TITLE
#409: Add ChassisController::setMaxVelocity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ USE_PACKAGE:=1
 # Set this to 1 to add additional rules to compile your project as a PROS library template
 IS_LIBRARY:=1
 LIBNAME:=okapilib
-VERSION:=4.0.0-409
+VERSION:=4.0.0
 EXCLUDE_SRC_FROM_LIB=$(call rwildcard,$(SRCDIR)/test,*.*)
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+= $(foreach file, $(SRCDIR)/opcontrol $(SRCDIR)/initialize $(SRCDIR)/autonomous $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ USE_PACKAGE:=1
 # Set this to 1 to add additional rules to compile your project as a PROS library template
 IS_LIBRARY:=1
 LIBNAME:=okapilib
-VERSION:=4.0.0
+VERSION:=4.0.0-409
 EXCLUDE_SRC_FROM_LIB=$(call rwildcard,$(SRCDIR)/test,*.*)
 # this line excludes opcontrol.c and similar files
 EXCLUDE_SRC_FROM_LIB+= $(foreach file, $(SRCDIR)/opcontrol $(SRCDIR)/initialize $(SRCDIR)/autonomous $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(file).$(cext)) $(foreach cxxext,$(CXXEXTS),$(file).$(cxxext)))

--- a/include/okapi/api/chassis/controller/chassisController.hpp
+++ b/include/okapi/api/chassis/controller/chassisController.hpp
@@ -110,6 +110,18 @@ class ChassisController {
   virtual void stop() = 0;
 
   /**
+   * Sets a new maximum velocity in RPM [0-600].
+   *
+   * @param imaxVelocity The new maximum velocity.
+   */
+  virtual void setMaxVelocity(double imaxVelocity) = 0;
+
+  /**
+   * @return The maximum velocity in RPM [0-600].
+   */
+  virtual double getMaxVelocity() const = 0;
+
+  /**
    * Get the ChassisScales.
    */
   virtual ChassisScales getChassisScales() const = 0;

--- a/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerIntegrated.hpp
@@ -163,16 +163,14 @@ class ChassisControllerIntegrated : public ChassisController {
   /**
    * Sets a new maximum velocity in RPM [0-600].
    *
-   * @param imaxVelocity the new maximum velocity
+   * @param imaxVelocity The new maximum velocity.
    */
-  virtual void setMaxVelocity(double imaxVelocity);
+  void setMaxVelocity(double imaxVelocity) override;
 
   /**
-   * Returns the maximum velocity in RPM [0-600].
-   *
    * @return The maximum velocity in RPM [0-600].
    */
-  virtual double getMaxVelocity() const;
+  double getMaxVelocity() const override;
 
   protected:
   std::shared_ptr<Logger> logger;

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -208,6 +208,18 @@ class ChassisControllerPID : public ChassisController {
   void stop() override;
 
   /**
+   * Sets a new maximum velocity in RPM [0-600].
+   *
+   * @param imaxVelocity The new maximum velocity.
+   */
+  void setMaxVelocity(double imaxVelocity) override;
+
+  /**
+   * @return The maximum velocity in RPM [0-600].
+   */
+  double getMaxVelocity() const override;
+
+  /**
    * @return The internal ChassisModel.
    */
   std::shared_ptr<ChassisModel> getModel() override;

--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -208,7 +208,8 @@ class ChassisControllerPID : public ChassisController {
   void stop() override;
 
   /**
-   * Sets a new maximum velocity in RPM [0-600].
+   * Sets a new maximum velocity in RPM [0-600]. In voltage mode, the max velocity is ignored and a
+   * max voltage should be set on the underlying ChassisModel instead.
    *
    * @param imaxVelocity The new maximum velocity.
    */

--- a/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
@@ -17,7 +17,7 @@ namespace okapi {
 class DefaultOdomChassisController : public OdomChassisController {
   public:
   /**
-   * Odometry based chassis controller that moves using a separately constructed chassis controller. 
+   * Odometry based chassis controller that moves using a separately constructed chassis controller.
    * Spins up a task at the default priority plus 1 for odometry when constructed.
    *
    * Moves the robot around in the odom frame. Instead of telling the robot to drive forward or
@@ -139,6 +139,16 @@ class DefaultOdomChassisController : public OdomChassisController {
    * This delegates to the input ChassisController.
    */
   void stop() override;
+
+  /**
+   * This delegates to the input ChassisController.
+   */
+  void setMaxVelocity(double imaxVelocity) override;
+
+  /**
+   * This delegates to the input ChassisController.
+   */
+  double getMaxVelocity() const override;
 
   /**
    * This delegates to the input ChassisController.

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -619,6 +619,12 @@ class MockChassisController : public ChassisController {
   void stop() override {
     stopCalled++;
   }
+  void setMaxVelocity(double imaxVelocity) override {
+    chassisModel->setMaxVelocity(imaxVelocity);
+  }
+  double getMaxVelocity() const override {
+    return chassisModel->getMaxVelocity();
+  }
   ChassisScales getChassisScales() const override {
     return scales;
   }

--- a/src/api/chassis/controller/chassisControllerIntegrated.cpp
+++ b/src/api/chassis/controller/chassisControllerIntegrated.cpp
@@ -148,11 +148,13 @@ std::shared_ptr<ChassisModel> ChassisControllerIntegrated::getModel() {
 ChassisModel &ChassisControllerIntegrated::model() {
   return *chassisModel;
 }
+
 void ChassisControllerIntegrated::setMaxVelocity(double imaxVelocity) {
   leftController->setMaxVelocity(imaxVelocity);
   rightController->setMaxVelocity(imaxVelocity);
   chassisModel->setMaxVelocity(imaxVelocity);
 }
+
 double ChassisControllerIntegrated::getMaxVelocity() const {
   return chassisModel->getMaxVelocity();
 }

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -342,6 +342,14 @@ void ChassisControllerPID::stop() {
   chassisModel->stop();
 }
 
+void ChassisControllerPID::setMaxVelocity(double imaxVelocity) {
+  chassisModel->setMaxVelocity(imaxVelocity);
+}
+
+double ChassisControllerPID::getMaxVelocity() const {
+  return chassisModel->getMaxVelocity();
+}
+
 std::shared_ptr<ChassisModel> ChassisControllerPID::getModel() {
   return chassisModel;
 }

--- a/src/api/chassis/controller/defaultOdomChassisController.cpp
+++ b/src/api/chassis/controller/defaultOdomChassisController.cpp
@@ -145,6 +145,14 @@ void DefaultOdomChassisController::stop() {
   controller->stop();
 }
 
+void DefaultOdomChassisController::setMaxVelocity(double imaxVelocity) {
+  controller->setMaxVelocity(imaxVelocity);
+}
+
+double DefaultOdomChassisController::getMaxVelocity() const {
+  return controller->getMaxVelocity();
+}
+
 ChassisScales DefaultOdomChassisController::getChassisScales() const {
   return controller->getChassisScales();
 }


### PR DESCRIPTION
### Description of the Change

This PR adds `ChassisController::setMaxVelocity(double)` and `ChassisController::getMaxVelocity`.

### Motivation

To set the max velocity on a chassis controller, in the case of CCI, its special implementation must be called. Just setting the max velocity on the underlying chassis model is not enough.

### Possible Drawbacks

None.

### Verification Process

- [x] Ask Pradyun to test it

### Applicable Issues

Closes #409.
