### PR TITLE
CrossplatformThread double delete

### DIFF
--- a/include/okapi/api/coreProsAPI.hpp
+++ b/include/okapi/api/coreProsAPI.hpp
@@ -60,7 +60,9 @@ class CrossplatformThread {
 #ifdef THREADS_STD
     thread.join();
 #else
-    pros::c::task_delete(thread);
+    if (pros::c::task_get_state(thread) != pros::E_TASK_STATE_DELETED) {
+      pros::c::task_delete(thread);
+    }
 #endif
   }
 


### PR DESCRIPTION
### Description of the Change

When a task callback returns, it looks like RTOS deletes the task. Therefore, when a `CrossplatformThread` is destructed, and the task callback has already returned, it is deleting an already deleted task. This causes a segfault. 

### Motivation

Segfaults are bad, though I think this situation is fairly rare: a short-lived task being held by a CrossPlatformThread that will be destructed before program end.

### Possible Drawbacks

It's possible that `STATE_INVALID` might also need to be checked on, but I don't think so.

### Verification Process

This causes the unit tests in my own code to pass and not segfault. This is only reproducible on the V5 brain, std::threads behave better when double deleted (or they aren't deleted when the callback ends). 

Otherwise my code works fine and CrossplatformThread still works.

### Example

This segfaults:

```cpp
void initialize() {
        CrossplatformThread c([](void*){std::cout << "i am a fickle task" << std::endl;}, nullptr);
        pros::delay(500);
}
```