### PR TITLE
Enable autobrief

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -195,7 +195,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If


### PR DESCRIPTION
### Description of the Change

Enables doxygen autobrief which uses the first sentence of the function comment as the `\brief` command.

Before: 
![image](https://user-images.githubusercontent.com/16546293/87357533-03fd2f00-c519-11ea-80c6-42a39b771395.png)
![image](https://user-images.githubusercontent.com/16546293/87357555-0bbcd380-c519-11ea-8860-73a1af097c4a.png)

After:
![image](https://user-images.githubusercontent.com/16546293/87357575-15463b80-c519-11ea-8b82-381cee95e74b.png)
![image](https://user-images.githubusercontent.com/16546293/87357586-1b3c1c80-c519-11ea-85ac-ab9c52e3ff6b.png)


### Motivation

Makes the docs look better and easier navigation.

### Possible Drawbacks

I have not looked through all pages to see how this changes things, though I think this change is a very minor risk. 
