### PR TITLE
Add curvature drive

### DIFF
--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -127,7 +127,7 @@
 #include "okapi/api/util/mathUtil.hpp"
 #include "okapi/api/util/supplier.hpp"
 #include "okapi/api/util/timeUtil.hpp"
+#include "okapi/impl/util/configurableTimeUtilFactory.hpp"
 #include "okapi/impl/util/rate.hpp"
 #include "okapi/impl/util/timeUtilFactory.hpp"
 #include "okapi/impl/util/timer.hpp"
-#include "okapi/impl/util/configurableTimeUtilFactory.hpp"

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -85,8 +85,8 @@ class ChassisModel : public ReadOnlyChassisModel {
 
   /**
    * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
-   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
-   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous
+   * because the forward speed will not affect the rate of turning. The algorithm switches to
    * arcade if the forward speed is 0. Uses voltage mode.
    *
    * @param iforwardSpeed speed in the forward direction

--- a/include/okapi/api/chassis/model/chassisModel.hpp
+++ b/include/okapi/api/chassis/model/chassisModel.hpp
@@ -84,6 +84,18 @@ class ChassisModel : public ReadOnlyChassisModel {
   virtual void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) = 0;
 
   /**
+   * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
+   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * arcade if the forward speed is 0. Uses voltage mode.
+   *
+   * @param iforwardSpeed speed in the forward direction
+   * @param icurvature curvature (inverse of radius) to drive in
+   * @param ithreshold deadband on joystick values
+   */
+  virtual void curvature(double iforwardSpeed, double icurvature, double ithreshold = 0) = 0;
+
+  /**
    * Power the left side motors. Uses velocity mode.
    *
    * @param ipower motor power

--- a/include/okapi/api/chassis/model/hDriveModel.hpp
+++ b/include/okapi/api/chassis/model/hDriveModel.hpp
@@ -102,8 +102,8 @@ class HDriveModel : public ChassisModel {
 
   /**
    * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
-   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
-   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous
+   * because the forward speed will not affect the rate of turning. The algorithm switches to
    * arcade if the forward speed is 0. Uses voltage mode. Sets the middle motor to zero velocity.
    *
    * @param iforwardSpeed speed in the forward direction

--- a/include/okapi/api/chassis/model/hDriveModel.hpp
+++ b/include/okapi/api/chassis/model/hDriveModel.hpp
@@ -101,6 +101,18 @@ class HDriveModel : public ChassisModel {
   void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
+   * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
+   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * arcade if the forward speed is 0. Uses voltage mode. Sets the middle motor to zero velocity.
+   *
+   * @param iforwardSpeed speed in the forward direction
+   * @param icurvature curvature (inverse of radius) to drive in
+   * @param ithreshold deadband on joystick values
+   */
+  void curvature(double iforwardSpeed, double icurvature, double ithreshold = 0) override;
+
+  /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
    *
    * @param irightSpeed speed to the right

--- a/include/okapi/api/chassis/model/hDriveModel.hpp
+++ b/include/okapi/api/chassis/model/hDriveModel.hpp
@@ -124,6 +124,17 @@ class HDriveModel : public ChassisModel {
   hArcade(double irightSpeed, double iforwardSpeed, double iyaw, double ithreshold = 0);
 
   /**
+   * Drive the robot with an curvature drive layout. Uses voltage mode.
+   *
+   * @param irightSpeed speed to the right
+   * @param iforwardSpeed speed in the forward direction
+   * @param icurvature curvature (inverse of radius) to drive in
+   * @param ithreshold deadband on joystick values
+   */
+  virtual void
+  hCurvature(double irightSpeed, double iforwardSpeed, double icurvature, double ithreshold = 0);
+
+  /**
    * Power the left side motors. Uses velocity mode.
    *
    * @param ispeed The motor power.

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -89,8 +89,8 @@ class SkidSteerModel : public ChassisModel {
 
   /**
    * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
-   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
-   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous
+   * because the forward speed will not affect the rate of turning. The algorithm switches to
    * arcade if the forward speed is 0. Uses voltage mode.
    *
    * @param iforwardSpeed speed in the forward direction

--- a/include/okapi/api/chassis/model/skidSteerModel.hpp
+++ b/include/okapi/api/chassis/model/skidSteerModel.hpp
@@ -88,6 +88,18 @@ class SkidSteerModel : public ChassisModel {
   void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
+   * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
+   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * arcade if the forward speed is 0. Uses voltage mode.
+   *
+   * @param iforwardSpeed speed in the forward direction
+   * @param icurvature curvature (inverse of radius) to drive in
+   * @param ithreshold deadband on joystick values
+   */
+  void curvature(double iforwardSpeed, double icurvature, double ithreshold = 0) override;
+
+  /**
    * Power the left side motors. Uses velocity mode.
    *
    * @param ispeed The motor power.

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -116,8 +116,8 @@ class XDriveModel : public ChassisModel {
 
   /**
    * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
-   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
-   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous
+   * because the forward speed will not affect the rate of turning. The algorithm switches to
    * arcade if the forward speed is 0. Uses voltage mode.
    *
    * @param iforwardSpeed speed forward direction
@@ -139,23 +139,23 @@ class XDriveModel : public ChassisModel {
 
   /**
    * Drive the robot with a field-oriented arcade drive layout. Uses voltage mode.
-   * For example: 
+   * For example:
    *    Both `fieldOrientedXArcade(1, 0, 0, 0_deg)` and `fieldOrientedXArcade(1, 0, 0, 90_deg)`
    *    will drive the chassis in the forward/north direction. In other words, no matter
-   *    the robot's heading, the robot will move forward/north when you tell it 
+   *    the robot's heading, the robot will move forward/north when you tell it
    *    to move forward/north and will move right/east when you tell it to move right/east.
-   *    
-   * 
+   *
+   *
    * @param ixSpeed forward speed -- (`+1`) forward, (`-1`) backward
    * @param iySpeed sideways speed -- (`+1`) right, (`-1`) left
    * @param iyaw turn speed -- (`+1`) clockwise, (`-1`) counter-clockwise
    * @param iangle current chassis angle (`0_deg` = no correction, winds clockwise)
    * @param ithreshold deadband on joystick values
    */
-  virtual void fieldOrientedXArcade(double ixSpeed, 
-                                    double iySpeed, 
-                                    double iyaw, 
-                                    QAngle iangle, 
+  virtual void fieldOrientedXArcade(double ixSpeed,
+                                    double iySpeed,
+                                    double iyaw,
+                                    QAngle iangle,
                                     double ithreshold = 0);
 
   /**

--- a/include/okapi/api/chassis/model/xDriveModel.hpp
+++ b/include/okapi/api/chassis/model/xDriveModel.hpp
@@ -115,6 +115,18 @@ class XDriveModel : public ChassisModel {
   void arcade(double iforwardSpeed, double iyaw, double ithreshold = 0) override;
 
   /**
+   * Drive the robot with a curvature drive layout. The robot drives in constant radius turns
+   * where you control the curvature (inverse of radius) you drive in. This is advantageous 
+   * because the forward speed will not affect the rate of turning. The algorithm switches to 
+   * arcade if the forward speed is 0. Uses voltage mode.
+   *
+   * @param iforwardSpeed speed forward direction
+   * @param icurvature curvature (inverse of radius) to drive in
+   * @param ithreshold deadband on joystick values
+   */
+  void curvature(double iforwardSpeed, double icurvature, double ithreshold = 0) override;
+
+  /**
    * Drive the robot with an arcade drive layout. Uses voltage mode.
    *
    * @param irightSpeed speed to the right

--- a/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncLinearMotionProfileController.hpp
@@ -273,7 +273,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
   /**
    * Follow the supplied path. Must follow the disabled lifecycle.
    */
-  virtual void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path, std::unique_ptr<AbstractRate> rate);
+  virtual void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path,
+                                 std::unique_ptr<AbstractRate> rate);
 
   /**
    * Converts linear "chassis" speed to rotational motor speed.
@@ -283,7 +284,8 @@ class AsyncLinearMotionProfileController : public AsyncPositionController<std::s
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string
-  getPathErrorMessage(const std::vector<PathfinderPoint> &points, const std::string &ipathId, int length);
+  std::string getPathErrorMessage(const std::vector<PathfinderPoint> &points,
+                                  const std::string &ipathId,
+                                  int length);
 };
 } // namespace okapi

--- a/include/okapi/api/control/async/asyncMotionProfileController.hpp
+++ b/include/okapi/api/control/async/asyncMotionProfileController.hpp
@@ -66,8 +66,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    * If the waypoints form a path which is impossible to achieve, an instance of
    * `std::runtime_error` is thrown (and an error is logged) which describes the waypoints. If there
    * are no waypoints, no path is generated.
-   * 
-   * NOTE: The waypoints are expected to be in the 
+   *
+   * NOTE: The waypoints are expected to be in the
    * okapi::State::FRAME_TRANSFORMATION format where +x is forward, +y is right,
    * and 0 theta is measured from the +x axis to the +y axis.
    *
@@ -290,7 +290,8 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
   /**
    * Follow the supplied path. Must follow the disabled lifecycle.
    */
-  virtual void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path, std::unique_ptr<AbstractRate> rate);
+  virtual void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path,
+                                 std::unique_ptr<AbstractRate> rate);
 
   /**
    * Converts linear chassis speed to rotational motor speed.
@@ -300,8 +301,9 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
    */
   QAngularSpeed convertLinearToRotational(QSpeed linear) const;
 
-  std::string
-  getPathErrorMessage(const std::vector<PathfinderPoint> &points, const std::string &ipathId, int length);
+  std::string getPathErrorMessage(const std::vector<PathfinderPoint> &points,
+                                  const std::string &ipathId,
+                                  int length);
 
   /**
    * Joins and escapes a directory and file name
@@ -315,8 +317,10 @@ class AsyncMotionProfileController : public AsyncPositionController<std::string,
 
   void internalStorePath(std::ostream &file, const std::string &ipathId);
   void internalLoadPath(std::istream &file, const std::string &ipathId);
-  void internalLoadPathfinderPath(std::istream &leftFile, std::istream &rightFile, const std::string &ipathId);
+  void internalLoadPathfinderPath(std::istream &leftFile,
+                                  std::istream &rightFile,
+                                  const std::string &ipathId);
 
-  static constexpr double DT = 0.01; 
+  static constexpr double DT = 0.01;
 };
 } // namespace okapi

--- a/include/okapi/api/util/mathUtil.hpp
+++ b/include/okapi/api/util/mathUtil.hpp
@@ -120,12 +120,11 @@ static constexpr std::int8_t adiUpdateRate = 10;
  * @return `base^expo`.
  */
 constexpr double ipow(const double base, const int expo) {
-  return (expo == 0)
-           ? 1
-           : expo == 1 ? base
-                       : expo > 1 ? ((expo & 1) ? base * ipow(base, expo - 1)
-                                                : ipow(base, expo / 2) * ipow(base, expo / 2))
-                                  : 1 / ipow(base, -expo);
+  return (expo == 0) ? 1
+         : expo == 1 ? base
+         : expo > 1  ? ((expo & 1) ? base * ipow(base, expo - 1)
+                                   : ipow(base, expo / 2) * ipow(base, expo / 2))
+                     : 1 / ipow(base, -expo);
 }
 
 /**

--- a/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
+++ b/include/okapi/impl/chassis/controller/chassisControllerBuilder.hpp
@@ -474,7 +474,7 @@ class ChassisControllerBuilder {
   TimeUtilFactory closedLoopControllerTimeUtilFactory = TimeUtilFactory();
   TimeUtilFactory odometryTimeUtilFactory = TimeUtilFactory();
 
-  AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid,1.0};
+  AbstractMotor::GearsetRatioPair gearset{AbstractMotor::gearset::invalid, 1.0};
   ChassisScales driveScales{{1, 1}, imev5GreenTPR};
   bool differentOdomScales{false};
   ChassisScales odomScales{{1, 1}, imev5GreenTPR};

--- a/include/okapi/impl/device/rotarysensor/IMU.hpp
+++ b/include/okapi/impl/device/rotarysensor/IMU.hpp
@@ -61,12 +61,12 @@ class IMU : public ContinuousRotarySensor {
    * @return ``1`` or ``PROS_ERR``.
    */
   std::int32_t reset() override;
-  
+
   /**
    * Resets rotation value to desired value
    * For example, ``reset(0)`` will reset the sensor to zero.
    * But ``reset(90)`` will reset the sensor to 90 degrees.
-   * 
+   *
    * @param inewAngle desired reset value
    * @return ``1`` or ``PROS_ERR``.
    */

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -486,6 +486,11 @@ class MockChassisModel : public ChassisModel {
     lastArcadeZ = izRotation;
   }
 
+  void curvature(double iforwardSpeed, double icurvature, double) override {
+    lastCurvatureForward = iforwardSpeed;
+    lastCurvatureCurvature = icurvature;
+  }
+
   void left(double ispeed) override {
     lastLeft = ispeed;
   }
@@ -536,6 +541,8 @@ class MockChassisModel : public ChassisModel {
   mutable double lastTankRight{0};
   mutable double lastArcadeY{0};
   mutable double lastArcadeZ{0};
+  mutable double lastCurvatureForward{0};
+  mutable double lastCurvatureCurvature{0};
   mutable double lastLeft{0};
   mutable double lastRight{0};
   mutable bool resetSensorsWasCalled{false};

--- a/src/api/chassis/controller/chassisControllerPid.cpp
+++ b/src/api/chassis/controller/chassisControllerPid.cpp
@@ -117,7 +117,8 @@ void ChassisControllerPID::trampoline(void *context) {
 
 void ChassisControllerPID::moveDistanceAsync(const QLength itarget) {
   LOG_INFO("ChassisControllerPID: moving " + std::to_string(itarget.convert(meter)) + " meters");
-  LOG_DEBUG("ChassisControllerPID: straight " + std::to_string(scales.straight) + " ratio " + std::to_string(gearsetRatioPair.ratio));
+  LOG_DEBUG("ChassisControllerPID: straight " + std::to_string(scales.straight) + " ratio " +
+            std::to_string(gearsetRatioPair.ratio));
 
   distancePid->reset();
   anglePid->reset();
@@ -155,7 +156,8 @@ void ChassisControllerPID::moveRaw(const double itarget) {
 void ChassisControllerPID::turnAngleAsync(const QAngle idegTarget) {
   LOG_INFO("ChassisControllerPID: turning " + std::to_string(idegTarget.convert(degree)) +
            " degrees");
-  LOG_DEBUG("ChassisControllerPID: scales.turn " + std::to_string(scales.turn) + " ratio " + std::to_string(gearsetRatioPair.ratio));
+  LOG_DEBUG("ChassisControllerPID: scales.turn " + std::to_string(scales.turn) + " ratio " +
+            std::to_string(gearsetRatioPair.ratio));
 
   turnPid->reset();
   turnPid->flipDisable(false);

--- a/src/api/chassis/model/hDriveModel.cpp
+++ b/src/api/chassis/model/hDriveModel.cpp
@@ -36,7 +36,7 @@ void HDriveModel::forward(const double ispeed) {
 
 void HDriveModel::driveVector(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -55,7 +55,7 @@ void HDriveModel::driveVector(const double iforwardSpeed, const double iyaw) {
 
 void HDriveModel::driveVectorVoltage(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -87,7 +87,7 @@ void HDriveModel::stop() {
 
 void HDriveModel::tank(const double ileftSpeed, const double irightSpeed, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L198
   double leftSpeed = std::clamp(ileftSpeed, -1.0, 1.0);
   if (std::abs(leftSpeed) < ithreshold) {
     leftSpeed = 0;
@@ -105,7 +105,7 @@ void HDriveModel::tank(const double ileftSpeed, const double irightSpeed, const 
 
 void HDriveModel::arcade(const double iforwardSpeed, const double iyaw, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L48
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) <= ithreshold) {
     forwardSpeed = 0;
@@ -148,7 +148,7 @@ void HDriveModel::curvature(const double iforwardSpeed,
                             const double icurvature, 
                             const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) < ithreshold) {
     forwardSpeed = 0;

--- a/src/api/chassis/model/hDriveModel.cpp
+++ b/src/api/chassis/model/hDriveModel.cpp
@@ -144,6 +144,42 @@ void HDriveModel::arcade(const double iforwardSpeed, const double iyaw, const do
   middleMotor->moveVelocity(0);
 }
 
+void HDriveModel::curvature(const double iforwardSpeed, 
+                            const double icurvature, 
+                            const double ithreshold) {
+  // This code is adapted from WPIlib. All credit goes to them. Link:
+  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  if (std::abs(forwardSpeed) < ithreshold) {
+    forwardSpeed = 0;
+  }
+
+  double curvature = std::clamp(icurvature, -1.0, 1.0);
+  if (std::abs(curvature) < ithreshold) {
+    curvature = 0;
+  }
+
+  // the algorithm switches to arcade when forward speed is 0 to allow point turns.
+  if(forwardSpeed == 0){
+    arcade(forwardSpeed, curvature, ithreshold);
+    return;
+  }
+
+  double leftSpeed = forwardSpeed + std::abs(forwardSpeed) * curvature;
+  double rightSpeed = forwardSpeed - std::abs(forwardSpeed) * curvature;
+  double maxSpeed = std::max(leftSpeed, rightSpeed);
+
+  // normalizes output
+  if(maxSpeed > 1.0){
+    leftSpeed /= maxSpeed;
+	  rightSpeed /= maxSpeed;
+  }
+
+  leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  rightSideMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  middleMotor->moveVelocity(0);
+}
+
 void HDriveModel::hArcade(const double ixSpeed,
                           const double iforwardSpeed,
                           const double iyaw,

--- a/src/api/chassis/model/hDriveModel.cpp
+++ b/src/api/chassis/model/hDriveModel.cpp
@@ -144,8 +144,8 @@ void HDriveModel::arcade(const double iforwardSpeed, const double iyaw, const do
   middleMotor->moveVelocity(0);
 }
 
-void HDriveModel::curvature(const double iforwardSpeed, 
-                            const double icurvature, 
+void HDriveModel::curvature(const double iforwardSpeed,
+                            const double icurvature,
                             const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
@@ -160,7 +160,7 @@ void HDriveModel::curvature(const double iforwardSpeed,
   }
 
   // the algorithm switches to arcade when forward speed is 0 to allow point turns.
-  if(forwardSpeed == 0){
+  if (forwardSpeed == 0) {
     arcade(forwardSpeed, curvature, ithreshold);
     return;
   }
@@ -170,9 +170,9 @@ void HDriveModel::curvature(const double iforwardSpeed,
   double maxSpeed = std::max(leftSpeed, rightSpeed);
 
   // normalizes output
-  if(maxSpeed > 1.0){
+  if (maxSpeed > 1.0) {
     leftSpeed /= maxSpeed;
-	  rightSpeed /= maxSpeed;
+    rightSpeed /= maxSpeed;
   }
 
   leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
@@ -206,9 +206,9 @@ void HDriveModel::hArcade(const double ixSpeed,
   middleMotor->moveVoltage(static_cast<int16_t>(std::clamp(xSpeed, -1.0, 1.0) * maxVoltage));
 }
 
-void HDriveModel::hCurvature(const double ixSpeed, 
+void HDriveModel::hCurvature(const double ixSpeed,
                              const double iforwardSpeed,
-                             const double icurvature, 
+                             const double icurvature,
                              const double ithreshold) {
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) < ithreshold) {
@@ -226,7 +226,7 @@ void HDriveModel::hCurvature(const double ixSpeed,
   }
 
   // the algorithm switches to arcade when forward speed is 0 to allow point turns.
-  if(forwardSpeed == 0){
+  if (forwardSpeed == 0) {
     hArcade(xSpeed, forwardSpeed, curvature, ithreshold);
     return;
   }
@@ -236,9 +236,9 @@ void HDriveModel::hCurvature(const double ixSpeed,
   double maxSpeed = std::max(leftSpeed, rightSpeed);
 
   // normalizes output
-  if(maxSpeed > 1.0){
+  if (maxSpeed > 1.0) {
     leftSpeed /= maxSpeed;
-	  rightSpeed /= maxSpeed;
+    rightSpeed /= maxSpeed;
   }
 
   leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));

--- a/src/api/chassis/model/hDriveModel.cpp
+++ b/src/api/chassis/model/hDriveModel.cpp
@@ -206,6 +206,46 @@ void HDriveModel::hArcade(const double ixSpeed,
   middleMotor->moveVoltage(static_cast<int16_t>(std::clamp(xSpeed, -1.0, 1.0) * maxVoltage));
 }
 
+void HDriveModel::hCurvature(const double ixSpeed, 
+                             const double iforwardSpeed,
+                             const double icurvature, 
+                             const double ithreshold) {
+  double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  if (std::abs(forwardSpeed) < ithreshold) {
+    forwardSpeed = 0;
+  }
+
+  double curvature = std::clamp(icurvature, -1.0, 1.0);
+  if (std::abs(curvature) < ithreshold) {
+    curvature = 0;
+  }
+
+  double xSpeed = std::clamp(ixSpeed, -1.0, 1.0);
+  if (std::abs(xSpeed) < ithreshold) {
+    xSpeed = 0;
+  }
+
+  // the algorithm switches to arcade when forward speed is 0 to allow point turns.
+  if(forwardSpeed == 0){
+    hArcade(xSpeed, forwardSpeed, curvature, ithreshold);
+    return;
+  }
+
+  double leftSpeed = forwardSpeed + std::abs(forwardSpeed) * curvature;
+  double rightSpeed = forwardSpeed - std::abs(forwardSpeed) * curvature;
+  double maxSpeed = std::max(leftSpeed, rightSpeed);
+
+  // normalizes output
+  if(maxSpeed > 1.0){
+    leftSpeed /= maxSpeed;
+	  rightSpeed /= maxSpeed;
+  }
+
+  leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  rightSideMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  middleMotor->moveVoltage(static_cast<int16_t>(xSpeed * maxVoltage));
+}
+
 void HDriveModel::left(const double ispeed) {
   leftSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -137,8 +137,8 @@ void SkidSteerModel::arcade(const double iforwardSpeed,
     static_cast<int16_t>(std::clamp(rightOutput, -1.0, 1.0) * maxVoltage));
 }
 
-void SkidSteerModel::curvature(const double iforwardSpeed, 
-                               const double icurvature, 
+void SkidSteerModel::curvature(const double iforwardSpeed,
+                               const double icurvature,
                                const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
@@ -153,7 +153,7 @@ void SkidSteerModel::curvature(const double iforwardSpeed,
   }
 
   // the algorithm switches to arcade when forward speed is 0 to allow point turns.
-  if(forwardSpeed == 0){
+  if (forwardSpeed == 0) {
     arcade(forwardSpeed, curvature, ithreshold);
     return;
   }
@@ -163,9 +163,9 @@ void SkidSteerModel::curvature(const double iforwardSpeed,
   double maxSpeed = std::max(leftSpeed, rightSpeed);
 
   // normalizes output
-  if(maxSpeed > 1.0){
+  if (maxSpeed > 1.0) {
     leftSpeed /= maxSpeed;
-	rightSpeed /= maxSpeed;
+    rightSpeed /= maxSpeed;
   }
 
   leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -137,6 +137,41 @@ void SkidSteerModel::arcade(const double iforwardSpeed,
     static_cast<int16_t>(std::clamp(rightOutput, -1.0, 1.0) * maxVoltage));
 }
 
+void SkidSteerModel::curvature(const double iforwardSpeed, 
+                               const double icurvature, 
+                               const double ithreshold) {
+  // This code is adapted from WPIlib. All credit goes to them. Link:
+  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  if (std::abs(forwardSpeed) < ithreshold) {
+    forwardSpeed = 0;
+  }
+
+  double curvature = std::clamp(icurvature, -1.0, 1.0);
+  if (std::abs(curvature) < ithreshold) {
+    curvature = 0;
+  }
+
+  // the algorithm switches to arcade when forward speed is 0 to allow point turns.
+  if(forwardSpeed == 0){
+    arcade(forwardSpeed, curvature, ithreshold);
+    return;
+  }
+
+  double leftSpeed = forwardSpeed + std::abs(forwardSpeed) * curvature;
+  double rightSpeed = forwardSpeed - std::abs(forwardSpeed) * curvature;
+  double maxSpeed = std::max(leftSpeed, rightSpeed);
+
+  // normalizes output
+  if(maxSpeed > 1.0){
+    leftSpeed /= maxSpeed;
+	rightSpeed /= maxSpeed;
+  }
+
+  leftSideMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  rightSideMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+}
+
 void SkidSteerModel::left(const double ispeed) {
   leftSideMotor->moveVelocity(static_cast<int16_t>(std::clamp(ispeed, -1.0, 1.0) * maxVelocity));
 }

--- a/src/api/chassis/model/skidSteerModel.cpp
+++ b/src/api/chassis/model/skidSteerModel.cpp
@@ -31,7 +31,7 @@ void SkidSteerModel::forward(const double ispeed) {
 
 void SkidSteerModel::driveVector(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -49,7 +49,7 @@ void SkidSteerModel::driveVector(const double iforwardSpeed, const double iyaw) 
 
 void SkidSteerModel::driveVectorVoltage(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -80,7 +80,7 @@ void SkidSteerModel::tank(const double ileftSpeed,
                           const double irightSpeed,
                           const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L198
   double leftSpeed = std::clamp(ileftSpeed, -1.0, 1.0);
   if (std::abs(leftSpeed) < ithreshold) {
     leftSpeed = 0;
@@ -99,7 +99,7 @@ void SkidSteerModel::arcade(const double iforwardSpeed,
                             const double iyaw,
                             const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L48
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) <= ithreshold) {
     forwardSpeed = 0;
@@ -141,7 +141,7 @@ void SkidSteerModel::curvature(const double iforwardSpeed,
                                const double icurvature, 
                                const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) < ithreshold) {
     forwardSpeed = 0;

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -1,4 +1,4 @@
-/*
+  /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -36,7 +36,7 @@ void XDriveModel::forward(const double ispeed) {
 
 void XDriveModel::driveVector(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -56,7 +56,7 @@ void XDriveModel::driveVector(const double iforwardSpeed, const double iyaw) {
 
 void XDriveModel::driveVectorVoltage(const double iforwardSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -92,7 +92,7 @@ void XDriveModel::strafe(const double ispeed) {
 
 void XDriveModel::strafeVector(const double istrafeSpeed, const double iyaw) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
   const double forwardSpeed = std::clamp(istrafeSpeed, -1.0, 1.0);
   const double yaw = std::clamp(iyaw, -1.0, 1.0);
 
@@ -126,7 +126,7 @@ void XDriveModel::stop() {
 
 void XDriveModel::tank(const double ileftSpeed, const double irightSpeed, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L198
   double leftSpeed = std::clamp(ileftSpeed, -1.0, 1.0);
   if (std::abs(leftSpeed) < ithreshold) {
     leftSpeed = 0;
@@ -145,7 +145,7 @@ void XDriveModel::tank(const double ileftSpeed, const double irightSpeed, const 
 
 void XDriveModel::arcade(const double iforwardSpeed, const double iyaw, const double ithreshold) {
   // This code is taken from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/master/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L73
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L48
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) <= ithreshold) {
     forwardSpeed = 0;
@@ -191,7 +191,7 @@ void XDriveModel::curvature(const double iforwardSpeed,
                             const double icurvature, 
                             const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
-  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
   double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
   if (std::abs(forwardSpeed) < ithreshold) {
     forwardSpeed = 0;

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -187,6 +187,43 @@ void XDriveModel::arcade(const double iforwardSpeed, const double iyaw, const do
   bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
 }
 
+void XDriveModel::curvature(const double iforwardSpeed, 
+                            const double icurvature, 
+                            const double ithreshold) {
+  // This code is adapted from WPIlib. All credit goes to them. Link:
+  // https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49
+  double forwardSpeed = std::clamp(iforwardSpeed, -1.0, 1.0);
+  if (std::abs(forwardSpeed) < ithreshold) {
+    forwardSpeed = 0;
+  }
+
+  double curvature = std::clamp(icurvature, -1.0, 1.0);
+  if (std::abs(curvature) < ithreshold) {
+    curvature = 0;
+  }
+
+  // the algorithm switches to arcade when forward speed is 0 to allow point turns.
+  if(forwardSpeed == 0){
+    arcade(forwardSpeed, curvature, ithreshold);
+    return;
+  }
+
+  double leftSpeed = forwardSpeed + std::abs(forwardSpeed) * curvature;
+  double rightSpeed = forwardSpeed - std::abs(forwardSpeed) * curvature;
+  double maxSpeed = std::max(leftSpeed, rightSpeed);
+
+  // normalizes output
+  if(maxSpeed > 1.0){
+    leftSpeed /= maxSpeed;
+	  rightSpeed /= maxSpeed;
+  }
+
+  topLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+  topRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  bottomRightMotor->moveVoltage(static_cast<int16_t>(rightSpeed * maxVoltage));
+  bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
+}
+
 void XDriveModel::xArcade(const double ixSpeed,
                           const double iforwardSpeed,
                           const double iyaw,

--- a/src/api/chassis/model/xDriveModel.cpp
+++ b/src/api/chassis/model/xDriveModel.cpp
@@ -1,4 +1,4 @@
-  /*
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -187,8 +187,8 @@ void XDriveModel::arcade(const double iforwardSpeed, const double iyaw, const do
   bottomLeftMotor->moveVoltage(static_cast<int16_t>(leftOutput * maxVoltage));
 }
 
-void XDriveModel::curvature(const double iforwardSpeed, 
-                            const double icurvature, 
+void XDriveModel::curvature(const double iforwardSpeed,
+                            const double icurvature,
                             const double ithreshold) {
   // This code is adapted from WPIlib. All credit goes to them. Link:
   // https://github.com/wpilibsuite/allwpilib/blob/96e9a6989ce1688f3edb2d9b9d21ef8cd3861579/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp#L117
@@ -203,7 +203,7 @@ void XDriveModel::curvature(const double iforwardSpeed,
   }
 
   // the algorithm switches to arcade when forward speed is 0 to allow point turns.
-  if(forwardSpeed == 0){
+  if (forwardSpeed == 0) {
     arcade(forwardSpeed, curvature, ithreshold);
     return;
   }
@@ -213,9 +213,9 @@ void XDriveModel::curvature(const double iforwardSpeed,
   double maxSpeed = std::max(leftSpeed, rightSpeed);
 
   // normalizes output
-  if(maxSpeed > 1.0){
+  if (maxSpeed > 1.0) {
     leftSpeed /= maxSpeed;
-	  rightSpeed /= maxSpeed;
+    rightSpeed /= maxSpeed;
   }
 
   topLeftMotor->moveVoltage(static_cast<int16_t>(leftSpeed * maxVoltage));
@@ -253,10 +253,10 @@ void XDriveModel::xArcade(const double ixSpeed,
     static_cast<int16_t>(std::clamp(forwardSpeed - xSpeed + yaw, -1.0, 1.0) * maxVoltage));
 }
 
-void XDriveModel::fieldOrientedXArcade(double ixSpeed, 
-                                       double iySpeed, 
-                                       double iyaw, 
-                                       QAngle iangle, 
+void XDriveModel::fieldOrientedXArcade(double ixSpeed,
+                                       double iySpeed,
+                                       double iyaw,
+                                       QAngle iangle,
                                        double ithreshold) {
   double xSpeed = std::clamp(ixSpeed, -1.0, 1.0);
   if (std::abs(xSpeed) < ithreshold) {

--- a/src/impl/chassis/controller/chassisControllerBuilder.cpp
+++ b/src/impl/chassis/controller/chassisControllerBuilder.cpp
@@ -414,7 +414,7 @@ ChassisControllerBuilder::buildDOCC(std::shared_ptr<ChassisController> chassisCo
 }
 
 std::shared_ptr<ChassisControllerPID> ChassisControllerBuilder::buildCCPID() {
-  if(differentOdomScales) {
+  if (differentOdomScales) {
     // The chassis controller is going to multiply by the gearset ratio, but
     // since the odometry wheels are directly driven, we need to back this out here
     odomScales.straight = odomScales.straight / gearset.ratio;
@@ -477,16 +477,18 @@ std::shared_ptr<ChassisControllerIntegrated> ChassisControllerBuilder::buildCCI(
   return std::make_shared<ChassisControllerIntegrated>(
     chassisControllerTimeUtilFactory.create(),
     makeChassisModel(),
-    std::make_unique<AsyncPosIntegratedController>(leftMotorGroup,
-                                                   AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
-                                                   maxVelocity,
-                                                   closedLoopControllerTimeUtilFactory.create(),
-                                                   controllerLogger),
-    std::make_unique<AsyncPosIntegratedController>(rightMotorGroup,
-                                                   AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
-                                                   maxVelocity,
-                                                   closedLoopControllerTimeUtilFactory.create(),
-                                                   controllerLogger),
+    std::make_unique<AsyncPosIntegratedController>(
+      leftMotorGroup,
+      AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
+      maxVelocity,
+      closedLoopControllerTimeUtilFactory.create(),
+      controllerLogger),
+    std::make_unique<AsyncPosIntegratedController>(
+      rightMotorGroup,
+      AbstractMotor::GearsetRatioPair(gearset.internalGearset, 1.0),
+      maxVelocity,
+      closedLoopControllerTimeUtilFactory.create(),
+      controllerLogger),
     gearset,
     driveScales,
     controllerLogger);

--- a/test/asyncLinearMotionProfileControllerTests.cpp
+++ b/test/asyncLinearMotionProfileControllerTests.cpp
@@ -13,7 +13,8 @@ class MockAsyncLinearMotionProfileController : public AsyncLinearMotionProfileCo
   public:
   using AsyncLinearMotionProfileController::AsyncLinearMotionProfileController;
 
-  void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path, std::unique_ptr<AbstractRate> rate) override {
+  void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path,
+                         std::unique_ptr<AbstractRate> rate) override {
     executeSinglePathCalled = true;
     AsyncLinearMotionProfileController::executeSinglePath(path, std::move(rate));
   }

--- a/test/asyncMotionProfileControllerTests.cpp
+++ b/test/asyncMotionProfileControllerTests.cpp
@@ -7,11 +7,11 @@
 #include "test/tests/api/implMocks.hpp"
 #include <fstream>
 #ifdef WINDOWS
-    #include <direct.h>
-    #define getcwd _getcwd
+#include <direct.h>
+#define getcwd _getcwd
 #else
-    #include <unistd.h>
- #endif
+#include <unistd.h>
+#endif
 #include <gtest/gtest.h>
 
 using namespace okapi;
@@ -25,7 +25,8 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
   using AsyncMotionProfileController::internalStorePath;
   using AsyncMotionProfileController::makeFilePath;
 
-  void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path, std::unique_ptr<AbstractRate> rate) override {
+  void executeSinglePath(const std::vector<squiggles::ProfilePoint> &path,
+                         std::unique_ptr<AbstractRate> rate) override {
     executeSinglePathCalled = true;
     AsyncMotionProfileController::executeSinglePath(path, std::move(rate));
   }
@@ -40,8 +41,8 @@ class MockAsyncMotionProfileController : public AsyncMotionProfileController {
 class AsyncMotionProfileControllerTest : public ::testing::Test {
   protected:
   std::string get_working_path() {
-   char temp[FILENAME_MAX];
-   return ( getcwd(temp, sizeof(temp)) ? std::string( temp ) : std::string("") );
+    char temp[FILENAME_MAX];
+    return (getcwd(temp, sizeof(temp)) ? std::string(temp) : std::string(""));
   }
 
   void SetUp() override {
@@ -151,9 +152,8 @@ TEST_F(AsyncMotionProfileControllerTest, TwoPathsOverwriteEachOther) {
 
 TEST_F(AsyncMotionProfileControllerTest, ImpossiblePathThrowsException) {
   // Path is too long to fit within the time window considered by Squiggles
-  EXPECT_THROW(controller->generatePath({PathfinderPoint{0_m, 0_m, 0_deg},
-                                         PathfinderPoint{9999_m, 0_m, 0_deg}},
-                                        "A"),
+  EXPECT_THROW(controller->generatePath(
+                 {PathfinderPoint{0_m, 0_m, 0_deg}, PathfinderPoint{9999_m, 0_m, 0_deg}}, "A"),
                std::runtime_error);
   EXPECT_EQ(controller->getPaths().size(), 0);
 }
@@ -306,7 +306,7 @@ TEST_F(AsyncMotionProfileControllerTest, FollowPathNotMirrored) {
   EXPECT_NE(leftMotor->lastVelocity, 0);
   EXPECT_NE(rightMotor->lastVelocity, 0);
   EXPECT_GT(leftMotor->maxVelocity, rightMotor->maxVelocity);
-  
+
   // Disable the controller so gtest doesn't clean up the test fixture while the internal thread is
   // still running
   controller->flipDisable(true);

--- a/test/hDriveModelTests.cpp
+++ b/test/hDriveModelTests.cpp
@@ -327,6 +327,76 @@ TEST_F(HDriveModelTest, HArcadeBoundsInputAllNoForward) {
   EXPECT_EQ(middleMotor->lastVoltage, 12000);
 }
 
+TEST_F(HDriveModelTest, HCurvatureHalfPower) {
+  model.hCurvature(0, 0.5, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 9000);
+  EXPECT_EQ(rightMotor->lastVoltage, 3000);
+  EXPECT_EQ(middleMotor->lastVoltage, 0);
+}
+
+TEST_F(HDriveModelTest, HCurvatureHalfPowerStrafe) {
+  model.hCurvature(0.5, 0, 0);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 0);
+  EXPECT_EQ(rightMotor->lastVoltage, 0);
+  EXPECT_EQ(middleMotor->lastVoltage, 6000);
+}
+
+TEST_F(HDriveModelTest, HCurvatureFullPower) {
+  model.hCurvature(1, 1, 0);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 12000);
+  EXPECT_EQ(rightMotor->lastVoltage, 12000);
+  EXPECT_EQ(middleMotor->lastVoltage, 12000);
+}
+
+TEST_F(HDriveModelTest, HCurvatureFullPowerTurn) {
+  model.hCurvature(1, 1, 1);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 12000);
+  EXPECT_EQ(rightMotor->lastVoltage, 0);
+  EXPECT_EQ(middleMotor->lastVoltage, 12000);
+}
+
+TEST_F(HDriveModelTest, HCurvatureNormalizes) {
+  model.hCurvature(-0.25, 0.7, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 12000);
+  EXPECT_EQ(rightMotor->lastVoltage, 4000);
+  EXPECT_EQ(middleMotor->lastVoltage, -3000);
+}
+
+TEST_F(HDriveModelTest, HCurvatureBoundsInput) {
+  model.hCurvature(-10, 10, 10);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 12000);
+  EXPECT_EQ(rightMotor->lastVoltage, 0);
+  EXPECT_EQ(middleMotor->lastVoltage, -12000);
+}
+
+TEST_F(HDriveModelTest, HCurvatureThresholds) {
+  model.hCurvature(0.4, 0.5, 0.5, 0.7);
+
+  assertAllMotorsLastVelocity(0);
+  assertAllMotorsLastVoltage(0);
+}
+
+TEST_F(HDriveModelTest, HCurvatureNegativeZero) {
+  model.hCurvature(-0.0, -0.0, -0.0);
+
+  assertAllMotorsLastVelocity(0);
+  EXPECT_EQ(leftMotor->lastVoltage, 0);
+  EXPECT_EQ(rightMotor->lastVoltage, 0);
+  EXPECT_EQ(middleMotor->lastVoltage, 0);
+}
+
 TEST_F(HDriveModelTest, SetMaxVelocity) {
   model.setMaxVelocity(2);
   model.forward(0.5);

--- a/test/hDriveModelTests.cpp
+++ b/test/hDriveModelTests.cpp
@@ -194,6 +194,49 @@ TEST_F(HDriveModelTest, ArcadeNegativeZero) {
   assertAllMotorsLastVelocity(0);
   assertLeftAndRightMotorsLastVoltage(-12000, 12000);
 }
+
+TEST_F(HDriveModelTest, CurvatureHalfPower) {
+  model.curvature(0.5, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(9000, 3000);
+}
+
+TEST_F(HDriveModelTest, CurvatureNormalizes) {
+  model.curvature(0.7, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, 4000);
+}
+
+TEST_F(HDriveModelTest, CurvatureSwitchesToArcade) {
+  model.curvature(0.0, 1.0);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, -12000);
+}
+
+TEST_F(HDriveModelTest, CurvatureBoundsInput) {
+  model.curvature(10, -10);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 12000);
+}
+
+TEST_F(HDriveModelTest, CurvatureThresholds) {
+  model.curvature(0.2, 0.2, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 0);
+}
+
+TEST_F(HDriveModelTest, CurvatureNegativeZero) {
+  model.curvature(-0.0, -0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(-6000, 6000);
+}
+
 TEST_F(HDriveModelTest, HArcadeHalfPowerForward) {
   model.hArcade(0, 0.5, 0);
 

--- a/test/skidSteerModelTests.cpp
+++ b/test/skidSteerModelTests.cpp
@@ -183,6 +183,48 @@ TEST_F(SkidSteerModelTest, ArcadeNegativeZero) {
   assertLeftAndRightMotorsLastVoltage(-12000, 12000);
 }
 
+TEST_F(SkidSteerModelTest, CurvatureHalfPower) {
+  model.curvature(0.5, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(9000, 3000);
+}
+
+TEST_F(SkidSteerModelTest, CurvatureNormalizes) {
+  model.curvature(0.7, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, 4000);
+}
+
+TEST_F(SkidSteerModelTest, CurvatureSwitchesToArcade) {
+  model.curvature(0.0, 1.0);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, -12000);
+}
+
+TEST_F(SkidSteerModelTest, CurvatureBoundsInput) {
+  model.curvature(10, -10);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 12000);
+}
+
+TEST_F(SkidSteerModelTest, CurvatureThresholds) {
+  model.curvature(0.2, 0.2, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 0);
+}
+
+TEST_F(SkidSteerModelTest, CurvatureNegativeZero) {
+  model.curvature(-0.0, -0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(-6000, 6000);
+}
+
 TEST_F(SkidSteerModelTest, SetMaxVelocity) {
   model.setMaxVelocity(2);
   model.forward(0.5);

--- a/test/xDriveModelTests.cpp
+++ b/test/xDriveModelTests.cpp
@@ -272,6 +272,48 @@ TEST_F(XDriveModelTest, ArcadeNegativeZero) {
   assertLeftAndRightMotorsLastVoltage(-12000, 12000);
 }
 
+TEST_F(XDriveModelTest, CurvatureHalfPower) {
+  model.curvature(0.5, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(9000, 3000);
+}
+
+TEST_F(XDriveModelTest, CurvatureNormalizes) {
+  model.curvature(0.7, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, 4000);
+}
+
+TEST_F(XDriveModelTest, CurvatureSwitchesToArcade) {
+  model.curvature(0.0, 1.0);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(12000, -12000);
+}
+
+TEST_F(XDriveModelTest, CurvatureBoundsInput) {
+  model.curvature(10, -10);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 12000);
+}
+
+TEST_F(XDriveModelTest, CurvatureThresholds) {
+  model.curvature(0.2, 0.2, 0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(0, 0);
+}
+
+TEST_F(XDriveModelTest, CurvatureNegativeZero) {
+  model.curvature(-0.0, -0.5);
+
+  assertAllMotorsLastVelocity(0);
+  assertLeftAndRightMotorsLastVoltage(-6000, 6000);
+}
+
 TEST_F(XDriveModelTest, XArcadeHalfPowerForward) {
   model.xArcade(0, 0.5, 0);
 


### PR DESCRIPTION
### Description of the Change

Adds curvature drive (aka cheesy drive) into OkapiLib. It is similar to arcade, but instead of having the right stick control the rate of heading change, it controls the curvature of the path the robot drives in. This allows the robot to turn at a constant rate regardless of how fast your robot is moving, which allows better control under high speeds. A quick demo can be found [here](https://www.youtube.com/watch?v=oUWnYTcbHEw).

The implementation is mostly adapted from [wpilib](https://github.com/wpilibsuite/allwpilib/blob/main/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp#L49) (DifferentialDrive.cpp)

### Motivation

From our team's year long usage curvature drive is very nice to drive with especially with high speed chassis. I think a lot of teams will find it useful.

### Possible Drawbacks

Not that I can think of.

### Verification Process

Unit tests were added and passed.
The same code were used on our robot last year and no issues occurred.

### Applicable Issues

None, this is a new feature
