### PR TITLE
Ensure the system is stopped after internal tasks exit

### DIFF
--- a/include/okapi/api/chassis/controller/chassisControllerPid.hpp
+++ b/include/okapi/api/chassis/controller/chassisControllerPid.hpp
@@ -250,8 +250,23 @@ class ChassisControllerPID : public ChassisController {
   static void trampoline(void *context);
   void loop();
 
+  /**
+   * Wait for the distance setup (distancePid and anglePid) to settle.
+   *
+   * @return true if done settling; false if settling should be tried again
+   */
   bool waitForDistanceSettled();
+
+  /**
+   * Wait for the angle setup (anglePid) to settle.
+   *
+   * @return true if done settling; false if settling should be tried again
+   */
   bool waitForAngleSettled();
+
+  /**
+   * Stops all the controllers and the ChassisModel.
+   */
   void stopAfterSettled();
 
   typedef enum { distance, angle, none } modeType;

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -107,6 +107,8 @@ void ChassisControllerPID::loop() {
     rate->delayUntil(threadSleepTime);
   }
 
+  stop();
+
   LOG_INFO_S("Stopped ChassisControllerPID task.");
 }
 
@@ -243,11 +245,6 @@ void ChassisControllerPID::waitUntilSettled() {
   LOG_INFO_S("ChassisControllerPID: Done waiting to settle");
 }
 
-/**
- * Wait for the distance setup (distancePid and anglePid) to settle.
- *
- * @return true if done settling; false if settling should be tried again
- */
 bool ChassisControllerPID::waitForDistanceSettled() {
   LOG_INFO_S("ChassisControllerPID: Waiting to settle in distance mode");
 
@@ -266,11 +263,6 @@ bool ChassisControllerPID::waitForDistanceSettled() {
   return true;
 }
 
-/**
- * Wait for the angle setup (anglePid) to settle.
- *
- * @return true if done settling; false if settling should be tried again
- */
 bool ChassisControllerPID::waitForAngleSettled() {
   LOG_INFO_S("ChassisControllerPID: Waiting to settle in angle mode");
 
@@ -339,7 +331,6 @@ void ChassisControllerPID::stop() {
   mode = none;
   doneLooping.store(true, std::memory_order_release);
   stopAfterSettled();
-  chassisModel->stop();
 }
 
 void ChassisControllerPID::setMaxVelocity(double imaxVelocity) {

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -220,6 +220,10 @@ void AsyncLinearMotionProfileController::loop() {
                   std::to_string(path->second.length));
 
         executeSinglePath(path->second, timeUtil.getRate());
+
+        // Set 0 after the path because:
+        // 1. We only support an exit velocity of zero
+        // 2. Because of (1), we should make sure the system is stopped
         output->controllerSet(0);
 
         LOG_INFO_S("AsyncLinearMotionProfileController: Done moving");

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -234,6 +234,10 @@ void AsyncMotionProfileController::loop() {
                   std::to_string(path->second.length));
 
         executeSinglePath(path->second, timeUtil.getRate());
+
+        // Stop the chassis after the path because:
+        // 1. We only support an exit velocity of zero
+        // 2. Because of (1), we should make sure the system is stopped
         model->stop();
 
         LOG_INFO_S("AsyncMotionProfileController: Done moving");


### PR DESCRIPTION
### Description of the Change

This PR ensures that the system (controller output, chassis model, etc.) is stopped after a class' internal task controlling it exits.

### Motivation

This will prevent runaway robots.

### Possible Drawbacks

None.

### Verification Process

- [ ] @theol0403 Should retest the program in the issue and ensure that the robot stops when the task is killed.

### Applicable Issues

Closes #412.
