### PR TITLE
Fix tutorials to use "wheel track" instead of "wheelbase"

### DIFF
--- a/docs/tutorials/walkthrough/chassisControllerBuilder.md
+++ b/docs/tutorials/walkthrough/chassisControllerBuilder.md
@@ -70,7 +70,7 @@ wheels those encoders are attached to. Otherwise, `withDimensions` will refer to
 
 ```cpp
 ChassisControllerBuilder()
-    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
 ```
 
@@ -78,7 +78,7 @@ ChassisControllerBuilder()
 
 ```cpp
 ChassisControllerBuilder()
-    // Green gearset, external ratio of (36.0 / 60.0), 4 inch wheel diameter, 11.5 inch wheelbase
+    // Green gearset, external ratio of (36.0 / 60.0), 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions({AbstractMotor::gearset::green, (36.0 / 60.0)}, {{4_in, 11.5_in}, imev5GreenTPR})
 ```
 
@@ -130,7 +130,7 @@ to [withOdometry](@ref okapi::ChassisControllerBuilder::withOdometry).
 ```cpp
 ChassisControllerBuilder()
     .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withOdometry() // Use the same scales as the chassis (above)
     .buildOdometry()
@@ -151,7 +151,7 @@ dimensions will be different than the ones given to
 ```cpp
 ChassisControllerBuilder()
     .withMotors(1, -2) // Left motor is 1, right motor is 2 (reversed)
-    // Green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // Green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withSensors(
         ADIEncoder{'A', 'B'}, // Left encoder in ADI ports A & B

--- a/docs/tutorials/walkthrough/odometry.md
+++ b/docs/tutorials/walkthrough/odometry.md
@@ -28,7 +28,7 @@ Here is an example using [ChassisControllerIntegrated](@ref okapi::ChassisContro
 ```cpp
 ChassisControllerBuilder()
     .withMotors(1, -2) // left motor is 1, right motor is 2 (reversed)
-    // green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withOdometry() // use the same scales as the chassis (above)
     .buildOdometry(); // build an odometry chassis
@@ -44,7 +44,7 @@ ChassisControllerBuilder()
         {0.001, 0, 0.0001}, // Turn controller gains
         {0.001, 0, 0.0001}  // Angle controller gains (helps drive straight)
     )
-    // green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withOdometry() // use the same scales as the chassis (above)
     .buildOdometry(); // build an odometry chassis
@@ -63,7 +63,7 @@ to specify the scales for the tracking wheels.
 ```cpp
 ChassisControllerBuilder()
     .withMotors(1, -2) // left motor is 1, right motor is 2 (reversed)
-    // green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withSensors(
         ADIEncoder{'A', 'B'}, // left encoder in ADI ports A & B
@@ -104,7 +104,7 @@ Here is an example using [ChassisControllerIntegrated](@ref okapi::ChassisContro
 ```cpp
 ChassisControllerBuilder()
     .withMotors(1, -2) // left motor is 1, right motor is 2 (reversed)
-    // green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     .withSensors(
         ADIEncoder{'A', 'B'}, // left encoder in ADI ports A & B
@@ -190,7 +190,7 @@ Here is is a full example of odometry using [ChassisControllerIntegrated](@ref o
 std::shared_ptr<OdomChassisController> chassis =
   ChassisControllerBuilder()
     .withMotors(1, -2) // left motor is 1, right motor is 2 (reversed)
-    // green gearset, 4 inch wheel diameter, 11.5 inch wheelbase
+    // green gearset, 4 inch wheel diameter, 11.5 inch wheel track
     .withDimensions(AbstractMotor::gearset::green, {{4_in, 11.5_in}, imev5GreenTPR})
     // left encoder in ADI ports A & B, right encoder in ADI ports C & D (reversed)
     .withSensors(ADIEncoder{'A', 'B'}, ADIEncoder{'C', 'D', true})


### PR DESCRIPTION
### Description of the Change

Fix the Chassis Controller Builder and Odometry tutorials to correctly refer to the width dimension as the wheel track instead of the wheelbase.  The other tutorials do not have this issue.

### Motivation

Referring to the width dimension as the wheelbase may confuse or mislead readers.

### Possible Drawbacks

None

### Verification Process

### Applicable Issues
