### PR TITLE
Changed Arcade controller example

### DIFF
--- a/docs/tutorials/walkthrough/clawbot.md
+++ b/docs/tutorials/walkthrough/clawbot.md
@@ -323,7 +323,7 @@ void opcontrol() {
     while (true) {
         // Arcade drive with the left stick
         drive->getModel()->arcade(controller.getAnalog(ControllerAnalog::leftY),
-                                  controller.getAnalog(ControllerAnalog::rightY));
+                                  controller.getAnalog(ControllerAnalog::leftX));
 
         // Don't power the arm if it is all the way down
         if (armLimitSwitch.isPressed()) {


### PR DESCRIPTION
Changed the example code for arcade drive to use x and y on left stick instead of left y and right y