### PR TITLE
Change .gitmodules URL to HTTPS from git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = https://github.com/eranpeer/FakeIt.git
 [submodule "m.css"]
 	path = m.css
-	url = git://github.com/mosra/m.css
+	url = https://github.com/mosra/m.css.git


### PR DESCRIPTION
GitHub deprecated the git:// protocol on Jan 11, 2022. Since then, CI runs and submodule updates just timeout because the URL cannot be found.

Before this: https://github.com/karmanyaahm/OkapiLib/runs/6540663229?check_suite_focus=true
After this: https://github.com/karmanyaahm/OkapiLib/runs/6540786827?check_suite_focus=true
(the run still fails because I don't have code coverage credentials, but the main test part works)

Source: https://github.blog/2021-09-01-improving-git-protocol-security-github/.
