### PR TITLE
Make ChassisScales tpr a double

### DIFF
--- a/include/okapi/api/chassis/controller/chassisScales.hpp
+++ b/include/okapi/api/chassis/controller/chassisScales.hpp
@@ -55,7 +55,7 @@ class ChassisScales {
    * @param ilogger The logger this instance will log to.
    */
   ChassisScales(const std::initializer_list<QLength> &idimensions,
-                std::int32_t itpr,
+                double itpr,
                 const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
   /**
@@ -72,7 +72,7 @@ class ChassisScales {
    * @param ilogger The logger this instance will log to.
    */
   ChassisScales(const std::initializer_list<double> &iscales,
-                std::int32_t itpr,
+                double itpr,
                 const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
 
   QLength wheelDiameter;
@@ -82,9 +82,9 @@ class ChassisScales {
   double straight;
   double turn;
   double middle;
-  std::int32_t tpr;
+  double tpr;
 
   protected:
-  void validateInputSize(std::size_t inputSize, const std::shared_ptr<Logger> &logger);
+  static void validateInputSize(std::size_t inputSize, const std::shared_ptr<Logger> &logger);
 };
 } // namespace okapi

--- a/src/api/chassis/controller/chassisScales.cpp
+++ b/src/api/chassis/controller/chassisScales.cpp
@@ -9,7 +9,7 @@
 
 namespace okapi {
 ChassisScales::ChassisScales(const std::initializer_list<QLength> &idimensions,
-                             const std::int32_t itpr,
+                             const double itpr,
                              const std::shared_ptr<Logger> &logger)
   : tpr(itpr) {
   validateInputSize(idimensions.size(), logger);
@@ -42,7 +42,7 @@ ChassisScales::ChassisScales(const std::initializer_list<QLength> &idimensions,
 }
 
 ChassisScales::ChassisScales(const std::initializer_list<double> &iscales,
-                             const std::int32_t itpr,
+                             const double itpr,
                              const std::shared_ptr<Logger> &logger)
   : tpr(itpr) {
   validateInputSize(iscales.size(), logger);
@@ -63,9 +63,9 @@ ChassisScales::ChassisScales(const std::initializer_list<double> &iscales,
     middle = straight;
   }
 
-  wheelDiameter = (tpr / (straight * 1_pi)) * meter;
+  wheelDiameter = static_cast<double>(tpr / (straight * 1_pi)) * meter;
   wheelTrack = turn * wheelDiameter;
-  middleWheelDiameter = (tpr / (middle * 1_pi)) * meter;
+  middleWheelDiameter = static_cast<double>(tpr / (middle * 1_pi)) * meter;
 
   if (vec.size() >= 4) {
     middleWheelDistance = vec.at(2) * meter;


### PR DESCRIPTION
### Description of the Change

This PR makes `ChassisScales` `tpr` ctor parameter a `double`.

### Motivation

`tpr` was previously an integer type, which caused some loss in precision for people with fractional external gear ratios.

### Applicable Issues

Closes #423.
