### PR TITLE
Add OdomChassisController::getOdometry

### DIFF
--- a/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/defaultOdomChassisController.hpp
@@ -34,7 +34,7 @@ class DefaultOdomChassisController : public OdomChassisController {
    * @param ilogger The logger this instance will log to.
    */
   DefaultOdomChassisController(const TimeUtil &itimeUtil,
-                               std::unique_ptr<Odometry> iodometry,
+                               std::shared_ptr<Odometry> iodometry,
                                std::shared_ptr<ChassisController> icontroller,
                                const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
                                QLength imoveThreshold = 0_mm,

--- a/include/okapi/api/chassis/controller/odomChassisController.hpp
+++ b/include/okapi/api/chassis/controller/odomChassisController.hpp
@@ -40,7 +40,7 @@ class OdomChassisController : public ChassisController {
    * @param iturnThreshold minimum angle turn (smaller turns will be skipped)
    */
   OdomChassisController(TimeUtil itimeUtil,
-                        std::unique_ptr<Odometry> iodometry,
+                        std::shared_ptr<Odometry> iodometry,
                         const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
                         const QLength &imoveThreshold = 0_mm,
                         const QAngle &iturnThreshold = 0_deg,
@@ -134,12 +134,17 @@ class OdomChassisController : public ChassisController {
    */
   CrossplatformThread *getOdomThread() const;
 
+  /**
+   * @return The internal odometry.
+   */
+  std::shared_ptr<Odometry> getOdometry();
+
   protected:
   std::shared_ptr<Logger> logger;
   TimeUtil timeUtil;
   QLength moveThreshold;
   QAngle turnThreshold;
-  std::unique_ptr<Odometry> odom;
+  std::shared_ptr<Odometry> odom;
   CrossplatformThread *odomTask{nullptr};
   std::atomic_bool dtorCalled{false};
   StateMode defaultStateMode{StateMode::FRAME_TRANSFORMATION};

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -273,7 +273,7 @@ class ChassisControllerBuilder {
    * @param iturnThreshold The minimum angle turn.
    * @return An ongoing builder.
    */
-  ChassisControllerBuilder &withOdometry(std::unique_ptr<Odometry> iodometry,
+  ChassisControllerBuilder &withOdometry(std::shared_ptr<Odometry> iodometry,
                                          const StateMode &imode = StateMode::FRAME_TRANSFORMATION,
                                          const QLength &imoveThreshold = 0_mm,
                                          const QAngle &iturnThreshold = 0_deg);
@@ -461,7 +461,7 @@ class ChassisControllerBuilder {
   std::shared_ptr<Logger> controllerLogger = Logger::getDefaultLogger();
 
   bool hasOdom{false}; // Whether odometry was passed
-  std::unique_ptr<Odometry> odometry;
+  std::shared_ptr<Odometry> odometry;
   StateMode stateMode;
   QLength moveThreshold;
   QAngle turnThreshold;

--- a/src/api/chassis/controller/defaultOdomChassisController.cpp
+++ b/src/api/chassis/controller/defaultOdomChassisController.cpp
@@ -12,7 +12,7 @@
 namespace okapi {
 DefaultOdomChassisController::DefaultOdomChassisController(
   const TimeUtil &itimeUtil,
-  std::unique_ptr<Odometry> iodometry,
+  std::shared_ptr<Odometry> iodometry,
   std::shared_ptr<ChassisController> icontroller,
   const StateMode &imode,
   const QLength imoveThreshold,

--- a/src/api/chassis/controller/odomChassisController.cpp
+++ b/src/api/chassis/controller/odomChassisController.cpp
@@ -9,7 +9,7 @@
 
 namespace okapi {
 OdomChassisController::OdomChassisController(TimeUtil itimeUtil,
-                                             std::unique_ptr<Odometry> iodometry,
+                                             std::shared_ptr<Odometry> iodometry,
                                              const StateMode &imode,
                                              const QLength &imoveThreshold,
                                              const QAngle &iturnThreshold,
@@ -83,5 +83,9 @@ void OdomChassisController::loop() {
 
 CrossplatformThread *OdomChassisController::getOdomThread() const {
   return odomTask;
+}
+
+std::shared_ptr<Odometry> OdomChassisController::getOdometry() {
+  return odom;
 }
 } // namespace okapi

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -235,7 +235,7 @@ ChassisControllerBuilder &ChassisControllerBuilder::withOdometry(const ChassisSc
 }
 
 ChassisControllerBuilder &
-ChassisControllerBuilder::withOdometry(std::unique_ptr<Odometry> iodometry,
+ChassisControllerBuilder::withOdometry(std::shared_ptr<Odometry> iodometry,
                                        const StateMode &imode,
                                        const QLength &imoveThreshold,
                                        const QAngle &iturnThreshold) {
@@ -369,12 +369,12 @@ std::shared_ptr<DefaultOdomChassisController>
 ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisController) {
   if (odometry == nullptr) {
     if (middleSensor == nullptr) {
-      odometry = std::make_unique<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
+      odometry = std::make_shared<TwoEncoderOdometry>(odometryTimeUtilFactory.create(),
                                                       chassisController->getModel(),
                                                       odomScales,
                                                       controllerLogger);
     } else {
-      odometry = std::make_unique<ThreeEncoderOdometry>(odometryTimeUtilFactory.create(),
+      odometry = std::make_shared<ThreeEncoderOdometry>(odometryTimeUtilFactory.create(),
                                                         chassisController->getModel(),
                                                         odomScales,
                                                         controllerLogger);

--- a/test/defaultOdomChassisControllerTest.cpp
+++ b/test/defaultOdomChassisControllerTest.cpp
@@ -26,7 +26,7 @@ class DefaultOdomChassisControllerTest : public ::testing::Test {
     controller = std::make_shared<MockChassisController>();
 
     drive = new MockDefaultOdomChassisController(
-      createTimeUtil(), std::unique_ptr<Odometry>(odom), controller);
+      createTimeUtil(), std::shared_ptr<Odometry>(odom), controller);
     drive->odomTaskRunning = true;
   }
 


### PR DESCRIPTION
### Description of the Change

This PR adds `OdomChassisController::getOdometry` to return the internal odometry instance.

### Motivation

Some users wanted this.

### Applicable Issues

Closes #420.
