### PR TITLE
#444: Add V5 IMU Wrapper Class

### DIFF
--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -84,11 +84,11 @@
 #include "okapi/impl/device/motor/adiMotor.hpp"
 #include "okapi/impl/device/motor/motor.hpp"
 #include "okapi/impl/device/motor/motorGroup.hpp"
+#include "okapi/impl/device/rotarysensor/IMU.hpp"
 #include "okapi/impl/device/rotarysensor/adiEncoder.hpp"
 #include "okapi/impl/device/rotarysensor/adiGyro.hpp"
 #include "okapi/impl/device/rotarysensor/integratedEncoder.hpp"
 #include "okapi/impl/device/rotarysensor/potentiometer.hpp"
-#include "okapi/impl/device/rotarysensor/IMU.hpp"
 
 #include "okapi/api/filter/averageFilter.hpp"
 #include "okapi/api/filter/composableFilter.hpp"

--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -88,6 +88,7 @@
 #include "okapi/impl/device/rotarysensor/adiGyro.hpp"
 #include "okapi/impl/device/rotarysensor/integratedEncoder.hpp"
 #include "okapi/impl/device/rotarysensor/potentiometer.hpp"
+#include "okapi/impl/device/rotarysensor/IMU.hpp"
 
 #include "okapi/api/filter/averageFilter.hpp"
 #include "okapi/api/filter/composableFilter.hpp"

--- a/include/okapi/impl/device/motor/motor.hpp
+++ b/include/okapi/impl/device/motor/motor.hpp
@@ -15,7 +15,7 @@ class Motor : public AbstractMotor {
   /**
    * A V5 motor.
    *
-   * @param iport The port number in the range [1, 21]. A negative port number is shorthand for
+   * @param iport The port number in the range ``[1, 21]``. A negative port number is shorthand for
    * reversing the motor.
    */
   Motor(std::int8_t iport);

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -34,15 +34,17 @@ class IMU : public ContinuousRotarySensor {
   /**
    * Get the current rotation about `iaxis`.
    *
-   * @return The current sensor value or one of the following values of `errno`:
+   * This may set the following values of `errno` on error:
    * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
    * - `ENODEV` - The port cannot be configured as an IMU.
    * - `EAGAIN` - The sensor is calibrating.
+   *
+   * @return The current sensor value or `PROS_ERR`.
    */
   double get() const override;
 
   /**
-   * Get the current sensor value remapped into the target range (`[1800, -1800]` by default).
+   * Get the current sensor value remapped into the target range (`[-1800, 1800]` by default).
    *
    * @param iupperBound The upper bound of the range.
    * @param ilowerBound The lower bound of the range.
@@ -53,10 +55,12 @@ class IMU : public ContinuousRotarySensor {
   /**
    * Get the current acceleration along `iaxis`.
    *
-   * @return The current sensor value or one of the following values of `errno`:
+   * This may set the following values of `errno` on error:
    * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
    * - `ENODEV` - The port cannot be configured as an IMU.
    * - `EAGAIN` - The sensor is calibrating.
+   *
+   * @return The current sensor value or `PROS_ERR`.
    */
   double getAcceleration();
 
@@ -71,10 +75,12 @@ class IMU : public ContinuousRotarySensor {
    * Calibrate the IMU. Resets the rotation value to zero. Calibration is expected to take two
    * seconds, but is bounded to five seconds.
    *
-   * @return `1` on success, or one of the following values of `errno`:
+   * This may set the following values of `errno` on error:
    * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
    * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating or timed out calibrating.
+   * - `EAGAIN` - The sensor is calibrating.
+   *
+   * @return `1` or `PROS_ERR`.
    */
   std::int32_t calibrate();
 
@@ -82,10 +88,12 @@ class IMU : public ContinuousRotarySensor {
    * Get the sensor value for use in a control loop. This method might be automatically called in
    * another thread by the controller.
    *
-   * @return the current sensor value, or one of the following values of `errno`
-   * - `ENXIO` - The given iport is not in range of the V5 ports (1-21).
+   * This may set the following values of `errno` on error:
+   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
    * - `ENODEV` - The port cannot be configured as an IMU.
    * - `EAGAIN` - The sensor is calibrating.
+   *
+   * @return The current sensor value or `PROS_ERR`.
    */
   double controllerGet() override;
 
@@ -96,10 +104,12 @@ class IMU : public ContinuousRotarySensor {
   /**
    * Get the current rotation about `iaxis` from the IMU. The internal offset is not accounted for.
    *
-   *@return the current sensor value or one of the following values of `errno`
-   * - `ENXIO` - The given iport is not in range of the V5 ports (1-21).
+   * This may set the following values of `errno` on error:
+   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
    * - `ENODEV` - The port cannot be configured as an IMU.
    * - `EAGAIN` - The sensor is calibrating.
+   *
+   * @return The current sensor value or `PROS_ERR`.
    */
   double readAngle() const;
 

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -12,88 +12,87 @@
 #include "okapi/api/device/rotarysensor/continuousRotarySensor.hpp"
 
 namespace okapi {
-enum class IMUAxes{
+enum class IMUAxes {
   z, ///< Yaw Axis
   y, ///< Pitch Axis
   x  ///< Roll Axis
 };
 
-class IMU : public ContinuousRotarySensor{
+class IMU : public ContinuousRotarySensor {
   public:
   /**
-   * An inertial sensor on the given port. If the port has not previously been configured as an IMU,
-   * then the constructor will block for 2 seconds for calibration. The IMU returns double angle results
+   * An inertial sensor on the given port.  The IMU returns an angle
+   * about the selected axis in degrees.
    *
    * @param iport: The port to use the inertial sensor from
    * @param iaxis: The axis of the inertial sensor to measure, default z
    */
-   IMU(std::uint8_t iport,IMUAxes iaxis = IMUAxes::z);
+  IMU(std::uint8_t iport, IMUAxes iaxis = IMUAxes::z);
 
-   virtual ~IMU();
+  virtual ~IMU();
 
-   /**
-    * Get the current rotation about iaxis
-    *
-    *@return the current sensor value or one of the following values of `errno`
-    * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-    * `ENODEV` - the port cannot be configured as an IMU
-    * `EAGAIN` - the sensor is calibrating
-    */
-    double get() const override;
+  /**
+   * Get the current rotation about iaxis.
+   *
+   *@return the current sensor value or one of the following values of `errno`
+   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+   * `ENODEV` - the port cannot be configured as an IMU
+   * `EAGAIN` - the sensor is calibrating
+   */
+  double get() const override;
 
-    /**
-     * Get the current sensor value remapped into the target range ([1800, -1800] by default).
-     *
-     * @param iupperBound the upper bound of the range.
-     * @param ilowerBound the lower bound of the range.
-     * @return the remapped sensor value.
-     */
-    double getRemapped(double iupperBound = 180, double ilowerBound = -180) const
-      __attribute__((optimize(3)));
+  /**
+   * Get the current sensor value remapped into the target range ([1800, -1800] by default).
+   *
+   * @param iupperBound the upper bound of the range.
+   * @param ilowerBound the lower bound of the range.
+   * @return the remapped sensor value.
+   */
+  double getRemapped(double iupperBound = 1800, double ilowerBound = -1800) const;
 
-      /**
-       * Get the current acceleration along iaxis
-       *
-       *@return the current sensor value or one of the following values of `errno`
-       * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-       * `ENODEV` - the port cannot be configured as an IMU
-       * `EAGAIN` - the sensor is calibrating
-       */
-    double getAcc();
+  /**
+   * Get the current acceleration along iaxis.
+   *
+   *@return the current sensor value or one of the following values of `errno`
+   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+   * `ENODEV` - the port cannot be configured as an IMU
+   * `EAGAIN` - the sensor is calibrating
+   */
+  double getAcceleration();
 
-    /**
-     * Reset the sensor to zero.
-     *
-     * @returns `1` on success
-     */
-    std::int32_t reset() override;
+  /**
+   * Reset the sensor to zero.
+   *
+   * @return `1` on success
+   */
+  std::int32_t reset() override;
 
-    /**
-     * Calibrates the IMU
-     *
-     * @return `1` on success, or one of the following values of `errno`
-     * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-     * `ENODEV` - the port cannot be configured as an IMU
-     * `EAGAIN` - the sensor is calibrating
-     */
-    std::int32_t calibrate();
+  /**
+   * Calibrate the IMU. Reset rotation value to `0`.
+   *
+   * @return `1` on success, or one of the following values of `errno`
+   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+   * `ENODEV` - the port cannot be configured as an IMU
+   * `EAGAIN` - the sensor is calibrating
+   */
+  std::int32_t calibrate();
 
-    /**
-     * Get the sensor value for use in a control loop. This method might be automatically called in
-     * another thread by the controller.
-     *
-     * @return the current sensor value, or one of the following values of `errno`
-     * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-     * `ENODEV` - the port cannot be configured as an IMU
-     * `EAGAIN` - the sensor is calibrating
-     */
-    double controllerGet() override;
+  /**
+   * Get the sensor value for use in a control loop. This method might be automatically called in
+   * another thread by the controller.
+   *
+   * @return the current sensor value, or one of the following values of `errno`
+   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+   * `ENODEV` - the port cannot be configured as an IMU
+   * `EAGAIN` - the sensor is calibrating
+   */
+  double controllerGet() override;
 
-    private:
-    double offset = 0; // this offset must invert based on the value currrently measured
+  private:
+  double offset = 0;
 
-    protected:
-    std::uint8_t port;
-    IMUAxes axis;
+  protected:
+  std::uint8_t port;
+  IMUAxes axis;
 };
 } // namespace okapi

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -91,6 +91,16 @@ class IMU : public ContinuousRotarySensor {
   private:
   double offset = 0;
 
+  /**
+   * Get the current rotation about iaxis from the IMU. `Offset` is not considered.
+   *
+   *@return the current sensor value or one of the following values of `errno`
+   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+   * `ENODEV` - the port cannot be configured as an IMU
+   * `EAGAIN` - the sensor is calibrating
+   */
+  double readAngle() const;
+
   protected:
   std::uint8_t port;
   IMUAxes axis;

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -29,8 +29,6 @@ class IMU : public ContinuousRotarySensor {
    */
   IMU(std::uint8_t iport, IMUAxes iaxis = IMUAxes::z);
 
-  virtual ~IMU();
-
   /**
    * Get the current rotation about `iaxis`.
    *
@@ -62,7 +60,7 @@ class IMU : public ContinuousRotarySensor {
    *
    * @return The current sensor value or `PROS_ERR`.
    */
-  double getAcceleration();
+  double getAcceleration() const;
 
   /**
    * Reset the rotation value to zero.

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -1,0 +1,99 @@
+/*
+ * @author Alex Riensche, UNL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+
+#include "api.h"
+#include "okapi/api/control/controllerInput.hpp"
+#include "okapi/api/device/rotarysensor/continuousRotarySensor.hpp"
+
+namespace okapi {
+enum class IMUAxes{
+  z, ///< Yaw Axis
+  y, ///< Pitch Axis
+  x  ///< Roll Axis
+};
+
+class IMU : public ContinuousRotarySensor{
+  public:
+  /**
+   * An inertial sensor on the given port. If the port has not previously been configured as an IMU,
+   * then the constructor will block for 2 seconds for calibration. The IMU returns double angle results
+   *
+   * @param iport: The port to use the inertial sensor from
+   * @param iaxis: The axis of the inertial sensor to measure, default z
+   */
+   IMU(std::uint8_t iport,IMUAxes iaxis = IMUAxes::z);
+
+   virtual ~IMU();
+
+   /**
+    * Get the current rotation about iaxis
+    *
+    *@return the current sensor value or one of the following values of `errno`
+    * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+    * `ENODEV` - the port cannot be configured as an IMU
+    * `EAGAIN` - the sensor is calibrating
+    */
+    double get() const override;
+
+    /**
+     * Get the current sensor value remapped into the target range ([1800, -1800] by default).
+     *
+     * @param iupperBound the upper bound of the range.
+     * @param ilowerBound the lower bound of the range.
+     * @return the remapped sensor value.
+     */
+    double getRemapped(double iupperBound = 180, double ilowerBound = -180) const
+      __attribute__((optimize(3)));
+
+      /**
+       * Get the current acceleration along iaxis
+       *
+       *@return the current sensor value or one of the following values of `errno`
+       * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+       * `ENODEV` - the port cannot be configured as an IMU
+       * `EAGAIN` - the sensor is calibrating
+       */
+    double getAcc();
+
+    /**
+     * Reset the sensor to zero.
+     *
+     * @returns `1` on success
+     */
+    std::int32_t reset() override;
+
+    /**
+     * Calibrates the IMU
+     *
+     * @return `1` on success, or one of the following values of `errno`
+     * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+     * `ENODEV` - the port cannot be configured as an IMU
+     * `EAGAIN` - the sensor is calibrating
+     */
+    std::int32_t calibrate();
+
+    /**
+     * Get the sensor value for use in a control loop. This method might be automatically called in
+     * another thread by the controller.
+     *
+     * @return the current sensor value, or one of the following values of `errno`
+     * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
+     * `ENODEV` - the port cannot be configured as an IMU
+     * `EAGAIN` - the sensor is calibrating
+     */
+    double controllerGet() override;
+
+    private:
+    double offset = 0; // this offset must invert based on the value currrently measured
+
+    protected:
+    std::uint8_t port;
+    IMUAxes axis;
+};
+} // namespace okapi

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -1,6 +1,4 @@
 /*
- * @author Alex Riensche, UNL
- *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -24,25 +22,25 @@ class IMU : public ContinuousRotarySensor {
    * An inertial sensor on the given port. The IMU returns an angle about the selected axis in
    * degrees.
    *
+   * ```cpp
+   * auto imuZ = IMU(1);
+   * auto imuX = IMU(1, IMUAxes::x);
+   * ```
+   *
    * @param iport The port to use the inertial sensor from.
    * @param iaxis The axis of the inertial sensor to measure, default `IMUAxes::z`.
    */
   IMU(std::uint8_t iport, IMUAxes iaxis = IMUAxes::z);
 
   /**
-   * Get the current rotation about `iaxis`.
+   * Get the current rotation about the configured axis.
    *
-   * This may set the following values of `errno` on error:
-   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
-   * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating.
-   *
-   * @return The current sensor value or `PROS_ERR`.
+   * @return The current sensor value or ``PROS_ERR``.
    */
   double get() const override;
 
   /**
-   * Get the current sensor value remapped into the target range (`[-1800, 1800]` by default).
+   * Get the current sensor value remapped into the target range (``[-1800, 1800]`` by default).
    *
    * @param iupperBound The upper bound of the range.
    * @param ilowerBound The lower bound of the range.
@@ -53,11 +51,6 @@ class IMU : public ContinuousRotarySensor {
   /**
    * Get the current acceleration along `iaxis`.
    *
-   * This may set the following values of `errno` on error:
-   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
-   * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating.
-   *
    * @return The current sensor value or `PROS_ERR`.
    */
   double getAcceleration() const;
@@ -65,7 +58,7 @@ class IMU : public ContinuousRotarySensor {
   /**
    * Reset the rotation value to zero.
    *
-   * @return This always returns `1`.
+   * @return ``1`` or ``PROS_ERR``.
    */
   std::int32_t reset() override;
 
@@ -73,12 +66,7 @@ class IMU : public ContinuousRotarySensor {
    * Calibrate the IMU. Resets the rotation value to zero. Calibration is expected to take two
    * seconds, but is bounded to five seconds.
    *
-   * This may set the following values of `errno` on error:
-   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
-   * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating.
-   *
-   * @return `1` or `PROS_ERR`.
+   * @return ``1`` or ``PROS_ERR``.
    */
   std::int32_t calibrate();
 
@@ -86,37 +74,26 @@ class IMU : public ContinuousRotarySensor {
    * Get the sensor value for use in a control loop. This method might be automatically called in
    * another thread by the controller.
    *
-   * This may set the following values of `errno` on error:
-   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
-   * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating.
-   *
-   * @return The current sensor value or `PROS_ERR`.
+   * @return The current sensor value or ``PROS_ERR``.
    */
   double controllerGet() override;
-
-  protected:
-  std::uint8_t port;
-  IMUAxes axis;
-
-  /**
-   * Get the current rotation about `iaxis` from the IMU. The internal offset is not accounted for.
-   *
-   * This may set the following values of `errno` on error:
-   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
-   * - `ENODEV` - The port cannot be configured as an IMU.
-   * - `EAGAIN` - The sensor is calibrating.
-   *
-   * @return The current sensor value or `PROS_ERR`.
-   */
-  double readAngle() const;
 
   /**
    * @return Whether the IMU is calibrating.
    */
   bool isCalibrating() const;
 
-  private:
+  protected:
+  std::uint8_t port;
+  IMUAxes axis;
   double offset = 0;
+
+  /**
+   * Get the current rotation about the configured axis. The internal offset is not accounted for
+   * or modified. This just reads from the sensor.
+   *
+   * @return The current sensor value or ``PROS_ERR``.
+   */
+  double readAngle() const;
 };
 } // namespace okapi

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -21,59 +21,60 @@ enum class IMUAxes {
 class IMU : public ContinuousRotarySensor {
   public:
   /**
-   * An inertial sensor on the given port.  The IMU returns an angle
-   * about the selected axis in degrees.
+   * An inertial sensor on the given port. The IMU returns an angle about the selected axis in
+   * degrees.
    *
-   * @param iport: The port to use the inertial sensor from
-   * @param iaxis: The axis of the inertial sensor to measure, default z
+   * @param iport The port to use the inertial sensor from.
+   * @param iaxis The axis of the inertial sensor to measure, default `IMUAxes::z`.
    */
   IMU(std::uint8_t iport, IMUAxes iaxis = IMUAxes::z);
 
   virtual ~IMU();
 
   /**
-   * Get the current rotation about iaxis.
+   * Get the current rotation about `iaxis`.
    *
-   *@return the current sensor value or one of the following values of `errno`
-   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-   * `ENODEV` - the port cannot be configured as an IMU
-   * `EAGAIN` - the sensor is calibrating
+   * @return The current sensor value or one of the following values of `errno`:
+   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
+   * - `ENODEV` - The port cannot be configured as an IMU.
+   * - `EAGAIN` - The sensor is calibrating.
    */
   double get() const override;
 
   /**
-   * Get the current sensor value remapped into the target range ([1800, -1800] by default).
+   * Get the current sensor value remapped into the target range (`[1800, -1800]` by default).
    *
-   * @param iupperBound the upper bound of the range.
-   * @param ilowerBound the lower bound of the range.
-   * @return the remapped sensor value.
+   * @param iupperBound The upper bound of the range.
+   * @param ilowerBound The lower bound of the range.
+   * @return The remapped sensor value.
    */
   double getRemapped(double iupperBound = 1800, double ilowerBound = -1800) const;
 
   /**
-   * Get the current acceleration along iaxis.
+   * Get the current acceleration along `iaxis`.
    *
-   *@return the current sensor value or one of the following values of `errno`
-   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-   * `ENODEV` - the port cannot be configured as an IMU
-   * `EAGAIN` - the sensor is calibrating
+   * @return The current sensor value or one of the following values of `errno`:
+   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
+   * - `ENODEV` - The port cannot be configured as an IMU.
+   * - `EAGAIN` - The sensor is calibrating.
    */
   double getAcceleration();
 
   /**
-   * Reset the sensor to zero.
+   * Reset the rotation value to zero.
    *
-   * @return `1` on success
+   * @return This always returns `1`.
    */
   std::int32_t reset() override;
 
   /**
-   * Calibrate the IMU. Reset rotation value to `0`.
+   * Calibrate the IMU. Resets the rotation value to zero. Calibration is expected to take two
+   * seconds, but is bounded to five seconds.
    *
-   * @return `1` on success, or one of the following values of `errno`
-   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-   * `ENODEV` - the port cannot be configured as an IMU
-   * `EAGAIN` - the sensor is calibrating
+   * @return `1` on success, or one of the following values of `errno`:
+   * - `ENXIO` - The given `iport` is not in range of the V5 ports (1-21).
+   * - `ENODEV` - The port cannot be configured as an IMU.
+   * - `EAGAIN` - The sensor is calibrating or timed out calibrating.
    */
   std::int32_t calibrate();
 
@@ -82,27 +83,32 @@ class IMU : public ContinuousRotarySensor {
    * another thread by the controller.
    *
    * @return the current sensor value, or one of the following values of `errno`
-   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-   * `ENODEV` - the port cannot be configured as an IMU
-   * `EAGAIN` - the sensor is calibrating
+   * - `ENXIO` - The given iport is not in range of the V5 ports (1-21).
+   * - `ENODEV` - The port cannot be configured as an IMU.
+   * - `EAGAIN` - The sensor is calibrating.
    */
   double controllerGet() override;
-
-  private:
-  double offset = 0;
-
-  /**
-   * Get the current rotation about iaxis from the IMU. `Offset` is not considered.
-   *
-   *@return the current sensor value or one of the following values of `errno`
-   * `ENXIO` - the given iport is not in range of the V5 ports (1-21)
-   * `ENODEV` - the port cannot be configured as an IMU
-   * `EAGAIN` - the sensor is calibrating
-   */
-  double readAngle() const;
 
   protected:
   std::uint8_t port;
   IMUAxes axis;
+
+  /**
+   * Get the current rotation about `iaxis` from the IMU. The internal offset is not accounted for.
+   *
+   *@return the current sensor value or one of the following values of `errno`
+   * - `ENXIO` - The given iport is not in range of the V5 ports (1-21).
+   * - `ENODEV` - The port cannot be configured as an IMU.
+   * - `EAGAIN` - The sensor is calibrating.
+   */
+  double readAngle() const;
+
+  /**
+   * @return Whether the IMU is calibrating.
+   */
+  bool isCalibrating() const;
+
+  private:
+  double offset = 0;
 };
 } // namespace okapi

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -27,7 +27,7 @@ class IMU : public ContinuousRotarySensor {
    * auto imuX = IMU(1, IMUAxes::x);
    * ```
    *
-   * @param iport The port to use the inertial sensor from.
+   * @param iport The port number in the range ``[1, 21]``.
    * @param iaxis The axis of the inertial sensor to measure, default `IMUAxes::z`.
    */
   IMU(std::uint8_t iport, IMUAxes iaxis = IMUAxes::z);
@@ -49,9 +49,9 @@ class IMU : public ContinuousRotarySensor {
   double getRemapped(double iupperBound = 1800, double ilowerBound = -1800) const;
 
   /**
-   * Get the current acceleration along `iaxis`.
+   * Get the current acceleration along the configured axis.
    *
-   * @return The current sensor value or `PROS_ERR`.
+   * @return The current sensor value or ``PROS_ERR``.
    */
   double getAcceleration() const;
 

--- a/include/okapi/impl/device/rotarysensor/adiGyro.hpp
+++ b/include/okapi/impl/device/rotarysensor/adiGyro.hpp
@@ -53,7 +53,7 @@ class ADIGyro : public ContinuousRotarySensor {
   double get() const override;
 
   /**
-   * Get the current sensor value remapped into the target range ([-1800, 1800] by default).
+   * Get the current sensor value remapped into the target range (``[-1800, 1800]`` by default).
    *
    * @param iupperBound the upper bound of the range.
    * @param ilowerBound the lower bound of the range.

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -79,7 +79,8 @@ std::int32_t IMU::calibrate() {
     return 1;
   } else {
     // We timed out
-    return EAGAIN;
+    errno = EAGAIN;
+    return PROS_ERR;
   }
 }
 

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include "okapi/impl/device/rotarysensor/IMU.hpp"
-#include "okapi/api/util/mathUtil.hpp"
+#include "okapi/api/odometry/odomMath.hpp"
 
 namespace okapi {
 IMU::IMU(const std::uint8_t iport, const IMUAxes iaxis) : port(iport), axis(iaxis) {
@@ -19,9 +19,7 @@ double IMU::get() const {
     return PROS_ERR;
   }
 
-  if (angle > 180 || angle < -180) {
-    angle += std::copysign(360, offset);
-  }
+  angle = OdomMath::constrainAngle180(angle * degree).convert(degree);
 
   return angle;
 }

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -9,7 +9,7 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-IMU::IMU(std::uint8_t iport, IMUAxes iaxis):port(iport),axis(iaxis) {
+IMU::IMU(std::uint8_t iport, IMUAxes iaxis) : port(iport), axis(iaxis) {
 }
 
 IMU::~IMU() = default;
@@ -17,20 +17,20 @@ IMU::~IMU() = default;
 double IMU::get() const {
   pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
   static double angle = 0;
-  switch(axis) {
-    case IMUAxes::x:
+  switch (axis) {
+  case IMUAxes::x:
     angle = eu.roll;
     break;
-    case IMUAxes::y:
+  case IMUAxes::y:
     angle = eu.pitch;
     break;
-    case IMUAxes::z:
+  case IMUAxes::z:
     angle = eu.yaw;
     break;
   }
-  angle += offset;
-  if(angle > 180 || angle < -180) {
-    angle += -360 * (offset/std::abs(offset));
+  angle -= offset;
+  if (angle > 180 || angle < -180) {
+    angle += 360 * (offset / std::abs(offset));
   }
   return angle;
 }
@@ -41,16 +41,16 @@ double IMU::getRemapped(const double iupperBound, const double ilowerBound) cons
   return remapRange(value, -180, 180, ilowerBound, iupperBound);
 }
 
-double IMU::getAcc() {
+double IMU::getAcceleration() {
   pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
-  switch(axis) {
-    case IMUAxes::x:
+  switch (axis) {
+  case IMUAxes::x:
     return accel.x;
     break;
-    case IMUAxes::y:
+  case IMUAxes::y:
     return accel.y;
     break;
-    case IMUAxes::z:
+  case IMUAxes::z:
     return accel.z;
     break;
   }
@@ -58,14 +58,15 @@ double IMU::getAcc() {
 }
 
 std::int32_t IMU::reset() {
-  const auto value = get() - offset;
-  offset = -1 * value;
+  offset = 0;
+  offset = get();
 
   return 1;
 }
 
 std::int32_t IMU::calibrate() {
   std::int32_t result = pros::c::imu_reset(port);
+  offset = 0;
   pros::delay(2100);
   return result;
 }

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -12,8 +12,6 @@ namespace okapi {
 IMU::IMU(const std::uint8_t iport, const IMUAxes iaxis) : port(iport), axis(iaxis) {
 }
 
-IMU::~IMU() = default;
-
 double IMU::get() const {
   double angle = readAngle() - offset;
 
@@ -38,7 +36,7 @@ double IMU::getRemapped(const double iupperBound, const double ilowerBound) cons
   return remapRange(get(), -180, 180, ilowerBound, iupperBound);
 }
 
-double IMU::getAcceleration() {
+double IMU::getAcceleration() const {
   const pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
 
   switch (axis) {

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -1,6 +1,4 @@
 /*
- * @author Alex Riensche, UNL
- *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,15 +11,14 @@ IMU::IMU(const std::uint8_t iport, const IMUAxes iaxis) : port(iport), axis(iaxi
 }
 
 double IMU::get() const {
-  double angle = readAngle() - offset;
+  const double angle = readAngle();
 
   if (angle == PROS_ERR) {
     return PROS_ERR;
   }
 
-  angle = OdomMath::constrainAngle180(angle * degree).convert(degree);
-
-  return angle;
+  // Account for the offset after checking for PROS_ERR
+  return OdomMath::constrainAngle180((angle - offset) * degree).convert(degree);
 }
 
 double IMU::getRemapped(const double iupperBound, const double ilowerBound) const {
@@ -46,12 +43,17 @@ double IMU::getAcceleration() const {
     return accel.z;
   }
 
-  return -1;
+  // This should not run
+  return PROS_ERR;
 }
 
 std::int32_t IMU::reset() {
   offset = readAngle();
-  return 1;
+  if (offset == PROS_ERR) {
+    return PROS_ERR;
+  } else {
+    return 1;
+  }
 }
 
 std::int32_t IMU::calibrate() {

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -17,6 +17,10 @@ IMU::~IMU() = default;
 double IMU::get() const {
   double angle = readAngle() - offset;
 
+  if (angle == PROS_ERR) {
+    return PROS_ERR;
+  }
+
   if (angle > 180 || angle < -180) {
     angle += std::copysign(360, offset);
   }
@@ -25,11 +29,17 @@ double IMU::get() const {
 }
 
 double IMU::getRemapped(const double iupperBound, const double ilowerBound) const {
+  const double value = get();
+
+  if (value == PROS_ERR) {
+    return PROS_ERR;
+  }
+
   return remapRange(get(), -180, 180, ilowerBound, iupperBound);
 }
 
 double IMU::getAcceleration() {
-  pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
+  const pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
 
   switch (axis) {
   case IMUAxes::x:
@@ -49,11 +59,11 @@ std::int32_t IMU::reset() {
 }
 
 std::int32_t IMU::calibrate() {
-  std::int32_t result = pros::c::imu_reset(port);
+  const std::int32_t result = pros::c::imu_reset(port);
 
   // Don't reset the offset or wait for calibration if the reset failed
   if (result == PROS_ERR) {
-    return errno;
+    return PROS_ERR;
   }
 
   offset = 0;
@@ -82,7 +92,7 @@ double IMU::controllerGet() {
 }
 
 double IMU::readAngle() const {
-  pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
+  const pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
   double angle = 0;
 
   switch (axis) {

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -15,23 +15,12 @@ IMU::IMU(std::uint8_t iport, IMUAxes iaxis) : port(iport), axis(iaxis) {
 IMU::~IMU() = default;
 
 double IMU::get() const {
-  pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
-  static double angle = 0;
-  switch (axis) {
-  case IMUAxes::x:
-    angle = eu.roll;
-    break;
-  case IMUAxes::y:
-    angle = eu.pitch;
-    break;
-  case IMUAxes::z:
-    angle = eu.yaw;
-    break;
-  }
-  angle -= offset;
+  double angle = readAngle() - offset;
+
   if (angle > 180 || angle < -180) {
     angle += 360 * (offset / std::abs(offset));
   }
+
   return angle;
 }
 
@@ -54,12 +43,12 @@ double IMU::getAcceleration() {
     return accel.z;
     break;
   }
+
   return -1;
 }
 
 std::int32_t IMU::reset() {
-  offset = 0;
-  offset = get();
+  offset = readAngle();
 
   return 1;
 }
@@ -73,6 +62,25 @@ std::int32_t IMU::calibrate() {
 
 double IMU::controllerGet() {
   return get();
+}
+
+double IMU::readAngle() const {
+  pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
+  double angle = 0;
+
+  switch (axis) {
+  case IMUAxes::x:
+    angle = eu.roll;
+    break;
+  case IMUAxes::y:
+    angle = eu.pitch;
+    break;
+  case IMUAxes::z:
+    angle = eu.yaw;
+    break;
+  }
+
+  return angle;
 }
 
 } // namespace okapi

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -1,0 +1,77 @@
+/*
+ * @author Alex Riensche, UNL
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "okapi/impl/device/rotarysensor/IMU.hpp"
+#include "okapi/api/util/mathUtil.hpp"
+
+namespace okapi {
+IMU::IMU(std::uint8_t iport, IMUAxes iaxis):port(iport),axis(iaxis) {
+}
+
+IMU::~IMU() = default;
+
+double IMU::get() const {
+  pros::c::euler_s_t eu = pros::c::imu_get_euler(port);
+  static double angle = 0;
+  switch(axis) {
+    case IMUAxes::x:
+    angle = eu.roll;
+    break;
+    case IMUAxes::y:
+    angle = eu.pitch;
+    break;
+    case IMUAxes::z:
+    angle = eu.yaw;
+    break;
+  }
+  angle += offset;
+  if(angle > 180 || angle < -180) {
+    angle += -360 * (offset/std::abs(offset));
+  }
+  return angle;
+}
+
+double IMU::getRemapped(const double iupperBound, const double ilowerBound) const {
+  double value = get();
+
+  return remapRange(value, -180, 180, ilowerBound, iupperBound);
+}
+
+double IMU::getAcc() {
+  pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
+  switch(axis) {
+    case IMUAxes::x:
+    return accel.x;
+    break;
+    case IMUAxes::y:
+    return accel.y;
+    break;
+    case IMUAxes::z:
+    return accel.z;
+    break;
+  }
+  return -1;
+}
+
+std::int32_t IMU::reset() {
+  const auto value = get() - offset;
+  offset = -1 * value;
+
+  return 1;
+}
+
+std::int32_t IMU::calibrate() {
+  std::int32_t result = pros::c::imu_reset(port);
+  pros::delay(2100);
+  return result;
+}
+
+double IMU::controllerGet() {
+  return get();
+}
+
+} // namespace okapi

--- a/src/impl/device/rotarysensor/IMU.cpp
+++ b/src/impl/device/rotarysensor/IMU.cpp
@@ -9,7 +9,7 @@
 #include "okapi/api/util/mathUtil.hpp"
 
 namespace okapi {
-IMU::IMU(std::uint8_t iport, IMUAxes iaxis) : port(iport), axis(iaxis) {
+IMU::IMU(const std::uint8_t iport, const IMUAxes iaxis) : port(iport), axis(iaxis) {
 }
 
 IMU::~IMU() = default;
@@ -18,30 +18,26 @@ double IMU::get() const {
   double angle = readAngle() - offset;
 
   if (angle > 180 || angle < -180) {
-    angle += 360 * (offset / std::abs(offset));
+    angle += std::copysign(360, offset);
   }
 
   return angle;
 }
 
 double IMU::getRemapped(const double iupperBound, const double ilowerBound) const {
-  double value = get();
-
-  return remapRange(value, -180, 180, ilowerBound, iupperBound);
+  return remapRange(get(), -180, 180, ilowerBound, iupperBound);
 }
 
 double IMU::getAcceleration() {
   pros::c::imu_accel_s_t accel = pros::c::imu_get_accel(port);
+
   switch (axis) {
   case IMUAxes::x:
     return accel.x;
-    break;
   case IMUAxes::y:
     return accel.y;
-    break;
   case IMUAxes::z:
     return accel.z;
-    break;
   }
 
   return -1;
@@ -49,15 +45,36 @@ double IMU::getAcceleration() {
 
 std::int32_t IMU::reset() {
   offset = readAngle();
-
   return 1;
 }
 
 std::int32_t IMU::calibrate() {
   std::int32_t result = pros::c::imu_reset(port);
+
+  // Don't reset the offset or wait for calibration if the reset failed
+  if (result == PROS_ERR) {
+    return errno;
+  }
+
   offset = 0;
-  pros::delay(2100);
-  return result;
+
+  // This operation should take approximately two seconds, so wait two seconds and then wait for it
+  // to finish. We bound the maximum delay time to ensure that this function does not hang
+  // indefinitely.
+  const uint32_t maxDelayTime = 5000;
+  const uint32_t before = pros::millis();
+  pros::delay(2000);
+  while (isCalibrating() && pros::millis() - before < maxDelayTime) {
+    pros::delay(10);
+  }
+
+  if (pros::millis() - before < maxDelayTime) {
+    // We did not timeout
+    return 1;
+  } else {
+    // We timed out
+    return EAGAIN;
+  }
 }
 
 double IMU::controllerGet() {
@@ -83,4 +100,7 @@ double IMU::readAngle() const {
   return angle;
 }
 
+bool IMU::isCalibrating() const {
+  return pros::c::imu_get_status(port) & pros::c::E_IMU_STATUS_CALIBRATING;
+}
 } // namespace okapi


### PR DESCRIPTION
### Description of the Change

Adds a new wrapper class derived from ContinuousRotarySensor for the V5 IMU. The constructor accepts a V5 port number and an enum axis definition to measure. The z(yaw) axis is configured as default. All axes return an angle in the range of -180 to 180, much like the existing ADIgyro class does. To measure more axes, separate IMU instances should be made by the user.

As suggested in the issue, a value, "offset" is used to reset the sensor. The PROS API does not allow for an easy zero process, so the `IMU::reset()` command will change the offset parameter to match the current measured angle. In the event of an `IMU::get()` command occurs outside the range of -180 to 180, the offset is inverted by adding -360*(offset/sign(offset)) to the original offset. 

Because the reset command does not calibrate the IMU, I added an `IMU::calibrate()` method. The constructor does not call this as the v5 port is automatically configured and is calibrated on brain startup. Any further calibration should be controlled by the user.

Because the IMU is an accelerometer as well as a gyro, I added an `IMU::getAccl()` command to retreive the acceleration value along the instanced axis.

### Motivation

Adding a wrapper class for the IMU will allow it to be integrated into odometry and chassis models at a later date. Implementing the sensor within okapi allows users to program their robot using the same namespace.

### Possible Drawbacks

The V5 IMU chooses one of 6 orientations based on the calibration process, then assigns the XYZ axes accordingly. I am unsure how/if this should be documented.

### Verification Process

I placed the IMU on a robot chassis read the gyro data using the PROSC API and the new IMU class. Both classes returned the same euler angles.

To test the reset function, I set the IMU to measure robot yaw. I started the program, and rotated the chassis 90 degrees, after which I pressed a button on my controller which was set to run the reset function. After doing so, the robot continued to read -180 to 180 with the 0 now located at the original 90 degrees. 

### Applicable Issues

Closes #444
