### PR TITLE
#422: Initialize controller buttons

### DIFF
--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -114,6 +114,6 @@ class Controller {
   protected:
   ControllerId okapiId;
   pros::controller_id_e_t prosId;
-  std::array<ControllerButton *, 12> buttonArray {};
+  std::array<ControllerButton *, 12> buttonArray{};
 };
 } // namespace okapi

--- a/include/okapi/impl/device/controller.hpp
+++ b/include/okapi/impl/device/controller.hpp
@@ -114,6 +114,6 @@ class Controller {
   protected:
   ControllerId okapiId;
   pros::controller_id_e_t prosId;
-  std::array<ControllerButton *, 12> buttonArray;
+  std::array<ControllerButton *, 12> buttonArray {};
 };
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

This PR fixes #422.
Following the rules of aggregate initialization, an empty initializer list will zero-initialize all elements of the array.

### Motivation

Having an uninitialized array can lead to segfaults.

### Verification Process

- [ ] Test using the following code:
```cpp
void opcontrol() {
  Controller controller;
  auto button = controller[ControllerDigital::R1];
}
```

I can probably test when I have the robot on monday.

