### PR TITLE
Remove useless code in AMPC and ALMPC dtors

### DIFF
--- a/src/api/control/async/asyncLinearMotionProfileController.cpp
+++ b/src/api/control/async/asyncLinearMotionProfileController.cpp
@@ -35,7 +35,6 @@ AsyncLinearMotionProfileController::AsyncLinearMotionProfileController(
 
 AsyncLinearMotionProfileController::~AsyncLinearMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
-  isDisabled();
 
   // Free paths before deleting the task
   std::scoped_lock lock(currentPathMutex);

--- a/src/api/control/async/asyncMotionProfileController.cpp
+++ b/src/api/control/async/asyncMotionProfileController.cpp
@@ -36,7 +36,6 @@ AsyncMotionProfileController::AsyncMotionProfileController(
 
 AsyncMotionProfileController::~AsyncMotionProfileController() {
   dtorCalled.store(true, std::memory_order_release);
-  isDisabled();
 
   // Free paths before deleting the task
   std::scoped_lock lock(currentPathMutex);


### PR DESCRIPTION
### Description of the Change

This PR removes two useless calls in the AMPC and ALMPC dtors.

### Motivation

These calls do nothing. Also it's bad to call virtual members in a dtor.

### Possible Drawbacks

None.

### Applicable Issues

None.
