### PR TITLE
Fixed Pathfinder as a C++ library

### DIFF
--- a/include/okapi/pathfinder/include/pathfinder/fit.h
+++ b/include/okapi/pathfinder/include/pathfinder/fit.h
@@ -1,6 +1,11 @@
 #ifndef PATHFINDER_FIT_H_DEF
 #define PATHFINDER_FIT_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
@@ -10,5 +15,9 @@ CAPI void pf_fit_hermite_quintic(Waypoint a, Waypoint b, Spline *s);
 
 #define FIT_HERMITE_CUBIC   &pf_fit_hermite_cubic
 #define FIT_HERMITE_QUINTIC &pf_fit_hermite_quintic
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/fit.h
+++ b/include/okapi/pathfinder/include/pathfinder/fit.h
@@ -17,7 +17,7 @@ CAPI void pf_fit_hermite_quintic(Waypoint a, Waypoint b, Spline *s);
 #define FIT_HERMITE_QUINTIC &pf_fit_hermite_quintic
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/followers/distance.h
+++ b/include/okapi/pathfinder/include/pathfinder/followers/distance.h
@@ -1,6 +1,11 @@
 #ifndef PATHFINDER_FOL_DISTANCE_H_DEF
 #define PATHFINDER_FOL_DISTANCE_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
@@ -16,5 +21,9 @@ CAPI typedef struct {
 CAPI double pathfinder_follow_distance(FollowerConfig c, DistanceFollower *follower, Segment *trajectory, int trajectory_length, double distance);
 
 CAPI double pathfinder_follow_distance2(FollowerConfig c, DistanceFollower *follower, Segment segment, int trajectory_length, double distance);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/followers/distance.h
+++ b/include/okapi/pathfinder/include/pathfinder/followers/distance.h
@@ -23,7 +23,7 @@ CAPI double pathfinder_follow_distance(FollowerConfig c, DistanceFollower *follo
 CAPI double pathfinder_follow_distance2(FollowerConfig c, DistanceFollower *follower, Segment segment, int trajectory_length, double distance);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/followers/encoder.h
+++ b/include/okapi/pathfinder/include/pathfinder/followers/encoder.h
@@ -1,6 +1,11 @@
 #ifndef PATHFINDER_FOL_ENCODER_H_DEF
 #define PATHFINDER_FOL_ENCODER_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
 typedef struct {
@@ -14,8 +19,13 @@ typedef struct {
     int segment, finished;
 } EncoderFollower;
 
+
 double pathfinder_follow_encoder(EncoderConfig c, EncoderFollower *follower, Segment *trajectory, int trajectory_length, int encoder_tick);
 
 double pathfinder_follow_encoder2(EncoderConfig c, EncoderFollower *follower, Segment segment, int trajectory_length, int encoder_tick);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/followers/encoder.h
+++ b/include/okapi/pathfinder/include/pathfinder/followers/encoder.h
@@ -25,7 +25,7 @@ double pathfinder_follow_encoder(EncoderConfig c, EncoderFollower *follower, Seg
 double pathfinder_follow_encoder2(EncoderConfig c, EncoderFollower *follower, Segment segment, int trajectory_length, int encoder_tick);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/io.h
+++ b/include/okapi/pathfinder/include/pathfinder/io.h
@@ -3,8 +3,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "okapi/pathfinder/include/pathfinder/structs.h"
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "okapi/pathfinder/include/pathfinder/structs.h"
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 
 #define CSV_LEADING_STRING "dt,x,y,position,velocity,acceleration,jerk,heading\n"
@@ -23,5 +29,9 @@ CAPI int pathfinder_deserialize(FILE *fp, Segment *target);
 
 CAPI void pathfinder_serialize_csv(FILE *fp, Segment *trajectory, int trajectory_length);
 CAPI int pathfinder_deserialize_csv(FILE *fp, Segment *target);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/io.h
+++ b/include/okapi/pathfinder/include/pathfinder/io.h
@@ -31,7 +31,7 @@ CAPI void pathfinder_serialize_csv(FILE *fp, Segment *trajectory, int trajectory
 CAPI int pathfinder_deserialize_csv(FILE *fp, Segment *target);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/mathutil.h
+++ b/include/okapi/pathfinder/include/pathfinder/mathutil.h
@@ -3,6 +3,11 @@
 #ifndef PATHFINDER_MATH_UTIL_H_DEF
 #define PATHFINDER_MATH_UTIL_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 
 #define PI 3.14159265358979323846
@@ -16,5 +21,9 @@ CAPI double bound_radians(double angle);
 CAPI double r2d(double angleInRads);
 
 CAPI double d2r(double angleInDegrees);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/mathutil.h
+++ b/include/okapi/pathfinder/include/pathfinder/mathutil.h
@@ -23,7 +23,7 @@ CAPI double r2d(double angleInRads);
 CAPI double d2r(double angleInDegrees);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/modifiers/swerve.h
+++ b/include/okapi/pathfinder/include/pathfinder/modifiers/swerve.h
@@ -1,6 +1,11 @@
 #ifndef PATHFINDER_MOD_SWERVE_H_DEF
 #define PATHFINDER_MOD_SWERVE_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
@@ -10,5 +15,9 @@ CAPI typedef enum {
 
 CAPI void pathfinder_modify_swerve(Segment *original, int length, Segment *front_left, Segment *front_right,
         Segment *back_left, Segment *back_right, double wheelbase_width, double wheelbase_depth, SWERVE_MODE mode);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/modifiers/swerve.h
+++ b/include/okapi/pathfinder/include/pathfinder/modifiers/swerve.h
@@ -17,7 +17,7 @@ CAPI void pathfinder_modify_swerve(Segment *original, int length, Segment *front
         Segment *back_left, Segment *back_right, double wheelbase_width, double wheelbase_depth, SWERVE_MODE mode);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/modifiers/tank.h
+++ b/include/okapi/pathfinder/include/pathfinder/modifiers/tank.h
@@ -1,9 +1,18 @@
 #ifndef PATHFINDER_MOD_TANK_H_DEF
 #define PATHFINDER_MOD_TANK_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
 CAPI void pathfinder_modify_tank(Segment *original, int length, Segment *left, Segment *right, double wheelbase_width);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/modifiers/tank.h
+++ b/include/okapi/pathfinder/include/pathfinder/modifiers/tank.h
@@ -12,7 +12,7 @@ extern "C"
 CAPI void pathfinder_modify_tank(Segment *original, int length, Segment *left, Segment *right, double wheelbase_width);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/trajectory.h
+++ b/include/okapi/pathfinder/include/pathfinder/trajectory.h
@@ -1,6 +1,11 @@
 #ifndef PATHFINDER_TRAJECTORY_H_DEF
 #define PATHFINDER_TRAJECTORY_H_DEF
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "okapi/pathfinder/include/pathfinder/lib.h"
 #include "okapi/pathfinder/include/pathfinder/structs.h"
 
@@ -14,5 +19,9 @@ CAPI TrajectoryInfo pf_trajectory_prepare(TrajectoryConfig c);
 CAPI int pf_trajectory_create(TrajectoryInfo info, TrajectoryConfig c, Segment *seg);
 CAPI int pf_trajectory_fromSecondOrderFilter(int filter_1_l, int filter_2_l, 
         double dt, double u, double v, double impulse, int len, Segment *t);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/okapi/pathfinder/include/pathfinder/trajectory.h
+++ b/include/okapi/pathfinder/include/pathfinder/trajectory.h
@@ -21,7 +21,7 @@ CAPI int pf_trajectory_fromSecondOrderFilter(int filter_1_l, int filter_2_l,
         double dt, double u, double v, double impulse, int len, Segment *t);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif


### PR DESCRIPTION
### Description of the Change

Because pathfinder was built as a C library, in order to be used with C++ pros projects, it must be labeled as such. Therefore extern "C" was added to the header files.

### Motivation

Pathfinder failed to link while compiling a pros project for the RIT  VEXU team

### Possible Drawbacks

N/A

### Verification Process

Ran pathfinder_generate(...), pathfinder_modify_tank(...), dtr(...) and pathfinder_follow_encoder(...) without errors occurring

### Applicable Issues

Closes #435.