### PR TITLE
Issue #302: Add common math functions to RQuantity

### DIFF
--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -234,7 +234,7 @@ root(const RQuantity<M, L, T, A> &lhs) {
   return RQuantity<std::ratio_divide<M, std::ratio<R>>,
                    std::ratio_divide<L, std::ratio<R>>,
                    std::ratio_divide<T, std::ratio<R>>,
-                   std::ratio_divide<A, std::ratio<R>>>(std::pow(lhs.getValue(), 1/R));
+                   std::ratio_divide<A, std::ratio<R>>>(std::pow(lhs.getValue(), 1.0/R));
 }
 
 template <typename M, typename L, typename T, typename A>

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -201,6 +201,18 @@ constexpr RQuantity<M, L, T, A> abs(const RQuantity<M, L, T, A> &rhs) {
   return RQuantity<M, L, T, A>(std::abs(rhs.getValue()));
 }
 
+template <typename R, typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_multiply<M, R>,
+                    std::ratio_multiply<L, R>,
+                    std::ratio_multiply<T, R>,
+                    std::ratio_multiply<A, R>>
+pow(const RQuantity<M, L, T, A> &lhs) {
+  return RQuantity<std::ratio_multiply<M, R>,
+                   std::ratio_multiply<L, R>,
+                   std::ratio_multiply<T, R>,
+                   std::ratio_multiply<A, R>>(std::pow(lhs.getValue(), double(R::num) / R::den));
+}
+
 template <typename M, typename L, typename T, typename A>
 constexpr RQuantity<std::ratio_divide<M, std::ratio<2>>,
                     std::ratio_divide<L, std::ratio<2>>,
@@ -226,6 +238,30 @@ cbrt(const RQuantity<M, L, T, A> &rhs) {
 }
 
 template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_multiply<M, std::ratio<2>>,
+                    std::ratio_multiply<L, std::ratio<2>>,
+                    std::ratio_multiply<T, std::ratio<2>>,
+                    std::ratio_multiply<A, std::ratio<2>>>
+square(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio_multiply<M, std::ratio<2>>,
+                   std::ratio_multiply<L, std::ratio<2>>,
+                   std::ratio_multiply<T, std::ratio<2>>,
+                   std::ratio_multiply<A, std::ratio<2>>>(std::pow(rhs.getValue(), 2));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_multiply<M, std::ratio<3>>,
+                    std::ratio_multiply<L, std::ratio<3>>,
+                    std::ratio_multiply<T, std::ratio<3>>,
+                    std::ratio_multiply<A, std::ratio<3>>>
+cube(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio_multiply<M, std::ratio<3>>,
+                   std::ratio_multiply<L, std::ratio<3>>,
+                   std::ratio_multiply<T, std::ratio<3>>,
+                   std::ratio_multiply<A, std::ratio<3>>>(std::pow(rhs.getValue(), 3));
+}
+
+template <typename M, typename L, typename T, typename A>
 constexpr RQuantity<M, L, T, A> hypot(const RQuantity<M, L, T, A> &lhs,
                                       const RQuantity<M, L, T, A> &rhs) {
   return RQuantity<M, L, T, A>(std::hypot(lhs.getValue(), rhs.getValue()));
@@ -248,6 +284,30 @@ template <typename M1,
 constexpr RQuantity<M1, L1, T1, A1> copysign(const RQuantity<M1, L1, T1, A1> &lhs,
                                              const RQuantity<M2, L2, T2, A2> &rhs) {
   return RQuantity<M1, L1, T1, A1>(std::copysign(lhs.getValue(), rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> ceil(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::ceil(lhs.getValue() / rhs.getValue()) * rhs.getValue());
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> floor(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::floor(lhs.getValue() / rhs.getValue()) * rhs.getValue());
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> trunc(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::trunc(lhs.getValue() / rhs.getValue()) * rhs.getValue());
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> round(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::round(lhs.getValue() / rhs.getValue()) * rhs.getValue());
 }
 
 // Common trig functions:

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -213,6 +213,30 @@ pow(const RQuantity<M, L, T, A> &lhs) {
                    std::ratio_multiply<A, R>>(std::pow(lhs.getValue(), double(R::num) / R::den));
 }
 
+template <int R, typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_multiply<M, std::ratio<R>>,
+                    std::ratio_multiply<L, std::ratio<R>>,
+                    std::ratio_multiply<T, std::ratio<R>>,
+                    std::ratio_multiply<A, std::ratio<R>>>
+pow(const RQuantity<M, L, T, A> &lhs) {
+  return RQuantity<std::ratio_multiply<M, std::ratio<R>>,
+                   std::ratio_multiply<L, std::ratio<R>>,
+                   std::ratio_multiply<T, std::ratio<R>>,
+                   std::ratio_multiply<A, std::ratio<R>>>(std::pow(lhs.getValue(), R));
+}
+
+template <int R, typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_divide<M, std::ratio<R>>,
+                    std::ratio_divide<L, std::ratio<R>>,
+                    std::ratio_divide<T, std::ratio<R>>,
+                    std::ratio_divide<A, std::ratio<R>>>
+root(const RQuantity<M, L, T, A> &lhs) {
+  return RQuantity<std::ratio_divide<M, std::ratio<R>>,
+                   std::ratio_divide<L, std::ratio<R>>,
+                   std::ratio_divide<T, std::ratio<R>>,
+                   std::ratio_divide<A, std::ratio<R>>>(std::pow(lhs.getValue(), 1/R));
+}
+
 template <typename M, typename L, typename T, typename A>
 constexpr RQuantity<std::ratio_divide<M, std::ratio<2>>,
                     std::ratio_divide<L, std::ratio<2>>,

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -2,6 +2,7 @@
  * @author Mikhail Semenov
  * @author Benjamin Jurke
  * @author Ryan Benasutti, WPI
+ * @author Wesley Chalmers
  *
  * This code is a modified version of Benjamin Jurke's work in 2015. You can read his blog post
  * here:
@@ -190,6 +191,157 @@ constexpr bool operator<(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L,
 template <typename M, typename L, typename T, typename A>
 constexpr bool operator>(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
   return (lhs.getValue() > rhs.getValue());
+}
+
+// Common math functions:
+// ------------------------------
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> abs(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::abs(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_divide<M, std::ratio<2>>,
+                    std::ratio_divide<L, std::ratio<2>>,
+                    std::ratio_divide<T, std::ratio<2>>,
+                    std::ratio_divide<A, std::ratio<2>>>
+sqrt(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio_divide<M, std::ratio<2>>,
+                   std::ratio_divide<L, std::ratio<2>>,
+                   std::ratio_divide<T, std::ratio<2>>,
+                   std::ratio_divide<A, std::ratio<2>>>(std::sqrt(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio_divide<M, std::ratio<3>>,
+                    std::ratio_divide<L, std::ratio<3>>,
+                    std::ratio_divide<T, std::ratio<3>>,
+                    std::ratio_divide<A, std::ratio<3>>>
+cbrt(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio_divide<M, std::ratio<3>>,
+                   std::ratio_divide<L, std::ratio<3>>,
+                   std::ratio_divide<T, std::ratio<3>>,
+                   std::ratio_divide<A, std::ratio<3>>>(std::cbrt(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> hypot(const RQuantity<M, L, T, A> &lhs,
+                                      const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::hypot(lhs.getValue(), rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> max(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::max(lhs.getValue(), rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> min(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::min(lhs.getValue(), rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, A> mod(const RQuantity<M, L, T, A> &lhs,
+                                    const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, A>(std::fmod(lhs.getValue(), rhs.getValue()));
+}
+
+template <typename M1,
+          typename L1,
+          typename T1,
+          typename A1,
+          typename M2,
+          typename L2,
+          typename T2,
+          typename A2>
+constexpr RQuantity<M1, L1, T1, A1> copysign(const RQuantity<M1, L1, T1, A1> &lhs,
+                                             const RQuantity<M2, L2, T2, A2> &rhs) {
+  return RQuantity<M1, L1, T1, A1>(std::copysign(lhs.getValue(), rhs.getValue()));
+}
+
+// Common trig functions:
+// ------------------------------
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+sin(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::sin(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+cos(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::cos(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+tan(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::tan(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+asin(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::asin(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+acos(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::acos(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+atan(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::atan(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+sinh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::sinh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+cosh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::cosh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
+tanh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::tanh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+asinh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::asinh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+acosh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::acosh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
+atanh(const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::atanh(rhs.getValue()));
+}
+
+template <typename M, typename L, typename T, typename A>
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+atan2(const RQuantity<M, L, T, A> &lhs, const RQuantity<M, L, T, A> &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::atan2(lhs.getValue(), rhs.getValue()));
 }
 
 inline namespace literals {

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -265,76 +265,70 @@ constexpr RQuantity<M1, L1, T1, A1> copysign(const RQuantity<M1, L1, T1, A1> &lh
 // Common trig functions:
 // ------------------------------
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-sin(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::sin(rhs.getValue()));
+constexpr Number
+sin(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::sin(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-cos(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::cos(rhs.getValue()));
+constexpr Number
+cos(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::cos(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-tan(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::tan(rhs.getValue()));
+constexpr Number
+tan(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::tan(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-asin(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::asin(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+asin(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::asin(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-acos(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::acos(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+acos(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::acos(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-atan(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::atan(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+atan(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::atan(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-sinh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::sinh(rhs.getValue()));
+constexpr Number
+sinh(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::sinh(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-cosh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::cosh(rhs.getValue()));
+constexpr Number
+cosh(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::cosh(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>
-tanh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_subtract<A, std::ratio<1>>>(std::tanh(rhs.getValue()));
+constexpr Number
+tanh(const RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>> &rhs) {
+  return Number(std::tanh(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-asinh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::asinh(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+asinh(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::asinh(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-acosh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::acosh(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+acosh(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::acosh(rhs.getValue()));
 }
 
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>
-atanh(const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, std::ratio_add<A, std::ratio<1>>>(std::atanh(rhs.getValue()));
+constexpr RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>
+atanh(const Number &rhs) {
+  return RQuantity<std::ratio<0>, std::ratio<0>, std::ratio<0>, std::ratio<1>>(
+    std::atanh(rhs.getValue()));
 }
 
 template <typename M, typename L, typename T, typename A>

--- a/include/okapi/api/units/RQuantity.hpp
+++ b/include/okapi/api/units/RQuantity.hpp
@@ -232,18 +232,6 @@ constexpr RQuantity<M, L, T, A> hypot(const RQuantity<M, L, T, A> &lhs,
 }
 
 template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> max(const RQuantity<M, L, T, A> &lhs,
-                                    const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, A>(std::max(lhs.getValue(), rhs.getValue()));
-}
-
-template <typename M, typename L, typename T, typename A>
-constexpr RQuantity<M, L, T, A> min(const RQuantity<M, L, T, A> &lhs,
-                                    const RQuantity<M, L, T, A> &rhs) {
-  return RQuantity<M, L, T, A>(std::min(lhs.getValue(), rhs.getValue()));
-}
-
-template <typename M, typename L, typename T, typename A>
 constexpr RQuantity<M, L, T, A> mod(const RQuantity<M, L, T, A> &lhs,
                                     const RQuantity<M, L, T, A> &rhs) {
   return RQuantity<M, L, T, A>(std::fmod(lhs.getValue(), rhs.getValue()));

--- a/src/api/control/util/pidTuner.cpp
+++ b/src/api/control/util/pidTuner.cpp
@@ -118,7 +118,7 @@ PIDTuner::Output PIDTuner::autotune() {
         const double outputVal = testController.step(inputVal);
         const double error = testController.getError();
         // sum of the error emphasizing later error
-        itae += (settleTime.convert(millisecond) * abs((int)error)) / divisor;
+        itae += (settleTime.convert(millisecond) * std::abs((int)error)) / divisor;
 
         output->controllerSet(outputVal);
         rate->delayUntil(loopDelta);

--- a/src/api/odometry/threeEncoderOdometry.cpp
+++ b/src/api/odometry/threeEncoderOdometry.cpp
@@ -52,19 +52,19 @@ OdomState ThreeEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &
     localOffX = deltaM;
     localOffY = deltaR;
   } else {
-    localOffX = 2 * sin(deltaTheta / 2) *
+    localOffX = 2 * std::sin(deltaTheta / 2) *
                 (deltaM / deltaTheta + chassisScales.middleWheelDistance.convert(meter) * 2);
-    localOffY =
-      2 * sin(deltaTheta / 2) * (deltaR / deltaTheta + chassisScales.wheelTrack.convert(meter) / 2);
+    localOffY = 2 * std::sin(deltaTheta / 2) *
+                (deltaR / deltaTheta + chassisScales.wheelTrack.convert(meter) / 2);
   }
 
   double avgA = state.theta.convert(radian) + (deltaTheta / 2);
 
-  double polarR = sqrt((localOffX * localOffX) + (localOffY * localOffY));
-  double polarA = atan2(localOffY, localOffX) - avgA;
+  double polarR = std::sqrt((localOffX * localOffX) + (localOffY * localOffY));
+  double polarA = std::atan2(localOffY, localOffX) - avgA;
 
-  double dX = sin(polarA) * polarR;
-  double dY = cos(polarA) * polarR;
+  double dX = std::sin(polarA) * polarR;
+  double dY = std::cos(polarA) * polarR;
 
   if (isnan(dX)) {
     dX = 0;

--- a/src/api/odometry/twoEncoderOdometry.cpp
+++ b/src/api/odometry/twoEncoderOdometry.cpp
@@ -65,9 +65,9 @@ OdomState TwoEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &it
   double localOffX, localOffY;
 
   if (deltaTheta != 0) {
-    localOffX = 2 * sin(deltaTheta / 2) * chassisScales.middleWheelDistance.convert(meter);
-    localOffY =
-      2 * sin(deltaTheta / 2) * (deltaR / deltaTheta + chassisScales.wheelTrack.convert(meter) / 2);
+    localOffX = 2 * std::sin(deltaTheta / 2) * chassisScales.middleWheelDistance.convert(meter);
+    localOffY = 2 * std::sin(deltaTheta / 2) *
+                (deltaR / deltaTheta + chassisScales.wheelTrack.convert(meter) / 2);
   } else {
     localOffX = 0;
     localOffY = deltaR;
@@ -75,11 +75,11 @@ OdomState TwoEncoderOdometry::odomMathStep(const std::valarray<std::int32_t> &it
 
   double avgA = state.theta.convert(radian) + (deltaTheta / 2);
 
-  double polarR = sqrt(localOffX * localOffX + localOffY * localOffY);
-  double polarA = atan2(localOffY, localOffX) - avgA;
+  double polarR = std::sqrt(localOffX * localOffX + localOffY * localOffY);
+  double polarA = std::atan2(localOffY, localOffX) - avgA;
 
-  double dX = sin(polarA) * polarR;
-  double dY = cos(polarA) * polarR;
+  double dX = std::sin(polarA) * polarR;
+  double dY = std::cos(polarA) * polarR;
 
   if (isnan(dX)) {
     dX = 0;

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -53,12 +53,12 @@ TEST(UnitTests, AbsFreeFunction) {
 }
 
 TEST(UnitTests, PowRootTest) {
-  EXPECT_EQ(pow<2>(3_in), 3_in * 3_in);
-  EXPECT_EQ(root<3>(3_in * 3_in * 3_in), 3_in);
+  EXPECT_DOUBLE_EQ((pow<2>(3_in)).convert(inch2), 9.0);
+  EXPECT_DOUBLE_EQ(root<3>(3_in * 3_in * 3_in).convert(inch), 3.0);
 
   RQuantity three_halves_power = pow<std::ratio<3, 2>>(3_in);
   RQuantity cube_of_sqrt = pow<3>(root<2>(3_in));
-  EXPECT_EQ(three_halves_power, cube_of_sqrt);
+  EXPECT_DOUBLE_EQ(three_halves_power.getValue(), cube_of_sqrt.getValue());
 }
 
 TEST(UnitTests, SquareCubeTest) {
@@ -70,8 +70,8 @@ TEST(UnitTests, SquareCubeTest) {
 }
 
 TEST(UnitTests, ModTest) {
-  EXPECT_EQ(mod(QLength(4.0), QLength(2.0)), QLength(0.0));
-  EXPECT_EQ(mod(10_in, 3_in), 1_in);
+  EXPECT_DOUBLE_EQ(mod(QLength(4.0), QLength(2.0)).convert(meter), 0.0);
+  EXPECT_DOUBLE_EQ(mod(10_in, 3_in).convert(inch), 1.0);
 }
 
 TEST(UnitTests, CopysignTest) {
@@ -80,31 +80,31 @@ TEST(UnitTests, CopysignTest) {
 }
 
 TEST(UnitTests, RoundTest) {
-  EXPECT_EQ(ceil(4.1_in, inch), 5_in);
-  EXPECT_EQ(ceil(-4.1_in, inch), -4_in);
+  EXPECT_DOUBLE_EQ(ceil(4.1_in, inch).convert(inch), 5.0);
+  EXPECT_DOUBLE_EQ(ceil(-4.1_in, inch).convert(inch), -4.0);
 
-  EXPECT_EQ(floor(1.17_s, 100_ms), 1.1_s);
-  EXPECT_EQ(floor(-1.17_s, 100_ms), -1.2_s);
+  EXPECT_DOUBLE_EQ(floor(1.17_s, 100_ms).convert(second), 1.1);
+  EXPECT_DOUBLE_EQ(floor(-1.17_s, 100_ms).convert(second), -1.2);
 
-  EXPECT_EQ(trunc(5.8_cm, centimeter), 5_cm);
-  EXPECT_EQ(trunc(-5.8_cm, centimeter), -5_cm);
+  EXPECT_DOUBLE_EQ(trunc(5.8_cm, centimeter).convert(centimeter), 5.0);
+  EXPECT_DOUBLE_EQ(trunc(-5.8_cm, centimeter).convert(centimeter), -5.0);
 
-  EXPECT_EQ(round(2.4_in, inch), 2_in);
-  EXPECT_EQ(round(2.6_in, inch), 3_in);
-  EXPECT_EQ(round(-2.4_in, inch), -2_in);
-  EXPECT_EQ(round(-2.6_in, inch), -3_in);
+  EXPECT_DOUBLE_EQ(round(2.4_in, inch).convert(inch), 2.0);
+  EXPECT_DOUBLE_EQ(round(2.6_in, inch).convert(inch), 3.0);
+  EXPECT_DOUBLE_EQ(round(-2.4_in, inch).convert(inch), -2.0);
+  EXPECT_DOUBLE_EQ(round(-2.6_in, inch).convert(inch), -3.0);
 }
 
 TEST(UnitTests, TrigTest) {
-  EXPECT_EQ(sin(30_deg), Number(0.5));
-  EXPECT_EQ(cos(60_deg), Number(0.5));
-  EXPECT_EQ(tan(45_deg), Number(1.0));
+  EXPECT_DOUBLE_EQ(sin(30_deg).convert(number), 0.5);
+  EXPECT_DOUBLE_EQ(cos(60_deg).convert(number), 0.5);
+  EXPECT_DOUBLE_EQ(tan(45_deg).convert(number), 1.0);
 }
 
 TEST(UnitTests, InverseTrigTest) {
-  EXPECT_EQ(asin(Number(0.5)), 30_deg);
-  EXPECT_EQ(acos(Number(0.5)), 60_deg);
-  EXPECT_EQ(atan(Number(1.0)), 45_deg);
+  EXPECT_DOUBLE_EQ(asin(Number(0.5)).convert(degree), 30.0);
+  EXPECT_DOUBLE_EQ(acos(Number(0.5)).convert(degree), 60.0);
+  EXPECT_DOUBLE_EQ(atan(Number(1.0)).convert(degree), 45.0);
 }
 
 TEST(UnitTests, HyperbTest) {

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -8,6 +8,7 @@
 #include "okapi/api/units/QArea.hpp"
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QTime.hpp"
+#include "okapi/api/units/QVolume.hpp"
 #include <gtest/gtest.h>
 
 using namespace okapi;
@@ -43,4 +44,80 @@ TEST(UnitTests, UnaryMinusTest) {
 
 TEST(UnitTests, SqrtTest) {
   EXPECT_DOUBLE_EQ(std::sqrt(2), (2 * meter2).sqrt().convert(meter));
+}
+
+TEST(UnitTests, AbsFreeFunction) {
+  EXPECT_EQ(abs(3.0_m), 3.0_m);
+  EXPECT_EQ(abs(-3.0_m), 3.0_m);
+}
+
+TEST(UnitTests, PowRootTest) {
+  EXPECT_EQ(pow<2>(3_in), 3_in * 3_in);
+  EXPECT_EQ(root<3>(3_in * 3_in * 3_in), 3_in);
+  EXPECT_EQ(pow<std::ratio<3, 2>>(3_in), pow<3>(root<2>(3_in)));
+}
+
+TEST(UnitTests, SquareCubeTest) {
+  EXPECT_EQ(square(QLength(3)), QArea(9));
+  EXPECT_EQ(cube(QLength(4)), QVolume(64));
+  EXPECT_EQ(sqrt(QArea(25)), QLength(5));
+  EXPECT_EQ(cbrt(QVolume(8)), QLength(2));
+  EXPECT_EQ(hypot(QLength(3), QLength(4)), QLength(5));
+}
+
+TEST(UnitTests, ModTest) {
+  EXPECT_EQ(mod(QLength(4), QLength(2)), QLength(0));
+  EXPECT_EQ(mod(10_in, 3_in), 1_in);
+}
+
+TEST(UnitTests, CopysignTest) {
+  EXPECT_EQ(copysign(3_m, -4_in), -3_m);
+  EXPECT_EQ(copysign(1_s, 5_m), 1_s);
+}
+
+TEST(UnitTests, RoundTest) {
+  EXPECT_EQ(ceil(4.1_in, inch), 5_in);
+  EXPECT_EQ(ceil(-4.1_in, inch), -4_in);
+
+  EXPECT_EQ(floor(1.17_s, 100_ms), 1.1_s);
+  EXPECT_EQ(floor(-1.17_s, 100_ms), -1.2_s);
+
+  EXPECT_EQ(trunc(5.8_cm, centimeter), 5_cm);
+  EXPECT_EQ(trunc(-5.8_cm, centimeter), -5_cm);
+
+  EXPECT_EQ(round(2.4_in, inch), 2_in);
+  EXPECT_EQ(round(2.6_in, inch), 3_in);
+  EXPECT_EQ(round(-2.4_in, inch), -2_in);
+  EXPECT_EQ(round(-2.6_in, inch), -3_in);
+}
+
+TEST(UnitTests, TrigTest) {
+  EXPECT_EQ(sin(30_deg), Number(0.5));
+  EXPECT_EQ(cos(60_deg), Number(0.5));
+  EXPECT_EQ(tan(45_deg), Number(1));
+}
+
+TEST(UnitTests, InverseTrigTest) {
+  EXPECT_EQ(asin(Number(0.5)), 30_deg);
+  EXPECT_EQ(acos(Number(0.5)), 60_deg);
+  EXPECT_EQ(atan(Number(1)), 45_deg);
+}
+
+TEST(UnitTests, HyperbTest) {
+  EXPECT_DOUBLE_EQ(sinh(37_deg).convert(radian), 0.6916004653045855);
+  EXPECT_DOUBLE_EQ(cosh(37_deg).convert(radian), 1.2158582169025791);
+  EXPECT_DOUBLE_EQ(tanh(37_deg).convert(radian), 0.5688167055090109);
+}
+
+TEST(UnitTests, InverseHyperbTest) {
+  EXPECT_DOUBLE_EQ(asinh(Number(0.6916004653045855)).convert(degree), 37.0);
+  EXPECT_DOUBLE_EQ(acosh(Number(1.2158582169025791)).convert(degree), 37.0);
+  EXPECT_DOUBLE_EQ(atanh(Number(0.5688167055090109)).convert(degree), 37.0);
+}
+
+TEST(UnitTests, Atan2Test) {
+  EXPECT_DOUBLE_EQ(atan2(1_ft, 2_ft).convert(radian), 0.4636476090008061);
+  EXPECT_DOUBLE_EQ(atan2(1_ft, -2_ft).convert(radian), 2.677945044588987);
+  EXPECT_DOUBLE_EQ(atan2(-1_ft, -2_ft).convert(radian), -2.677945044588987);
+  EXPECT_DOUBLE_EQ(atan2(-1_ft, 2_ft).convert(radian), -0.4636476090008061);
 }

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -5,6 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "okapi/api/units/QAngle.hpp"
 #include "okapi/api/units/QArea.hpp"
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QTime.hpp"
@@ -58,15 +59,15 @@ TEST(UnitTests, PowRootTest) {
 }
 
 TEST(UnitTests, SquareCubeTest) {
-  EXPECT_EQ(square(QLength(3)), QArea(9));
-  EXPECT_EQ(cube(QLength(4)), QVolume(64));
-  EXPECT_EQ(sqrt(QArea(25)), QLength(5));
-  EXPECT_EQ(cbrt(QVolume(8)), QLength(2));
-  EXPECT_EQ(hypot(QLength(3), QLength(4)), QLength(5));
+  EXPECT_EQ(square(QLength(3.0)), QArea(9.0));
+  EXPECT_EQ(cube(QLength(4.0)), QVolume(64.0));
+  EXPECT_EQ(sqrt(QArea(25.0)), QLength(5.0));
+  EXPECT_EQ(cbrt(QVolume(8.0)), QLength(2.0));
+  EXPECT_EQ(hypot(QLength(3.0), QLength(4.0)), QLength(5.0));
 }
 
 TEST(UnitTests, ModTest) {
-  EXPECT_EQ(mod(QLength(4), QLength(2)), QLength(0));
+  EXPECT_EQ(mod(QLength(4.0), QLength(2.0)), QLength(0.0));
   EXPECT_EQ(mod(10_in, 3_in), 1_in);
 }
 
@@ -94,13 +95,13 @@ TEST(UnitTests, RoundTest) {
 TEST(UnitTests, TrigTest) {
   EXPECT_EQ(sin(30_deg), Number(0.5));
   EXPECT_EQ(cos(60_deg), Number(0.5));
-  EXPECT_EQ(tan(45_deg), Number(1));
+  EXPECT_EQ(tan(45_deg), Number(1.0));
 }
 
 TEST(UnitTests, InverseTrigTest) {
   EXPECT_EQ(asin(Number(0.5)), 30_deg);
   EXPECT_EQ(acos(Number(0.5)), 60_deg);
-  EXPECT_EQ(atan(Number(1)), 45_deg);
+  EXPECT_EQ(atan(Number(1.0)), 45_deg);
 }
 
 TEST(UnitTests, HyperbTest) {

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -55,7 +55,10 @@ TEST(UnitTests, AbsFreeFunction) {
 TEST(UnitTests, PowRootTest) {
   EXPECT_EQ(pow<2>(3_in), 3_in * 3_in);
   EXPECT_EQ(root<3>(3_in * 3_in * 3_in), 3_in);
-  EXPECT_EQ(pow<std::ratio<3, 2>>(3_in), pow<3>(root<2>(3_in)));
+
+  RQuantity three_halves_power = pow<std::ratio<3, 2>>(3_in);
+  RQuantity cube_of_sqrt = pow<3>(root<2>(3_in));
+  EXPECT_EQ(three_halves_power, cube_of_sqrt);
 }
 
 TEST(UnitTests, SquareCubeTest) {
@@ -105,9 +108,9 @@ TEST(UnitTests, InverseTrigTest) {
 }
 
 TEST(UnitTests, HyperbTest) {
-  EXPECT_DOUBLE_EQ(sinh(37_deg).convert(radian), 0.6916004653045855);
-  EXPECT_DOUBLE_EQ(cosh(37_deg).convert(radian), 1.2158582169025791);
-  EXPECT_DOUBLE_EQ(tanh(37_deg).convert(radian), 0.5688167055090109);
+  EXPECT_DOUBLE_EQ(sinh(37_deg).convert(number), 0.6916004653045855);
+  EXPECT_DOUBLE_EQ(cosh(37_deg).convert(number), 1.2158582169025791);
+  EXPECT_DOUBLE_EQ(tanh(37_deg).convert(number), 0.5688167055090109);
 }
 
 TEST(UnitTests, InverseHyperbTest) {


### PR DESCRIPTION
### Description of the Change

Add common math and trig functions (`sin()`, `cos()`, `sqrt()`, etc.) to RQuantity (units API). This PR includes many of the functions present in the <cmath> header (trigonometric and hyperbolic functions, a few basic root functions, modulus, etc). It does not include rounding functions or log/exponent functions.

### Motivation

Previously, using common math functions with the units API required converting a number from an RQuantity to a double, using the function, and then converting the number back to an RQuantity. This PR adds functions like `sin()` that take RQuantity objects as arguments so users do not need to do this conversion.

### Possible Drawbacks

Because these functions are implemented as free functions [as per this comment](https://github.com/OkapiLib/OkapiLib/issues/302#issuecomment-619711767), they might clutter up the namespace a bit.

### Verification Process

I tested each function I implemented on my desktop to ensure it gave valid results. (I haven't gotten the chance to test on a V5 brain, but compilation succeeded when I copied these changes into a new PROS project. Since most of the work done by the units API is at compile time, this seemed like a good sign.)

### Applicable Issues

Closes #302.
