### PR TITLE
Allow varying units in printing odomState

### DIFF
--- a/include/okapi/api.hpp
+++ b/include/okapi/api.hpp
@@ -121,6 +121,7 @@
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/QTorque.hpp"
 #include "okapi/api/units/QVolume.hpp"
+#include "okapi/api/units/RQuantityName.hpp"
 
 #include "okapi/api/util/abstractRate.hpp"
 #include "okapi/api/util/abstractTimer.hpp"

--- a/include/okapi/api/odometry/odomState.hpp
+++ b/include/okapi/api/odometry/odomState.hpp
@@ -7,6 +7,7 @@
 
 #include "okapi/api/units/QAngle.hpp"
 #include "okapi/api/units/QLength.hpp"
+#include "okapi/api/units/RQuantityName.hpp"
 #include <string>
 
 namespace okapi {
@@ -18,7 +19,11 @@ struct OdomState {
   /**
    * @return A string representing the state.
    */
-  std::string str() const;
+  std::string str(QLength idistanceUnit, QAngle iangleUnit) const;
+  std::string str(QLength idistanceUnit = meter,
+                  std::string distUnitName = "_m",
+                  QAngle iangleUnit = degree,
+                  std::string angleUnitName = "_deg") const;
 
   bool operator==(const OdomState &rhs) const;
 

--- a/include/okapi/api/odometry/odomState.hpp
+++ b/include/okapi/api/odometry/odomState.hpp
@@ -17,9 +17,34 @@ struct OdomState {
   QAngle theta{0_deg};
 
   /**
+   * Get a string for the current odometry state (optionally with the specified units).
+   *
+   * Examples:
+   *   - `OdomState::str(1_m, 1_deg)`: The default (no arguments specified).
+   *   - `OdomState::str(1_tile, 1_radian)`: distance tiles and angle radians.
+   *
+   * Throws std::domain_error if the units passed are undefined.
+   *
+   * @param idistanceUnit The units you want your distance to be in. This must be an exact, predefined QLength (such as foot, meter, inch, tile etc.).
+   * @param iangleUnit The units you want your angle to be in. This must be an exact, predefined QAngle (degree or radian).
    * @return A string representing the state.
    */
   std::string str(QLength idistanceUnit, QAngle iangleUnit) const;
+
+  /**
+   * Get a string for the current odometry state (optionally with the specified units).
+   *
+   * Examples:
+   *   - `OdomState::str(1_m, "_m", 1_deg, "_deg")`: The default (no arguments specified), prints in meters and degrees.
+   *   - `OdomState::str(1_in, "_in", 1_deg, "_deg")` or `OdomState::str(1_in, "\"", 1_deg, "°")`: to print values in inches and degrees with different suffixes.
+   *   - `OdomState::str(6_tile / 100, "%", 360_deg / 100, "%")` to get the distance values in % of the vex field, and angle values in % of a full rotation.
+   *
+   * @param idistanceUnit The units you want your distance to be in. The x or y position will be output in multiples of this length.
+   * @param distUnitName The suffix you as your distance unit.
+   * @param iangleUnit The units you want your angle to be in. The angle will be output in multiples of this unit.
+   * @param angleUnitName The suffix you want as your angle unit.
+   * @return A string representing the state.
+   */
   std::string str(QLength idistanceUnit = meter,
                   std::string distUnitName = "_m",
                   QAngle iangleUnit = degree,

--- a/include/okapi/api/units/RQuantityName.hpp
+++ b/include/okapi/api/units/RQuantityName.hpp
@@ -9,6 +9,14 @@
 
 namespace okapi {
 
+/**
+* Returns a short name for a unit.
+* For example: `str(1_ft)` will return "ft", so will `1 * foot` or `0.3048_m`.
+* Throws std::domain_error when `q` is a unit not defined in this function.
+*
+* @param q Your unit. Currently only QLength and QAngle are supported.
+* @return The short string suffix for that unit.
+*/
 template <class QType> std::string getShortUnitName(QType q) {
   const std::unordered_map<std::type_index, std::unordered_map<double, const char *>> shortNameMap =
     {{typeid(meter),

--- a/include/okapi/api/units/RQuantityName.hpp
+++ b/include/okapi/api/units/RQuantityName.hpp
@@ -1,0 +1,38 @@
+#include "okapi/api/units/QAngle.hpp"
+#include "okapi/api/units/QLength.hpp"
+#include "okapi/api/units/QSpeed.hpp"
+#include <stdexcept>
+#include <typeindex>
+#include <unordered_map>
+
+#pragma once
+
+namespace okapi {
+
+template <class QType> std::string getShortUnitName(QType q) {
+  const std::unordered_map<std::type_index, std::unordered_map<double, const char *>> shortNameMap =
+    {{typeid(meter),
+      {
+        {meter.getValue(), "m"},
+        {decimeter.getValue(), "dm"},
+        {centimeter.getValue(), "cm"},
+        {millimeter.getValue(), "mm"},
+        {kilometer.getValue(), "km"},
+        {inch.getValue(), "in"},
+        {foot.getValue(), "ft"},
+        {yard.getValue(), "yd"},
+        {mile.getValue(), "mi"},
+        {tile.getValue(), "tile"},
+      }},
+     {typeid(degree), {{degree.getValue(), "deg"}, {radian.getValue(), "rad"}}}};
+
+  try {
+    return shortNameMap.at(typeid(q)).at(q.getValue());
+  } catch (const std::out_of_range &e) {
+    throw std::domain_error(
+      "You have requested the shortname of an unknown unit somewhere (likely odometry strings). "
+      "Shortname for provided unit is unspecified. You can override this function to add more "
+      "names or manually specify the name instead.");
+  }
+}
+} // namespace okapi

--- a/src/api/odometry/odomState.cpp
+++ b/src/api/odometry/odomState.cpp
@@ -15,11 +15,28 @@ bool OdomState::operator!=(const OdomState &rhs) const {
   return !(rhs == *this);
 }
 
-std::string OdomState::str() const {
-  std::ostringstream os;
-  os << "OdomState(x=" << std::to_string(x.convert(meter))
-     << "m, y=" << std::to_string(y.convert(meter))
-     << "m, theta=" << std::to_string(theta.convert(degree)) << "deg)";
-  return os.str();
+std::string OdomState::str(QLength idistanceUnit,
+                           std::string distUnitName,
+                           QAngle iangleUnit,
+                           std::string angleUnitName) const {
+  char buf[150];
+  snprintf(buf,
+           sizeof(buf),
+           "OdomState(x=%.2f%s, y=%.2f%s, theta=%.2f%s)",
+           x.convert(idistanceUnit),
+           distUnitName.c_str(),
+           y.convert(idistanceUnit),
+           distUnitName.c_str(),
+           theta.convert(iangleUnit),
+           angleUnitName.c_str());
+  return std::string(buf);
 }
+
+std::string OdomState::str(QLength idistanceUnit, QAngle iangleUnit) const {
+  return str(idistanceUnit,
+             "_" + std::string(getShortUnitName(idistanceUnit)),
+             iangleUnit,
+             "_" + std::string(getShortUnitName(iangleUnit)));
+}
+
 } // namespace okapi

--- a/test/unitTests.cpp
+++ b/test/unitTests.cpp
@@ -8,6 +8,7 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QTime.hpp"
 #include "okapi/api/units/QVolume.hpp"
+#include "okapi/api/units/RQuantityName.hpp"
 #include <gtest/gtest.h>
 
 using namespace okapi;
@@ -122,4 +123,14 @@ TEST(UnitTests, Atan2Test) {
   EXPECT_DOUBLE_EQ(atan2(1_ft, -2_ft).convert(radian), 2.677945044588987);
   EXPECT_DOUBLE_EQ(atan2(-1_ft, -2_ft).convert(radian), -2.677945044588987);
   EXPECT_DOUBLE_EQ(atan2(-1_ft, 2_ft).convert(radian), -0.4636476090008061);
+}
+
+TEST(UnitTests, UnitShortNameTest) {
+  EXPECT_STREQ(getShortUnitName(meter).c_str(), "m");
+  EXPECT_STREQ(getShortUnitName(foot).c_str(), "ft");
+  EXPECT_STREQ(getShortUnitName(degree).c_str(), "deg");
+  EXPECT_STREQ(getShortUnitName(radian).c_str(), "rad");
+
+  EXPECT_ANY_THROW(getShortUnitName(millimeter * 2));
+  EXPECT_ANY_THROW(getShortUnitName(meter3));
 }


### PR DESCRIPTION
Test this with:
```cpp
void opcontrol()
{
        using namespace okapi::literals;
        auto o = okapi::OdomState{x : 4.20_tile, y : 31.4_in, theta : 69_deg};

        try
        {
                printf("%s\n", o.str().c_str()); //normal, compatible with existing behavior
                printf("%s\n", o.str(1_ft, 1_deg).c_str()); // basic unit specification
                printf("%s\n", o.str(okapi::meter, okapi::radian).c_str()); // another basic unit specification
                printf("%s\n", o.str(6_tile / 100, "%", 360_deg / 100, "%").c_str()); // fancy custom unit specification (% of field)
                printf("%s\n", o.str(1_m, 1.01_deg)); // should fail because no matching unit
        }
        catch (const std::domain_error &e)
        {
                printf("%s\n", e.what());
        }
}
```

TODO:
- [x] docs
- [x] Rebase: clean up commit history

Closes #467 