### PR TITLE
Add setMaxVelocity for AsyncPositionController

### DIFF
--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -217,12 +217,18 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   bool isDisabled() const override;
 
   /**
-   * Sets the "absolute" zero position of the controller to its current position.
-   *
    * This implementation does nothing because the API always requires the starting position to be
    * specified.
    */
   void tarePosition() override;
+
+  /**
+   * This implementation does nothing because the maximum velocity is configured using
+   * PathfinderLimits elsewhere.
+   *
+   * @param imaxVelocity Ignored.
+   */
+  void setMaxVelocity(std::int32_t imaxVelocity) override;
 
   /**
    * Starts the internal thread. This should not be called by normal users. This method is called

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -212,12 +212,18 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   bool isDisabled() const override;
 
   /**
-   * Sets the "absolute" zero position of the controller to its current position.
-   *
    * This implementation does nothing because the API always requires the starting position to be
    * specified.
    */
   void tarePosition() override;
+
+  /**
+   * This implementation does nothing because the maximum velocity is configured using
+   * PathfinderLimits elsewhere.
+   *
+   * @param imaxVelocity Ignored.
+   */
+  void setMaxVelocity(std::int32_t imaxVelocity) override;
 
   /**
    * Starts the internal thread. This should not be called by normal users. This method is called

--- a/include/okapi/api/control/async/asyncPosIntegratedController.hpp
+++ b/include/okapi/api/control/async/asyncPosIntegratedController.hpp
@@ -110,16 +110,16 @@ class AsyncPosIntegratedController : public AsyncPositionController<double, doub
   void controllerSet(double ivalue) override;
 
   /**
-   * Sets a new maximum velocity in RPM [0-600].
-   *
-   * @param imaxVelocity the new maximum velocity
-   */
-  virtual void setMaxVelocity(std::int32_t imaxVelocity);
-
-  /**
    * Sets the "absolute" zero position of the controller to its current position.
    */
   void tarePosition() override;
+
+  /**
+   * Sets a new maximum velocity in motor RPM [0-600].
+   *
+   * @param imaxVelocity The new maximum velocity in motor RPM [0-600].
+   */
+  void setMaxVelocity(std::int32_t imaxVelocity) override;
 
   /**
    * Stops the motor mid-movement. Does not change the last set target.

--- a/include/okapi/api/control/async/asyncPosPidController.hpp
+++ b/include/okapi/api/control/async/asyncPosPidController.hpp
@@ -74,6 +74,13 @@ class AsyncPosPIDController : public AsyncWrapper<double, double>,
    */
   void tarePosition() override;
 
+  /**
+   * This implementation does not respect the maximum velocity.
+   *
+   * @param imaxVelocity Ignored.
+   */
+  void setMaxVelocity(std::int32_t imaxVelocity) override;
+
   protected:
   std::shared_ptr<OffsetableControllerInput> offsettableInput;
 };

--- a/include/okapi/api/control/async/asyncPositionController.hpp
+++ b/include/okapi/api/control/async/asyncPositionController.hpp
@@ -18,5 +18,13 @@ class AsyncPositionController : virtual public AsyncController<Input, Output> {
    * Sets the "absolute" zero position of the controller to its current position.
    */
   virtual void tarePosition() = 0;
+
+  /**
+   * Sets a new maximum velocity (typically motor RPM [0-600]). The interpretation of the units
+   * of this velocity and whether it will be respected is implementation-dependent.
+   *
+   * @param imaxVelocity The new maximum velocity.
+   */
+  virtual void setMaxVelocity(std::int32_t imaxVelocity) = 0;
 };
 } // namespace okapi

--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -360,6 +360,9 @@ CrossplatformThread *AsyncLinearMotionProfileController::getThread() const {
 void AsyncLinearMotionProfileController::tarePosition() {
 }
 
+void AsyncLinearMotionProfileController::setMaxVelocity(std::int32_t) {
+}
+
 void AsyncLinearMotionProfileController::forceRemovePath(const std::string &ipathId) {
   if (!removePath(ipathId)) {
     LOG_WARN("AsyncLinearMotionProfileController: Disabling controller to remove path " + ipathId);

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -365,6 +365,9 @@ bool AsyncMotionProfileController::isDisabled() const {
 void AsyncMotionProfileController::tarePosition() {
 }
 
+void AsyncMotionProfileController::setMaxVelocity(std::int32_t) {
+}
+
 void AsyncMotionProfileController::startThread() {
   if (!task) {
     task = new CrossplatformThread(trampoline, this, "AsyncMotionProfileController");

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -60,4 +60,7 @@ AsyncPosPIDController::AsyncPosPIDController(
 void AsyncPosPIDController::tarePosition() {
   offsettableInput->tarePosition();
 }
+
+void AsyncPosPIDController::setMaxVelocity(std::int32_t) {
+}
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR adds `AsyncPositionController::setMaxVelocity`.

### Motivation

Users have been confused as to why they cannot call `setMaxVelocity`, thinking that the `AsyncPosControllerBuilder` returned the `AsyncPosIntegratedController` subclass.

### Possible Drawbacks

Most implementations ignore this. Still, I think this is a good thing to have, especially for any future cascade control implementations.

### Verification Process

This was not verified.

### Applicable Issues

Closes #415.
