### PR TITLE
Add APPC and AVPC {set/get}Gains.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ add_executable(OkapiLibV5
         test/chassisScalesTests.cpp
         test/asyncPosIntegratedControllerTests.cpp
         test/asyncVelIntegratedControllerTests.cpp
+        test/asyncVelPIDControllerTests.cpp
         test/asyncMotionProfileControllerTests.cpp
         test/asyncLinearMotionProfileControllerTests.cpp
         test/iterativeVelPIDControllerTests.cpp

--- a/include/okapi/api/control/async/asyncPosPidController.hpp
+++ b/include/okapi/api/control/async/asyncPosPidController.hpp
@@ -81,7 +81,22 @@ class AsyncPosPIDController : public AsyncWrapper<double, double>,
    */
   void setMaxVelocity(std::int32_t imaxVelocity) override;
 
+  /**
+   * Set controller gains.
+   *
+   * @param igains The new gains.
+   */
+  void setGains(const IterativePosPIDController::Gains &igains);
+
+  /**
+   * Gets the current gains.
+   *
+   * @return The current gains.
+   */
+  IterativePosPIDController::Gains getGains() const;
+
   protected:
   std::shared_ptr<OffsetableControllerInput> offsettableInput;
+  std::shared_ptr<IterativePosPIDController> internalController;
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncVelPidController.hpp
+++ b/include/okapi/api/control/async/asyncVelPidController.hpp
@@ -45,5 +45,22 @@ class AsyncVelPIDController : public AsyncWrapper<double, double>,
     double iratio = 1,
     std::unique_ptr<Filter> iderivativeFilter = std::make_unique<PassthroughFilter>(),
     const std::shared_ptr<Logger> &ilogger = Logger::getDefaultLogger());
+
+  /**
+   * Set controller gains.
+   *
+   * @param igains The new gains.
+   */
+  void setGains(const IterativeVelPIDController::Gains &igains);
+
+  /**
+   * Gets the current gains.
+   *
+   * @return The current gains.
+   */
+  IterativeVelPIDController::Gains getGains() const;
+
+  protected:
+  std::shared_ptr<IterativeVelPIDController> internalController;
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncWrapper.hpp
+++ b/include/okapi/api/control/async/asyncWrapper.hpp
@@ -36,7 +36,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
    */
   AsyncWrapper(const std::shared_ptr<ControllerInput<Input>> &iinput,
                const std::shared_ptr<ControllerOutput<Output>> &ioutput,
-               std::unique_ptr<IterativeController<Input, Output>> icontroller,
+               const std::shared_ptr<IterativeController<Input, Output>> &icontroller,
                const Supplier<std::unique_ptr<AbstractRate>> &irateSupplier,
                const double iratio = 1,
                std::shared_ptr<Logger> ilogger = Logger::getDefaultLogger())
@@ -44,7 +44,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
       rateSupplier(irateSupplier),
       input(iinput),
       output(ioutput),
-      controller(std::move(icontroller)),
+      controller(icontroller),
       ratio(iratio) {
   }
 
@@ -247,7 +247,7 @@ class AsyncWrapper : virtual public AsyncController<Input, Output> {
   Supplier<std::unique_ptr<AbstractRate>> rateSupplier;
   std::shared_ptr<ControllerInput<Input>> input;
   std::shared_ptr<ControllerOutput<Output>> output;
-  std::unique_ptr<IterativeController<Input, Output>> controller;
+  std::shared_ptr<IterativeController<Input, Output>> controller;
   bool hasFirstTarget{false};
   Input lastTarget;
   double ratio;

--- a/include/okapi/api/control/iterative/iterativePosPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativePosPidController.hpp
@@ -26,6 +26,9 @@ class IterativePosPIDController : public IterativePositionController<double, dou
     double kI{0};
     double kD{0};
     double kBias{0};
+
+    bool operator==(const Gains &rhs) const;
+    bool operator!=(const Gains &rhs) const;
   };
 
   /**

--- a/include/okapi/api/control/iterative/iterativeVelPidController.hpp
+++ b/include/okapi/api/control/iterative/iterativeVelPidController.hpp
@@ -22,6 +22,9 @@ class IterativeVelPIDController : public IterativeVelocityController<double, dou
     double kD{0};
     double kF{0};
     double kSF{0};
+
+    bool operator==(const Gains &rhs) const;
+    bool operator!=(const Gains &rhs) const;
   };
 
   /**

--- a/src/api/control/async/asyncPosPidController.cpp
+++ b/src/api/control/async/asyncPosPidController.cpp
@@ -45,7 +45,7 @@ AsyncPosPIDController::AsyncPosPIDController(
   : AsyncWrapper<double, double>(
       iinput,
       ioutput,
-      std::make_unique<IterativePosPIDController>(ikP,
+      std::make_shared<IterativePosPIDController>(ikP,
                                                   ikI,
                                                   ikD,
                                                   ikBias,
@@ -54,7 +54,8 @@ AsyncPosPIDController::AsyncPosPIDController(
       itimeUtil.getRateSupplier(),
       iratio,
       ilogger),
-    offsettableInput(iinput) {
+    offsettableInput(iinput),
+    internalController(std::static_pointer_cast<IterativePosPIDController>(controller)) {
 }
 
 void AsyncPosPIDController::tarePosition() {
@@ -62,5 +63,13 @@ void AsyncPosPIDController::tarePosition() {
 }
 
 void AsyncPosPIDController::setMaxVelocity(std::int32_t) {
+}
+
+void AsyncPosPIDController::setGains(const IterativePosPIDController::Gains &igains) {
+  internalController->setGains(igains);
+}
+
+IterativePosPIDController::Gains AsyncPosPIDController::getGains() const {
+  return internalController->getGains();
 }
 } // namespace okapi

--- a/src/api/control/async/asyncVelPidController.cpp
+++ b/src/api/control/async/asyncVelPidController.cpp
@@ -24,7 +24,7 @@ AsyncVelPIDController::AsyncVelPIDController(
   : AsyncWrapper<double, double>(
       iinput,
       ioutput,
-      std::make_unique<IterativeVelPIDController>(ikP,
+      std::make_shared<IterativeVelPIDController>(ikP,
                                                   ikD,
                                                   ikF,
                                                   ikSF,
@@ -33,6 +33,15 @@ AsyncVelPIDController::AsyncVelPIDController(
                                                   std::move(iderivativeFilter)),
       itimeUtil.getRateSupplier(),
       iratio,
-      ilogger) {
+      ilogger),
+    internalController(std::static_pointer_cast<IterativeVelPIDController>(controller)) {
+}
+
+void AsyncVelPIDController::setGains(const IterativeVelPIDController::Gains &igains) {
+  internalController->setGains(igains);
+}
+
+IterativeVelPIDController::Gains AsyncVelPIDController::getGains() const {
+  return internalController->getGains();
 }
 } // namespace okapi

--- a/src/api/control/iterative/iterativePosPidController.cpp
+++ b/src/api/control/iterative/iterativePosPidController.cpp
@@ -218,4 +218,14 @@ void IterativePosPIDController::setGains(const Gains &igains) {
 IterativePosPIDController::Gains IterativePosPIDController::getGains() const {
   return {kP, kI / sampleTime.convert(second), kD * sampleTime.convert(second), kBias};
 }
+
+bool IterativePosPIDController::Gains::
+operator==(const IterativePosPIDController::Gains &rhs) const {
+  return kP == rhs.kP && kI == rhs.kI && kD == rhs.kD && kBias == rhs.kBias;
+}
+
+bool IterativePosPIDController::Gains::
+operator!=(const IterativePosPIDController::Gains &rhs) const {
+  return !(rhs == *this);
+}
 } // namespace okapi

--- a/src/api/control/iterative/iterativeVelPidController.cpp
+++ b/src/api/control/iterative/iterativeVelPidController.cpp
@@ -190,4 +190,14 @@ QAngularSpeed IterativeVelPIDController::getVel() const {
 QTime IterativeVelPIDController::getSampleTime() const {
   return sampleTime;
 }
+
+bool IterativeVelPIDController::Gains::
+operator==(const IterativeVelPIDController::Gains &rhs) const {
+  return kP == rhs.kP && kD == rhs.kD && kF == rhs.kF && kSF == rhs.kSF;
+}
+
+bool IterativeVelPIDController::Gains::
+operator!=(const IterativeVelPIDController::Gains &rhs) const {
+  return !(rhs == *this);
+}
 } // namespace okapi

--- a/test/asyncPosPIDControllerTests.cpp
+++ b/test/asyncPosPIDControllerTests.cpp
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/api/control/async/asyncPosPidController.hpp"
-#include "okapi/api/util/mathUtil.hpp"
 #include "test/tests/api/implMocks.hpp"
 #include <gtest/gtest.h>
 
@@ -45,4 +44,10 @@ TEST_F(AsyncPosPIDControllerTest, TestTarePosition) {
   controller->tarePosition();
   rate->delayUntil(100_ms);
   EXPECT_EQ(controller->getError(), 100);
+}
+
+TEST_F(AsyncPosPIDControllerTest, TestSetAndGetGains) {
+  IterativePosPIDController::Gains gains{1, 2, 3, 4};
+  controller->setGains(gains);
+  EXPECT_EQ(controller->getGains(), gains);
 }

--- a/test/asyncVelPIDControllerTests.cpp
+++ b/test/asyncVelPIDControllerTests.cpp
@@ -1,0 +1,44 @@
+/*
+ * @author Ryan Benasutti, WPI
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/api/control/async/asyncVelPidController.hpp"
+#include "test/tests/api/implMocks.hpp"
+#include <gtest/gtest.h>
+
+using namespace okapi;
+
+class AsyncVelPIDControllerTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    input = std::make_shared<MockControllerInput>();
+    output = std::make_shared<MockMotor>();
+    controller = new AsyncVelPIDController(
+      input,
+      output,
+      createTimeUtil(),
+      0,
+      0,
+      0,
+      0,
+      std::make_unique<VelMath>(
+        360, std::make_unique<PassthroughFilter>(), 10_ms, std::make_unique<MockTimer>()));
+  }
+
+  void TearDown() override {
+    delete controller;
+  }
+
+  std::shared_ptr<MockControllerInput> input;
+  std::shared_ptr<MockMotor> output;
+  AsyncVelPIDController *controller;
+};
+
+TEST_F(AsyncVelPIDControllerTest, TestSetAndGetGains) {
+  IterativeVelPIDController::Gains gains{1, 2, 3, 4};
+  controller->setGains(gains);
+  EXPECT_EQ(controller->getGains(), gains);
+}


### PR DESCRIPTION
### Description of the Change

This PR adds `{set/get}Gains` methods to `AsyncPosPIDController` and `AsyncVelPIDController`.

### Motivation

Some users have asked for this. It's otherwise impossible to call these two methods on the underlying iterative controllers if you used the builder.

### Possible Drawbacks

The static cast in the ctors is a little weird, but it should be okay because we case immediately after initializing the base class inside the same ctor. Subclasses just shouldn't change the controller implementation at runtime.

### Verification Process

New tests.

### Applicable Issues

Closes #424. Closes #425.
