### PR TITLE
use odom gearset/drivescales when available

### DIFF
--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -78,8 +78,8 @@ ChassisControllerBuilder()
 
 ```cpp
 ChassisControllerBuilder()
-    // Green gearset, external ratio of (2.0 / 3.0), 4 inch wheel diameter, 11.5 inch wheelbase
-    .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR * (2.0 / 3.0)})
+    // Green gearset, external ratio of (36.0 / 60.0), 4 inch wheel diameter, 11.5 inch wheelbase
+    .withDimensions({AbstractMotor::gearset::green, (36.0 / 60.0)}, {{4_in, 11.5_in}, imev5GreenTPR})
 ```
 
 ### Gearset and raw scales:

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -318,7 +318,7 @@ class ChassisControllerBuilder {
    * @param iscales The ChassisScales for the base.
    * @return An ongoing builder.
    */
-  ChassisControllerBuilder &withDimensions(const AbstractMotor::gearset &igearset,
+  ChassisControllerBuilder &withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
                                            const ChassisScales &iscales);
 
   /**
@@ -474,7 +474,7 @@ class ChassisControllerBuilder {
   TimeUtilFactory closedLoopControllerTimeUtilFactory = TimeUtilFactory();
   TimeUtilFactory odometryTimeUtilFactory = TimeUtilFactory();
 
-  AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid};
+  AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid,1.0};
   ChassisScales driveScales{{1, 1}, imev5GreenTPR};
   bool differentOdomScales{false};
   ChassisScales odomScales{{1, 1}, imev5GreenTPR};

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -118,6 +118,7 @@ void ChassisControllerPID::trampoline(void *context) {
 
 void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   LOG_INFO("ChassisControllerPID: moving " + std::to_string(itarget.convert(meter)) + " meters");
+  LOG_DEBUG("ChassisControllerPID: straight " + std::to_string(scales.straight) + " ratio " + std::to_string(gearsetRatioPair.ratio));
 
   distancePid->reset();
   anglePid->reset();
@@ -126,7 +127,7 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   turnPid->flipDisable(true);
   mode = distance;
 
-  const double newTarget = itarget.convert(meter) * scales.straight * gearsetRatioPair.ratio;
+  const double newTarget = itarget.convert(meter) * scales.straight;
 
   LOG_INFO("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor ticks");
 
@@ -155,6 +156,7 @@ void ChassisControllerPID::moveRaw(const double itarget) {
 void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   LOG_INFO("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
            " degrees");
+  LOG_DEBUG("ChassisControllerPID: straight " + std::to_string(scales.turn) + " ratio " + std::to_string(gearsetRatioPair.ratio));
 
   turnPid->reset();
   turnPid->flipDisable(false);
@@ -163,7 +165,7 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   mode = angle;
 
   const double newTarget =
-    idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
+    idegTarget.convert(degree) * scales.turn * boolToSign(normalTurns);
 
   LOG_INFO("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor ticks");
 

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -32,7 +32,6 @@ ChassisControllerPID::ChassisControllerPID(
     LOG_ERROR(msg);
     throw std::invalid_argument(msg);
   }
-
   chassisModel->setGearing(igearset.internalGearset);
   chassisModel->setEncoderUnits(AbstractMotor::encoderUnits::counts);
 }
@@ -127,7 +126,7 @@ void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   turnPid->flipDisable(true);
   mode = distance;
 
-  const double newTarget = itarget.convert(meter) * scales.straight;
+  const double newTarget = itarget.convert(meter) * scales.straight * gearsetRatioPair.ratio;
 
   LOG_INFO("ChassisControllerPID: moving " + std::to_string(newTarget) + " motor ticks");
 
@@ -156,7 +155,7 @@ void ChassisControllerPID::moveRaw(const double itarget) {
 void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   LOG_INFO("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
            " degrees");
-  LOG_DEBUG("ChassisControllerPID: straight " + std::to_string(scales.turn) + " ratio " + std::to_string(gearsetRatioPair.ratio));
+  LOG_DEBUG("ChassisControllerPID: scales.turn " + std::to_string(scales.turn) + " ratio " + std::to_string(gearsetRatioPair.ratio));
 
   turnPid->reset();
   turnPid->flipDisable(false);
@@ -165,7 +164,7 @@ void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   mode = angle;
 
   const double newTarget =
-    idegTarget.convert(degree) * scales.turn * boolToSign(normalTurns);
+    idegTarget.convert(degree) * scales.turn * gearsetRatioPair.ratio * boolToSign(normalTurns);
 
   LOG_INFO("ChassisControllerPID: turning " + std::to_string(newTarget) + " motor ticks");
 

--- a/src/api/control/async/asyncPosIntegratedController.cpp
+++ b/src/api/control/async/asyncPosIntegratedController.cpp
@@ -50,7 +50,7 @@ double AsyncPosIntegratedController::getProcessValue() const {
 }
 
 double AsyncPosIntegratedController::getError() const {
-  return (lastTarget + offset) - getProcessValue() / pair.ratio;
+  return (lastTarget + offset) - (getProcessValue() / pair.ratio);
 }
 
 bool AsyncPosIntegratedController::isSettled() {

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -267,12 +267,13 @@ ChassisControllerBuilder::withOdometry(std::shared_ptr<Odometry> iodometry,
 }
 
 ChassisControllerBuilder &
-ChassisControllerBuilder::withDimensions(const AbstractMotor::gearset &igearset,
+ChassisControllerBuilder::withDimensions(const AbstractMotor::GearsetRatioPair &igearset,
                                          const ChassisScales &iscales) {
-  gearset = igearset;
+  gearset.internalGearset = igearset.internalGearset;
+  gearset.ratio = igearset.ratio;
 
   if (!maxVelSetByUser) {
-    maxVelocity = toUnderlyingType(igearset);
+    maxVelocity = toUnderlyingType(igearset.internalGearset);
   }
 
   driveScales = iscales;
@@ -464,16 +465,19 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
     break;
   }
 
+  // The chassis controller will handle the conversion of distance to motor
+  // position in terms of external gear ratio, so the controllers should
+  // be set to a ratio of 1.0
   return std::make_shared<ChassisControllerIntegrated>(
     chassisControllerTimeUtilFactory.create(),
     makeChassisModel(),
     std::make_unique<AsyncPosIntegratedController>(leftMotorGroup,
-                                                   gearset,
+                                                   AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
                                                    maxVelocity,
                                                    closedLoopControllerTimeUtilFactory.create(),
                                                    controllerLogger),
     std::make_unique<AsyncPosIntegratedController>(rightMotorGroup,
-                                                   gearset,
+                                                   AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
                                                    maxVelocity,
                                                    closedLoopControllerTimeUtilFactory.create(),
                                                    controllerLogger),

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -414,6 +414,12 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
 }
 
 std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
+  if(differentOdomScales) {
+    // The chassis controller is going to multiply by the gearset ratio, but
+    // since the odometry wheels are directly driven, we need to back this out here
+    odomScales.straight = odomScales.straight / gearset.ratio;
+    odomScales.turn = odomScales.turn / gearset.ratio;
+  }
   auto out = std::make_shared<ChassisControllerPID>(
     chassisControllerTimeUtilFactory.create(),
     makeChassisModel(),

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -413,6 +413,12 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
 }
 
 std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
+  auto ccGearset = gearset;
+  auto ccDriveScales = driveScales;
+  if(differentOdomScales) {
+    ccDriveScales = odomScales;
+    ccGearset = AbstractMotor::gearset::green;
+  }
   auto out = std::make_shared<ChassisControllerPID>(
     chassisControllerTimeUtilFactory.create(),
     makeChassisModel(),
@@ -428,8 +434,8 @@ std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
                                                 closedLoopControllerTimeUtilFactory.create(),
                                                 std::move(angleFilter),
                                                 controllerLogger),
-    gearset,
-    driveScales,
+    ccGearset,
+    ccDriveScales,
     controllerLogger);
 
   out->startThread();
@@ -442,6 +448,12 @@ std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
 }
 
 std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI() {
+  auto ccGearset = gearset;
+  auto ccDriveScales = driveScales;
+  if(differentOdomScales) {
+    ccDriveScales = odomScales;
+    ccGearset = AbstractMotor::gearset::green;
+  }
   std::shared_ptr<AbstractMotor> leftMotorGroup;
   std::shared_ptr<AbstractMotor> rightMotorGroup;
 
@@ -477,8 +489,8 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
                                                    maxVelocity,
                                                    closedLoopControllerTimeUtilFactory.create(),
                                                    controllerLogger),
-    gearset,
-    driveScales,
+    ccGearset,
+    ccDriveScales,
     controllerLogger);
 }
 

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -413,12 +413,6 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
 }
 
 std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
-  auto ccGearset = gearset;
-  auto ccDriveScales = driveScales;
-  if(differentOdomScales) {
-    ccDriveScales = odomScales;
-    ccGearset = AbstractMotor::gearset::green;
-  }
   auto out = std::make_shared<ChassisControllerPID>(
     chassisControllerTimeUtilFactory.create(),
     makeChassisModel(),
@@ -434,8 +428,8 @@ std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
                                                 closedLoopControllerTimeUtilFactory.create(),
                                                 std::move(angleFilter),
                                                 controllerLogger),
-    ccGearset,
-    ccDriveScales,
+    gearset,
+    odomScales,
     controllerLogger);
 
   out->startThread();
@@ -448,12 +442,6 @@ std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
 }
 
 std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI() {
-  auto ccGearset = gearset;
-  auto ccDriveScales = driveScales;
-  if(differentOdomScales) {
-    ccDriveScales = odomScales;
-    ccGearset = AbstractMotor::gearset::green;
-  }
   std::shared_ptr<AbstractMotor> leftMotorGroup;
   std::shared_ptr<AbstractMotor> rightMotorGroup;
 
@@ -489,8 +477,8 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
                                                    maxVelocity,
                                                    closedLoopControllerTimeUtilFactory.create(),
                                                    controllerLogger),
-    ccGearset,
-    ccDriveScales,
+    gearset,
+    driveScales,
     controllerLogger);
 }
 


### PR DESCRIPTION
### Description of the Change

When using geared drivetrains and odom, the odom drivescales are not used, leading to inaccurate movements

### Motivation

Correct behavior described above

### Possible Drawbacks

N/A

### Verification Process

Physical test

### Applicable Issues

Fixes #462
